### PR TITLE
feat: ABI-driven multi-output routing, remove onTaskUpdate handlers

### DIFF
--- a/config/tongflow.abi.json
+++ b/config/tongflow.abi.json
@@ -38,6 +38,63 @@
                 }
             },
             "additionalProperties": false
+        },
+        "VideoRef": {
+            "type": "object",
+            "required": [
+                "file_key"
+            ],
+            "properties": {
+                "file_key": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "mime": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "AudioRef": {
+            "type": "object",
+            "required": [
+                "file_key"
+            ],
+            "properties": {
+                "file_key": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "mime": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "ImageRef": {
+            "type": "object",
+            "required": [
+                "file_key"
+            ],
+            "properties": {
+                "file_key": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "mime": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
         }
     },
     "nodes": [
@@ -128,6 +185,13 @@
                     },
                     "result": {
                         "type": "string"
+                    },
+                    "texts": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "x-expand-each": true
                     }
                 },
                 "additionalProperties": false
@@ -661,20 +725,11 @@
                     "thinking": {
                         "type": "string"
                     },
-                    "image_base64": {
-                        "$ref": "#/$defs/FileRef"
+                    "video_file_key": {
+                        "$ref": "#/$defs/VideoRef"
                     },
-                    "video_base64": {
-                        "$ref": "#/$defs/FileRef"
-                    },
-                    "audio_base64": {
-                        "$ref": "#/$defs/FileRef"
-                    },
-                    "texts": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                    "audio_file_key": {
+                        "$ref": "#/$defs/AudioRef"
                     }
                 },
                 "additionalProperties": false
@@ -963,25 +1018,10 @@
                     "thinking": {
                         "type": "string"
                     },
-                    "image_base64": {
-                        "$ref": "#/$defs/FileRef"
-                    },
-                    "video_base64": {
-                        "$ref": "#/$defs/FileRef"
-                    },
-                    "audio_base64": {
-                        "$ref": "#/$defs/FileRef"
-                    },
                     "video_parts": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/$defs/FileRef"
-                        }
-                    },
-                    "texts": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
+                            "$ref": "#/$defs/VideoRef"
                         }
                     }
                 },
@@ -2900,20 +2940,7 @@
                     "clips": {
                         "type": "array",
                         "items": {
-                            "type": "object",
-                            "required": [
-                                "keep",
-                                "fileKey"
-                            ],
-                            "properties": {
-                                "keep": {
-                                    "type": "boolean"
-                                },
-                                "fileKey": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
+                            "$ref": "#/$defs/VideoRef"
                         }
                     }
                 },
@@ -3006,9 +3033,76 @@
                         "items": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "$ref": "#/$defs/VideoRef"
                             }
-                        }
+                        },
+                        "x-expand-each": true
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        {
+            "nodeSlot": "separate_speaker",
+            "inputs": {
+                "type": "object",
+                "required": [],
+                "properties": {
+                    "fileKey": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "outputs": {
+                "type": "object",
+                "required": [
+                    "success"
+                ],
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "error": {
+                        "type": "string"
+                    },
+                    "outputKeys": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/$defs/AudioRef"
+                        },
+                        "x-expand-each": true
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        {
+            "nodeSlot": "separate_audio_track",
+            "inputs": {
+                "type": "object",
+                "required": [],
+                "properties": {
+                    "fileKey": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "outputs": {
+                "type": "object",
+                "required": [
+                    "success"
+                ],
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "error": {
+                        "type": "string"
+                    },
+                    "file_key": {
+                        "$ref": "#/$defs/AudioRef"
                     }
                 },
                 "additionalProperties": false

--- a/src/components/workspace/nodes/batch/arrange-text.tsx
+++ b/src/components/workspace/nodes/batch/arrange-text.tsx
@@ -1,6 +1,5 @@
-import { useNodeId } from "@xyflow/react";
 import type { TongflowPluginNodeProps } from "@/types/tongflow-flow";
-import { memo, useCallback } from "react";
+import { memo } from "react";
 import { Atom } from "lucide-react";
 import { BaseNode } from "../base/base-node";
 import {
@@ -9,8 +8,6 @@ import {
     type GetPromptsContext,
 } from "@/utils/node-execution-config";
 import { useNodeState } from "@/hooks/use-node-data";
-import { useNodeTaskUpdate } from "@/hooks/use-task";
-import useFlow from "@/hooks/use-flow";
 import { Card } from "@/components/ui/card";
 import { NodeTextarea } from "../base/node-textarea";
 import { Input } from "@/components/ui/input";
@@ -53,9 +50,6 @@ const ArrangeTextNode = ({
     const tNodes = useTranslations("Workspace.nodes");
     const fileKeys = data.fileKeys ?? [];
     const infos = data.infos ?? [];
-    const expands = useFlow((s) => s.expands);
-
-    const id = useNodeId()!;
 
     // Use the new hook to manage state persistence
     const [state, setState] = useNodeState(
@@ -67,31 +61,6 @@ const ArrangeTextNode = ({
         data,
     );
     const { query, groupCount, duplicatable } = state;
-
-    // Handle task updates (permutation returns multiple groups)
-    const handleTaskUpdate = useCallback(
-        (task: any): boolean => {
-            if (task?.status === "COMPLETED") {
-                const groups = task?.data?.groups as string[][] | undefined;
-                if (groups && groups.length > 0 && id) {
-                    groups.forEach((group) => {
-                        expands(id, [
-                            {
-                                type: "videoNode",
-                                data: { fileKeys: [...group] },
-                            },
-                        ]);
-                    });
-                }
-                return true; // Already handled; skip the default logic
-            }
-            return false;
-        },
-        [id, expands],
-    );
-
-    // Subscribe to this node's task updates via useNodeTaskUpdate
-    useNodeTaskUpdate(id || "", handleTaskUpdate);
 
     return (
         <BaseNode
@@ -128,7 +97,6 @@ const ArrangeTextNode = ({
                           ]
                         : [];
                 },
-                onTaskUpdate: handleTaskUpdate,
             }}
         >
             <Card

--- a/src/components/workspace/nodes/batch/drop-video.tsx
+++ b/src/components/workspace/nodes/batch/drop-video.tsx
@@ -1,6 +1,5 @@
-import { useNodeId } from "@xyflow/react";
 import type { TongflowPluginNodeProps } from "@/types/tongflow-flow";
-import { memo, useCallback } from "react";
+import { memo } from "react";
 import { Atom } from "lucide-react";
 import { BaseNode } from "../base/base-node";
 import {
@@ -9,7 +8,6 @@ import {
     type GetPromptsContext,
 } from "@/utils/node-execution-config";
 import { useNodeState } from "@/hooks/use-node-data";
-import useFlow from "@/hooks/use-flow";
 import { NodeTextarea } from "../base/node-textarea";
 import { useTranslations } from "next-intl";
 
@@ -39,9 +37,6 @@ const DropVideoNode = ({
     const t = useTranslations("Workspace.nodes.batch");
     const tNodes = useTranslations("Workspace.nodes");
     const fileKeys = data.fileKeys;
-    const expands = useFlow((s) => s.expands);
-
-    const id = useNodeId()!;
 
     // Use the new hook to manage state persistence
     const [state, setState] = useNodeState(
@@ -51,32 +46,6 @@ const DropVideoNode = ({
         data,
     );
     const { query } = state;
-
-    // Handle task updates (filtering returns an array with keep markers)
-    const handleTaskUpdate = useCallback(
-        (task: any): boolean => {
-            if (task?.status === "COMPLETED") {
-                const clips = task?.data?.clips as
-                    | { keep: boolean; fileKey: string }[]
-                    | undefined;
-                const filteredData = clips ?? [];
-                const videoFileKeys = filteredData
-                    .filter((item) => item?.keep)
-                    .map((item) => item.fileKey);
-                if (videoFileKeys.length > 0 && id) {
-                    expands(id, [
-                        {
-                            type: "videoNode",
-                            data: { fileKeys: videoFileKeys },
-                        },
-                    ]);
-                }
-                return true;
-            }
-            return false;
-        },
-        [id, expands],
-    );
 
     return (
         <BaseNode
@@ -105,7 +74,6 @@ const DropVideoNode = ({
                           ]
                         : [];
                 },
-                onTaskUpdate: handleTaskUpdate,
             }}
         >
             <div className="p-4 space-y-4">

--- a/src/components/workspace/nodes/compose/texts-gen-text.tsx
+++ b/src/components/workspace/nodes/compose/texts-gen-text.tsx
@@ -1,66 +1,19 @@
 import {
-    useNodeId,
     useNodesData,
 } from "@xyflow/react";
 import type { TongflowPluginNodeProps } from "@/types/tongflow-flow";
-import { useState, memo, useCallback, useRef, useEffect, useMemo } from "react";
-import { Brain, Wand2 } from "lucide-react";
+import { memo, useMemo } from "react";
+import { Wand2 } from "lucide-react";
 
 import { BaseNode } from "../base/base-node";
-import { Label } from "@/components/ui/label";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select";
 import {
     upstreamParam,
     configParam,
     type GetPromptsContext,
 } from "@/utils/node-execution-config";
-import useFlow from "@/hooks/use-flow";
 import { useNodeState } from "@/hooks/use-node-data";
 import { NodeTextarea } from "../base/node-textarea";
 import { useTranslations } from "next-intl";
-
-// Reasoning box component
-const ReasoningBox = ({ content }: { content: string }) => {
-    const scrollRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        if (scrollRef.current) {
-            scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-        }
-    }, [content]);
-
-    return (
-        <div className="w-full h-full bg-blue-50 border border-blue-200 rounded-lg p-4 flex flex-col">
-            <div className="flex items-center justify-between mb-3 flex-shrink-0">
-                <div className="flex items-center gap-2">
-                    <Brain className="h-4 w-4 text-blue-600" />
-                    <h3 className="text-sm font-semibold text-blue-900">
-                        {/* Note: This component logic is inside component but t is not available here easily without passing it.
-                            I will move useTranslations to GenTextNode but ReasoningBox is outside.
-                            Actually, I can pass t as prop or move ReasoningBox inside, or just use a simple hook inside.
-                         */}
-                        Thinking Process
-                    </h3>
-                </div>
-            </div>
-            <div
-                ref={scrollRef}
-                className="flex-1 overflow-y-auto [&::-webkit-scrollbar]:hidden"
-                style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-            >
-                <p className="text-xs text-blue-700 leading-relaxed whitespace-pre-wrap break-words">
-                    {content}
-                </p>
-            </div>
-        </div>
-    );
-};
 
 // Workflow execution config
 const workflowConfig = {
@@ -85,15 +38,10 @@ const TextsGenTextNode = ({
 }: TongflowPluginNodeProps<"combine-text", "textsGenTextNode">) => {
     const { ids = [], texts: localTexts = [] } = data;
 
-    const expands = useFlow((s) => s.expands);
-    const updates = useFlow((s) => s.updates);
-    const id = useNodeId()!;
-
     // Collect text from all upstream textNodes (merge mode)
     const fromNodes = useNodesData(ids);
     const textNodes = fromNodes.filter((node) => node.type === "textNode");
 
-    // Collect text from all upstream textNodes
     const texts: string[] = useMemo(() => {
         if (textNodes.length > 0) {
             return textNodes.flatMap((node) => (node.data as any)?.texts || []);
@@ -101,7 +49,6 @@ const TextsGenTextNode = ({
         return localTexts;
     }, [textNodes, localTexts]);
 
-    // Use the hook to manage the user-entered prompt
     const [state, setState] = useNodeState(
         {
             userPrompt: "",
@@ -111,74 +58,6 @@ const TextsGenTextNode = ({
     const { userPrompt } = state;
     const t = useTranslations("Workspace.nodes");
     const tBase = useTranslations("Workspace.nodes.base");
-
-    // Streaming output state
-    const [reasoningContent, setReasoningContent] = useState<string>("");
-    const [showReasoningBox, setShowReasoningBox] = useState(false);
-    const [_answerContent, setAnswerContent] = useState<string>("");
-    const answerNodeIdRef = useRef<string | null>(null);
-
-    // Custom task updater — handles streaming deltas
-    const handleTaskUpdate = useCallback(
-        (task: any): boolean => {
-            // Handle task completion/failure - reset state
-            if (task?.status === "COMPLETED" || task?.status === "FAILED") {
-                setTimeout(() => {
-                    setReasoningContent("");
-                    setAnswerContent("");
-                    setShowReasoningBox(false);
-                    answerNodeIdRef.current = null;
-                }, 500);
-                // Return true to indicate it was handled and the default node creation logic is not needed
-                return true;
-            }
-
-            // Check streaming data
-            if (task?.data?.content) {
-                if (task?.data?.type === "reasoning") {
-                    setReasoningContent((prev) =>
-                        prev
-                            ? `${prev}${task.data.content}`
-                            : task.data.content,
-                    );
-                    setShowReasoningBox(true);
-                    return true;
-                }
-
-                if (task?.data?.type === "answer") {
-                    setShowReasoningBox(false);
-                    setAnswerContent((prev) => {
-                        const newContent = prev
-                            ? `${prev}${task.data.content}`
-                            : task.data.content;
-
-                        // Create or update the output node
-                        if (!answerNodeIdRef.current && id) {
-                            const nodeIds = expands(id, [
-                                {
-                                    type: "textNode",
-                                    data: { texts: [newContent] },
-                                },
-                            ]);
-                            if (nodeIds?.length > 0) {
-                                answerNodeIdRef.current = nodeIds[0];
-                            }
-                        } else if (answerNodeIdRef.current) {
-                            updates(answerNodeIdRef.current, {
-                                texts: [newContent],
-                            });
-                        }
-
-                        return newContent;
-                    });
-                    return true;
-                }
-            }
-
-            return false;
-        },
-        [id, expands, updates],
-    );
 
     return (
         <BaseNode
@@ -207,16 +86,7 @@ const TextsGenTextNode = ({
                         },
                     ];
                 },
-                onTaskUpdate: handleTaskUpdate,
             }}
-            overlay={
-                showReasoningBox ? (
-                    <div className="w-full h-full pointer-events-auto">
-                        {/* Passing raw string for now as I left ReasoningBox outside. Ideally refactor ReasoningBox to use t or accept title prop. */}
-                        <ReasoningBox content={reasoningContent} />
-                    </div>
-                ) : null
-            }
         >
             <div className="p-4 space-y-4">
                 <div className="space-y-2">
@@ -229,7 +99,6 @@ const TextsGenTextNode = ({
                     />
                 </div>
             </div>
-
         </BaseNode>
     );
 };

--- a/src/components/workspace/nodes/decompose/split-text.tsx
+++ b/src/components/workspace/nodes/decompose/split-text.tsx
@@ -1,9 +1,8 @@
 import {
-    useNodeId,
     useNodesData,
 } from "@xyflow/react";
 import type { TongflowPluginNodeProps } from "@/types/tongflow-flow";
-import { memo, useCallback, useMemo } from "react";
+import { memo, useMemo } from "react";
 import { Scissors } from "lucide-react";
 import { BaseNode } from "../base/base-node";
 import {
@@ -11,7 +10,6 @@ import {
     configParam,
     type GetPromptsContext,
 } from "@/utils/node-execution-config";
-import useFlow from "@/hooks/use-flow";
 import { useNodeState } from "@/hooks/use-node-data";
 import { NodeTextarea } from "../base/node-textarea";
 import { useTranslations } from "next-intl";
@@ -48,9 +46,6 @@ const SplitTextNode = ({
     const ids = data.ids ?? [];
     const localTexts = data.texts ?? [];
 
-    const expands = useFlow((s) => s.expands);
-    const id = useNodeId()!;
-
     // Pull prompts from predecessors
     const fromNodes = useNodesData(ids);
     const textNodes = fromNodes.filter((node) => node.type === "textNode");
@@ -65,29 +60,6 @@ const SplitTextNode = ({
     // Optional split instructions from user land
     const [state, setState] = useNodeState({ userPrompt: "" }, data);
     const { userPrompt } = state;
-
-    // Handle splitter tasks returning text arrays
-    const handleTaskUpdate = useCallback(
-        (task: any): boolean => {
-            if (task?.status === "COMPLETED") {
-                const taskData = task?.data as any;
-                const splitTexts: string[] = taskData?.texts || [];
-
-                if (splitTexts.length > 0 && id) {
-                    expands(
-                        id,
-                        splitTexts.map((text) => ({
-                            type: "textNode",
-                            data: { texts: [text] },
-                        })),
-                    );
-                }
-                return true;
-            }
-            return false;
-        },
-        [id, expands],
-    );
 
     return (
         <BaseNode
@@ -117,7 +89,6 @@ const SplitTextNode = ({
                           ]
                         : [];
                 },
-                onTaskUpdate: handleTaskUpdate,
             }}
         >
             <div className="p-4 space-y-4">

--- a/src/components/workspace/nodes/decompose/split-video.tsx
+++ b/src/components/workspace/nodes/decompose/split-video.tsx
@@ -1,6 +1,5 @@
-import { useNodeId } from "@xyflow/react";
 import type { TongflowPluginNodeProps } from "@/types/tongflow-flow";
-import { memo, useCallback } from "react";
+import { memo } from "react";
 import { Atom } from "lucide-react";
 import { BaseNode } from "../base/base-node";
 import {
@@ -8,7 +7,6 @@ import {
     configParam,
     type GetPromptsContext,
 } from "@/utils/node-execution-config";
-import useFlow from "@/hooks/use-flow";
 import { useTranslations } from "next-intl";
 
 const DEFAULT_FEATURE = "split-video";
@@ -37,37 +35,6 @@ const SplitVideoNode = ({
 }: TongflowPluginNodeProps<"split-video", "splitVideoNode">) => {
     const t = useTranslations("Workspace.nodes");
     const fileKeys = data.fileKeys;
-    const expands = useFlow((s) => s.expands);
-
-    const id = useNodeId()!;
-
-    const handleTaskUpdate = useCallback(
-        (task: any): boolean => {
-            if (task?.status === "COMPLETED") {
-                const taskData = task?.data as any;
-                const parts = taskData?.video_parts as
-                    | Array<{ file_key?: string }>
-                    | undefined;
-                const splitKeys =
-                    parts
-                        ?.map((p) =>
-                            typeof p?.file_key === "string"
-                                ? p.file_key.trim()
-                                : "",
-                        )
-                        .filter((k) => k.length > 0) ?? [];
-
-                if (splitKeys.length > 0 && id) {
-                    expands(id, [
-                        { type: "videoNode", data: { fileKeys: splitKeys } },
-                    ]);
-                }
-                return true;
-            }
-            return false;
-        },
-        [id, expands],
-    );
 
     return (
         <BaseNode
@@ -94,7 +61,6 @@ const SplitVideoNode = ({
                           }))
                         : [];
                 },
-                onTaskUpdate: handleTaskUpdate,
             }}
         >
         </BaseNode>

--- a/src/components/workspace/nodes/transfer/file-gen-text.tsx
+++ b/src/components/workspace/nodes/transfer/file-gen-text.tsx
@@ -1,17 +1,13 @@
-import { useNodeId } from "@xyflow/react";
 import type { TongflowPluginNodeProps } from "@/types/tongflow-flow";
-import { memo, useCallback } from "react";
+import { memo } from "react";
 import { FileText } from "lucide-react";
 
 import { BaseNode } from "../base/base-node";
-import useFlow from "@/hooks/use-flow";
-import { getFileUrl } from "@/lib/file-url";
 import {
     upstreamParam,
     type GetPromptsContext,
 } from "@/utils/node-execution-config";
 import { useTranslations } from "next-intl";
-import { logger } from "@/lib/logger";
 
 const DEFAULT_FEATURE = "parse-document";
 
@@ -41,45 +37,6 @@ const FileGenTextNode = ({
     const t = useTranslations("Workspace.nodes");
     const { fileKeys = [] } = data;
 
-    const nodeId = useNodeId();
-    const expands = useFlow((s) => s.expands);
-
-    // Custom task updater — awaits Markdown payloads before spawning text nodes
-    const handleTaskUpdate = useCallback(
-        async (task: any) => {
-            if (task?.status === "COMPLETED") {
-                const r2_key = task?.data?.r2_key;
-                if (r2_key && nodeId) {
-                    try {
-                        const response = await fetch(getFileUrl(r2_key));
-                        if (!response.ok) {
-                            throw new Error(
-                                `Failed to fetch markdown: ${response.statusText}`,
-                            );
-                        }
-                        const markdownContent = await response.text();
-
-                        // Expand markdown content as a text node
-                        expands(nodeId, [
-                            {
-                                type: "textNode",
-                                data: { texts: [markdownContent] },
-                            },
-                        ]);
-                    } catch (error) {
-                        logger.error(
-                            "Failed to fetch markdown content:",
-                            error,
-                        );
-                    }
-                }
-                return true; // Already handled; skip the default logic
-            }
-            return false;
-        },
-        [expands, nodeId],
-    );
-
     return (
         <BaseNode
             selected={selected}
@@ -104,7 +61,6 @@ const FileGenTextNode = ({
                         source: fileKey,
                     }));
                 },
-                onTaskUpdate: handleTaskUpdate,
             }}
         >
         </BaseNode>

--- a/src/components/workspace/nodes/transfer/separate-speaker.tsx
+++ b/src/components/workspace/nodes/transfer/separate-speaker.tsx
@@ -1,10 +1,8 @@
-import { useNodeId } from "@xyflow/react";
-import { memo, useCallback } from "react";
+import { memo } from "react";
 
 import type { RfDataNodeProps } from "@/types/nodes";
 
 import { BaseNode } from "../base/base-node";
-import useFlow from "@/hooks/use-flow";
 import { Atom } from "lucide-react";
 import {
     upstreamParam,
@@ -37,32 +35,7 @@ const workflowConfig = {
 
 const SeparateSpeakerNode = ({ selected, data }: SeparateSpeakerRfProps) => {
     const t = useTranslations("Workspace.nodes");
-    const updates = useFlow((s) => s.updates);
-    const id = useNodeId()!;
     const fileKeys = data.fileKeys;
-    const expands = useFlow((s) => s.expands);
-
-    // Custom task updater — expands every auxiliary file artifact
-    const handleTaskUpdate = useCallback(
-        (task: any) => {
-            if (task?.status === "COMPLETED") {
-                const outputKeys = task?.data?.outputKeys as string[];
-                if (outputKeys && outputKeys.length > 0) {
-                    outputKeys.forEach((fileKey) =>
-                        expands("", [
-                            {
-                                type: "audioNode",
-                                data: { fileKeys: [fileKey] },
-                            },
-                        ]),
-                    );
-                }
-                return true;
-            }
-            return false;
-        },
-        [expands],
-    );
 
     return (
         <BaseNode
@@ -90,7 +63,6 @@ const SeparateSpeakerNode = ({ selected, data }: SeparateSpeakerRfProps) => {
                         })) || []
                     );
                 },
-                onTaskUpdate: handleTaskUpdate,
             }}
         />
     );

--- a/src/components/workspace/nodes/transfer/separate-video-audio.tsx
+++ b/src/components/workspace/nodes/transfer/separate-video-audio.tsx
@@ -1,6 +1,5 @@
-import { useNodeId } from "@xyflow/react";
 import type { TongflowPluginNodeProps } from "@/types/tongflow-flow";
-import { memo, useCallback } from "react";
+import { memo } from "react";
 import { BaseNode } from "../base/base-node";
 import { Atom } from "lucide-react";
 import {
@@ -8,8 +7,6 @@ import {
     type GetPromptsContext,
 } from "@/utils/node-execution-config";
 import { useTranslations } from "next-intl";
-import useFlow from "@/hooks/use-flow";
-import { normalizeTaskPayloadData } from "@/utils/task-payload";
 
 const DEFAULT_FEATURE = "separate-video-audio";
 
@@ -34,28 +31,7 @@ const SeparateVideoAudioNode = ({
     data,
 }: TongflowPluginNodeProps<"separate-video-audio", "separateVideoAudioNode">) => {
     const t = useTranslations("Workspace.nodes");
-    const id = useNodeId()!;
-    const expands = useFlow((s) => s.expands);
     const fileKeys = data.fileKeys;
-
-    const onTaskUpdate = useCallback(
-        (task: any) => {
-            if (task?.status !== "COMPLETED") return false;
-            const payload =
-                normalizeTaskPayloadData(task?.data) ??
-                (task?.data as Record<string, unknown> | undefined);
-            if (!payload) return false;
-            const vk = payload["video_file_key"];
-            const ak = payload["audio_file_key"];
-            if (typeof vk !== "string" || typeof ak !== "string") return false;
-            expands(id, [
-                { type: "videoNode", data: { fileKeys: [vk] } },
-                { type: "audioNode", data: { fileKeys: [ak] } },
-            ]);
-            return true;
-        },
-        [expands, id],
-    );
 
     return (
         <BaseNode
@@ -83,7 +59,6 @@ const SeparateVideoAudioNode = ({
                         })) || []
                     );
                 },
-                onTaskUpdate,
             }}
         />
     );

--- a/src/components/workspace/nodes/transfer/text-gen-text.tsx
+++ b/src/components/workspace/nodes/transfer/text-gen-text.tsx
@@ -1,9 +1,8 @@
 import {
-    useNodeId,
     useNodesData,
 } from "@xyflow/react";
-import { useState, memo, useCallback, useRef, useEffect, useMemo } from "react";
-import { Brain, Maximize2, Wand2 } from "lucide-react";
+import { useState, memo, useMemo } from "react";
+import { Maximize2, Wand2 } from "lucide-react";
 
 import { BaseNode } from "../base/base-node";
 import { Card } from "@/components/ui/card";
@@ -22,7 +21,6 @@ import {
     configParam,
     type GetPromptsContext,
 } from "@/utils/node-execution-config";
-import useFlow from "@/hooks/use-flow";
 import { useNodeState } from "@/hooks/use-node-data";
 import { NodeTextarea } from "../base/node-textarea";
 import { useTranslations } from "next-intl";
@@ -50,57 +48,16 @@ const workflowConfig = {
     },
 };
 
-// Reasoning box component
-const ReasoningBox = ({ content }: { content: string }) => {
-    const tBase = useTranslations("Workspace.nodes.base");
-    const scrollRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        if (scrollRef.current) {
-            scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-        }
-    }, [content]);
-
-    return (
-        <div className="w-full h-full bg-blue-50 border border-blue-200 rounded-lg p-4 flex flex-col">
-            <div className="flex items-center justify-between mb-3 flex-shrink-0">
-                <div className="flex items-center gap-2">
-                    <Brain className="h-4 w-4 text-blue-600" />
-                    <h3 className="text-sm font-semibold text-blue-900">
-                        {tBase("thinkingProcess")}
-                    </h3>
-                </div>
-            </div>
-            <div
-                ref={scrollRef}
-                className="flex-1 overflow-y-auto [&::-webkit-scrollbar]:hidden"
-                style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-            >
-                <p className="text-xs text-blue-700 leading-relaxed whitespace-pre-wrap break-words">
-                    {content}
-                </p>
-            </div>
-        </div>
-    );
-};
-
 const GenTextNode = ({
     selected,
     data,
 }: TongflowPluginNodeProps<"gen-text", "genTextNode">) => {
     const { ids = [], texts: localTexts = [] } = data;
 
-    const expands = useFlow((s) => s.expands);
-    const updates = useFlow((s) => s.updates);
-    const id = useNodeId()!;
-
     // If ids are present, get data from associated nodes (composition mode)
-    // In composition mode, there may be multiple textNodes: one for input text and one for the prompt
     const fromNodes = useNodesData(ids);
     const textNodes = fromNodes.filter((node) => node.type === "textNode");
 
-    // Get text data from the composite node
-    // Use the first textNode as input text and the second one, if present, as the prompt
     const texts: string[] = useMemo(() => {
         if (textNodes.length > 0) {
             return (textNodes[0].data as any)?.texts || [];
@@ -108,7 +65,6 @@ const GenTextNode = ({
         return localTexts;
     }, [textNodes, localTexts]);
 
-    // If there is a second textNode, use it as the upstream prompt
     const upstreamPrompt: string = useMemo(() => {
         if (textNodes.length > 1) {
             const prompts = (textNodes[1].data as any)?.texts || [];
@@ -117,10 +73,8 @@ const GenTextNode = ({
         return "";
     }, [textNodes]);
 
-    // Determine whether there is an upstream prompt
     const hasUpstreamPrompt = !!upstreamPrompt;
 
-    // Use the hook to manage the user-entered prompt (the LLM plugin decides whether to use geminiModel/openaiModel)
     const [state, setState] = useNodeState(
         {
             userPrompt: "",
@@ -133,80 +87,10 @@ const GenTextNode = ({
 
     const nodeSlot = "gen-text";
 
-    // Get the prompt that will actually be used
     const effectivePrompt = hasUpstreamPrompt ? upstreamPrompt : userPrompt;
 
-    // Fullscreen editing modal state
     const [isFullscreenOpen, setIsFullscreenOpen] = useState(false);
     const [fullscreenValue, setFullscreenValue] = useState("");
-
-    // Streaming output state
-    const [reasoningContent, setReasoningContent] = useState<string>("");
-    const [showReasoningBox, setShowReasoningBox] = useState(false);
-    const [_answerContent, setAnswerContent] = useState<string>("");
-    const answerNodeIdRef = useRef<string | null>(null);
-
-    // Custom task updater — handles streaming deltas
-    const handleTaskUpdate = useCallback(
-        (task: any): boolean => {
-            // Handle task completion/failure - reset state
-            if (task?.status === "COMPLETED" || task?.status === "FAILED") {
-                setTimeout(() => {
-                    setReasoningContent("");
-                    setAnswerContent("");
-                    setShowReasoningBox(false);
-                    answerNodeIdRef.current = null;
-                }, 500);
-                // Return true to indicate it was handled and the default node creation logic is not needed
-                return true;
-            }
-
-            // Check streaming data
-            if (task?.data?.content) {
-                if (task?.data?.type === "reasoning") {
-                    setReasoningContent((prev) =>
-                        prev
-                            ? `${prev}${task.data.content}`
-                            : task.data.content,
-                    );
-                    setShowReasoningBox(true);
-                    return true;
-                }
-
-                if (task?.data?.type === "answer") {
-                    setShowReasoningBox(false);
-                    setAnswerContent((prev) => {
-                        const newContent = prev
-                            ? `${prev}${task.data.content}`
-                            : task.data.content;
-
-                        // Create or update the output node
-                        if (!answerNodeIdRef.current && id) {
-                            const nodeIds = expands(id, [
-                                {
-                                    type: "textNode",
-                                    data: { texts: [newContent] },
-                                },
-                            ]);
-                            if (nodeIds?.length > 0) {
-                                answerNodeIdRef.current = nodeIds[0];
-                            }
-                        } else if (answerNodeIdRef.current) {
-                            updates(answerNodeIdRef.current, {
-                                texts: [newContent],
-                            });
-                        }
-
-                        return newContent;
-                    });
-                    return true;
-                }
-            }
-
-            return false;
-        },
-        [id, expands, updates],
-    );
 
     return (
         <>
@@ -248,19 +132,10 @@ const GenTextNode = ({
                             text: `${text}\n\n${effectivePrompt}`,
                         }));
                     },
-                    onTaskUpdate: handleTaskUpdate,
                 }}
-                overlay={
-                    showReasoningBox ? (
-                        <div className="w-full h-full pointer-events-auto">
-                            <ReasoningBox content={reasoningContent} />
-                        </div>
-                    ) : null
-                }
             >
                 <div className="p-4 space-y-4">
                     <div className="space-y-2">
-                        {/* If there is an upstream prompt, show a preview */}
                         {hasUpstreamPrompt ? (
                             <Card className="p-3 bg-muted/50">
                                 <div className="space-y-2">

--- a/src/hooks/use-node-execution.ts
+++ b/src/hooks/use-node-execution.ts
@@ -16,7 +16,12 @@ import {
 import {
     normalizeTaskPayloadData,
     pickMarkdownFromPayload,
+    applyResolvedOutputRoutes,
 } from "@/utils/task-payload";
+import {
+    getAbiNodeBySlot,
+    resolveAbiOutputMappings,
+} from "@/lib/tongflow-abi";
 import { getValueByPath } from "@/utils/path-utils";
 import { useNodePluginResolver } from "./use-node-plugin-resolver";
 import { logger } from "@/lib/logger";
@@ -145,6 +150,23 @@ export function useNodeExecution({
             }
 
             if (task?.status === "COMPLETED") {
+                const payload =
+                    normalizeTaskPayloadData(task?.data) ??
+                    (task?.data as Record<string, unknown> | undefined);
+
+                // ABI convention-driven multi-output routing
+                const abiNode = feature
+                    ? getAbiNodeBySlot(feature)
+                    : undefined;
+                const routes = abiNode
+                    ? resolveAbiOutputMappings(abiNode)
+                    : [];
+                if (routes.length > 0) {
+                    applyResolvedOutputRoutes(nodeId, payload, routes, expands);
+                    return;
+                }
+
+                // Single-output fallback
                 const outputNodeType = outputType as
                     | OutputNodeType
                     | undefined;
@@ -153,10 +175,6 @@ export function useNodeExecution({
                     | "texts"
                     | undefined;
                 if (!outputNodeType || !outputDataField) return;
-
-                const payload =
-                    normalizeTaskPayloadData(task?.data) ??
-                    (task?.data as Record<string, unknown> | undefined);
 
                 const fileKey = payload?.file_key as string | undefined;
                 const text = payload?.text as string | undefined;

--- a/src/lib/tongflow-abi.ts
+++ b/src/lib/tongflow-abi.ts
@@ -21,6 +21,122 @@ const TongflowAbiFileSchema = z.object({
 
 export type TongflowAbiNode = z.infer<typeof AbiNodeSchema>;
 
+export interface ResolvedOutputRoute {
+    sourceField: string;
+    nodeType: "videoNode" | "audioNode" | "imageNode" | "textNode";
+    dataField: "fileKeys" | "texts";
+    expandEach: boolean;
+    itemValuePath?: string;
+    isArrayOfArrays?: boolean;
+}
+
+const REF_TO_NODE_TYPE: Record<
+    string,
+    Exclude<ResolvedOutputRoute["nodeType"], "textNode">
+> = {
+    VideoRef: "videoNode",
+    AudioRef: "audioNode",
+    ImageRef: "imageNode",
+};
+
+type JsonSchema = Record<string, unknown>;
+
+function resolveRef(refStr: string): string {
+    // "#/$defs/VideoRef" -> "VideoRef"
+    return refStr.split("/").pop() ?? "";
+}
+
+export function resolveAbiOutputMappings(
+    node: TongflowAbiNode,
+): ResolvedOutputRoute[] {
+    const outputs = node.outputs as JsonSchema | undefined;
+    if (!outputs || typeof outputs !== "object") return [];
+
+    const properties = outputs.properties as Record<string, JsonSchema> | undefined;
+    if (!properties) return [];
+
+    const routes: ResolvedOutputRoute[] = [];
+
+    for (const [field, schema] of Object.entries(properties)) {
+        if (field === "success" || field === "error" || field === "thinking") {
+            continue;
+        }
+
+        const ref = schema["$ref"] as string | undefined;
+        if (ref) {
+            const refName = resolveRef(ref);
+            const nodeType = REF_TO_NODE_TYPE[refName];
+            if (nodeType) {
+                routes.push({
+                    sourceField: field,
+                    nodeType,
+                    dataField: "fileKeys",
+                    expandEach: false,
+                    itemValuePath: "file_key",
+                });
+            }
+            continue;
+        }
+
+        if (schema.type === "array") {
+            const items = schema.items as JsonSchema | undefined;
+            if (!items) continue;
+
+            const expandEach = schema["x-expand-each"] === true;
+
+            const itemRef = items["$ref"] as string | undefined;
+            if (itemRef) {
+                const refName = resolveRef(itemRef);
+                const nodeType = REF_TO_NODE_TYPE[refName];
+                if (nodeType) {
+                    routes.push({
+                        sourceField: field,
+                        nodeType,
+                        dataField: "fileKeys",
+                        expandEach,
+                        itemValuePath: "file_key",
+                    });
+                }
+                continue;
+            }
+
+            // array of arrays (e.g. groups: VideoRef[][])
+            if (items.type === "array") {
+                const innerItems = items.items as JsonSchema | undefined;
+                if (!innerItems) continue;
+                const innerRef = innerItems["$ref"] as string | undefined;
+                if (innerRef) {
+                    const refName = resolveRef(innerRef);
+                    const nodeType = REF_TO_NODE_TYPE[refName];
+                    if (nodeType) {
+                        routes.push({
+                            sourceField: field,
+                            nodeType,
+                            dataField: "fileKeys",
+                            expandEach: true,
+                            itemValuePath: "file_key",
+                            isArrayOfArrays: true,
+                        });
+                    }
+                }
+                continue;
+            }
+
+            // array of strings with x-expand-each -> textNode
+            if (items.type === "string" && expandEach) {
+                routes.push({
+                    sourceField: field,
+                    nodeType: "textNode",
+                    dataField: "texts",
+                    expandEach: true,
+                });
+            }
+        }
+    }
+
+    return routes;
+}
+
 const parsed = TongflowAbiFileSchema.parse(tongflowAbi);
 
 const bySlot = new Map<string, TongflowAbiNode>();

--- a/src/utils/task-payload.ts
+++ b/src/utils/task-payload.ts
@@ -1,3 +1,122 @@
+import type { ResolvedOutputRoute } from "@/lib/tongflow-abi";
+import type { PossibleNode } from "@/hooks/use-flow";
+
+type ExpandsFn = (nodeId: string | null, nodes: PossibleNode[]) => string[];
+
+export function applyResolvedOutputRoutes(
+    nodeId: string,
+    payload: Record<string, unknown> | undefined,
+    routes: ResolvedOutputRoute[],
+    expands: ExpandsFn,
+): void {
+    for (const route of routes) {
+        const raw = payload?.[route.sourceField];
+        if (raw == null) continue;
+
+        if (Array.isArray(raw)) {
+            if (route.isArrayOfArrays) {
+                // e.g. groups: VideoRef[][] — each inner array → one node
+                for (const innerArr of raw as unknown[]) {
+                    if (!Array.isArray(innerArr)) continue;
+                    const keys = (innerArr as unknown[])
+                        .map((item) =>
+                            route.itemValuePath &&
+                            typeof item === "object" &&
+                            item !== null
+                                ? String(
+                                      (
+                                          item as Record<string, unknown>
+                                      )[route.itemValuePath],
+                                  )
+                                : String(item),
+                        )
+                        .filter(Boolean);
+                    if (keys.length) {
+                        expands(nodeId, [
+                            {
+                                type: route.nodeType,
+                                data: { [route.dataField]: keys },
+                            },
+                        ]);
+                    }
+                }
+                continue;
+            }
+
+            if (route.expandEach) {
+                // one-per-item
+                for (const item of raw as unknown[]) {
+                    const value =
+                        route.itemValuePath &&
+                        typeof item === "object" &&
+                        item !== null
+                            ? String(
+                                  (item as Record<string, unknown>)[
+                                      route.itemValuePath
+                                  ],
+                              )
+                            : String(item);
+                    if (value) {
+                        expands(nodeId, [
+                            {
+                                type: route.nodeType,
+                                data: { [route.dataField]: [value] },
+                            },
+                        ]);
+                    }
+                }
+            } else {
+                // all-in-one
+                const values = (raw as unknown[])
+                    .map((item) =>
+                        route.itemValuePath &&
+                        typeof item === "object" &&
+                        item !== null
+                            ? String(
+                                  (item as Record<string, unknown>)[
+                                      route.itemValuePath
+                                  ],
+                              )
+                            : String(item),
+                    )
+                    .filter(Boolean);
+                if (values.length) {
+                    expands(nodeId, [
+                        {
+                            type: route.nodeType,
+                            data: { [route.dataField]: values },
+                        },
+                    ]);
+                }
+            }
+        } else if (
+            typeof raw === "object" &&
+            raw !== null &&
+            route.itemValuePath
+        ) {
+            // scalar typed ref (e.g. VideoRef, AudioRef)
+            const value = String(
+                (raw as Record<string, unknown>)[route.itemValuePath],
+            );
+            if (value && value !== "undefined") {
+                expands(nodeId, [
+                    {
+                        type: route.nodeType,
+                        data: { [route.dataField]: [value] },
+                    },
+                ]);
+            }
+        } else if (typeof raw === "string" && raw) {
+            expands(nodeId, [
+                {
+                    type: route.nodeType,
+                    data: { [route.dataField]: [raw] },
+                },
+            ]);
+        }
+    }
+}
+
 /** SSE data is sometimes a JSON string; Modal may wrap content in markdown or nested result. */
 export function normalizeTaskPayloadData(
     data: unknown,


### PR DESCRIPTION
Replace per-node onTaskUpdate callbacks with a convention-based system
driven by the ABI schema. The frontend reads each node's ABI outputs
definition and auto-routes results to the correct downstream node types,
eliminating bespoke glue code in 10 node components.

Key changes:
- config/tongflow.abi.json: add VideoRef/AudioRef/ImageRef typed $defs;
  update split-video, separate-video-audio, drop-video, split-text,
  arrange-group outputs to use typed refs + x-expand-each annotation;
  add separate_speaker and separate_audio_track node entries
- src/lib/tongflow-abi.ts: add resolveAbiOutputMappings() that walks the
  ABI outputs schema and returns ResolvedOutputRoute[] from typed $refs
- src/utils/task-payload.ts: add applyResolvedOutputRoutes() pure fn
  handling scalar, all-in-one array, one-per-item, and array-of-arrays
- src/hooks/use-node-execution.ts: COMPLETED branch now checks ABI routes
  first and falls back to legacy single-output logic only when needed
- Remove handleTaskUpdate / onTaskUpdate from split-text, split-video,
  separate-video-audio, drop-video, arrange-text, separate-speaker,
  file-gen-text (parse-document now returns text in task.data.text)
- Remove streaming/reasoning UI (ReasoningBox, streaming state, deltas)
  from text-gen-text and texts-gen-text; default handler covers COMPLETED

https://claude.ai/code/session_01PXkXxcgpLSYmEJzdRGVUNs