### PR TITLE
chore: open-source readiness pass

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
 
 ## Checklist
 
-- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] I agree my contribution is covered by the [CLA](../CLA.md)
 - [ ] My branch is up to date with `main`
 - [ ] `pnpm typecheck` passes
 - [ ] `pnpm lint` (or `pnpm lint:check`) passes where applicable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,20 @@ jobs:
 
       - name: Build Next.js app
         run: pnpm build
+
+  sdk-tests:
+    name: SDK Tests (Python)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install SDK with test deps
+        run: pip install -e sdk pytest
+
+      - name: Run SDK tests
+        run: pytest
+        working-directory: sdk

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,3 +63,33 @@
 
 - **One canonical knob per concept.** `duration` (seconds, user-facing) — never alongside `num_frames`/`frame_rate`. `text` (single string) — never alongside `texts` for the same handle role.
 - **Plugin internals don't belong in ABI inputs.** ABI inputs are the cross-plugin product contract; if a field only makes sense for one plugin, make it a plugin constant.
+
+## Commit / PR checklist
+
+Run before every commit; CI ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) re-checks lint, typecheck, build, and SDK tests on a clean checkout.
+
+- [ ] **Scope** is narrow; follows existing patterns. Code comments in **English only**. No secrets — only [`.env.example`](.env.example) (placeholders) is tracked; real values stay in gitignored `.env`.
+- [ ] **If the ABI changed** ([`config/tongflow.abi.json`](config/tongflow.abi.json)): ran `pnpm gen:abi` and committed [`src/generated/abi/index.ts`](src/generated/abi/index.ts). Kept the Python SDK models in sync (see "Cross-layer changes").
+- [ ] `pnpm lint:check` passes (Biome, `--error-on-warnings`). Use `pnpm lint` to auto-format.
+- [ ] `pnpm typecheck` passes (`tsc --noEmit`).
+- [ ] `pnpm build` passes (catches Next.js / server-boundary issues lint misses).
+- [ ] **If `sdk/` changed:** `cd sdk && pytest` passes.
+- [ ] Branch off `main` (never commit straight to `main`); Conventional Commit message (`feat:`/`fix:`/`chore:`…). PRs are covered by the [CLA](CLA.md).
+
+## Release checklist
+
+Two independently-versioned artifacts: the **PyPI `tongflow` SDK** and the **desktop app**. Release the SDK first whenever plugins depend on new types.
+
+**SDK → PyPI** (publishing convention also in [`sdk/README.md`](sdk/README.md)):
+
+- [ ] Bump the version in **both** [`sdk/pyproject.toml`](sdk/pyproject.toml) **and** [`sdk/tongflow/__init__.py`](sdk/tongflow/__init__.py) (`__version__`) — they **must match**; drift between them is a recurring bug.
+- [ ] If ABI/types changed, regenerate models ([`sdk/tongflow/gen_models.py`](sdk/tongflow/gen_models.py)) and confirm `cd sdk && pytest` passes.
+- [ ] Publish: `pnpm tongflow:publish` ([`scripts/publish-tongflow-pypi.sh`](scripts/publish-tongflow-pypi.sh) — needs `TWINE_USERNAME=__token__` + `TWINE_PASSWORD` in `.env`; dry-run to TestPyPI with `TONGFLOW_UPLOAD_TESTPYPI=1`).
+- [ ] Bump every Modal plugin's `pip_install("tongflow==X.Y.Z")` pin to the just-published version (see "Plugin authoring rules").
+
+**Desktop app + GitHub release:**
+
+- [ ] Update [`CHANGELOG.md`](CHANGELOG.md) (Keep a Changelog format) and the app version in [`package.json`](package.json) / [`desktop/package.json`](desktop/package.json) if they're cut.
+- [ ] Tag the release (`git tag vX.Y.Z`); [`.github/workflows/desktop-release.yml`](.github/workflows/desktop-release.yml) builds the macOS (arm64/x64) and Windows installers.
+- [ ] Publish a GitHub Release with the installers attached and the CHANGELOG entry as notes.
+- [ ] Note: root `package.json` stays `"private": true` — it is the app, not an npm library; never `npm publish` it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,190 +1,66 @@
 # Contributing to TongFlow
 
-Thank you for your interest in contributing to TongFlow! This document provides guidelines and instructions for contributing.
+Thanks for your interest in contributing to TongFlow! This guide covers the essentials.
 
 ## Code of Conduct
 
 Please read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). Be respectful and constructive; we welcome contributors from all backgrounds.
 
-## Getting Started
-
-### Prerequisites
+## Prerequisites
 
 - Node.js 20+
 - pnpm
-- Python 3.10+ (for Modal plugins)
-- Modal account (free tier available at [modal.com](https://modal.com))
+- Python 3.10+ (only needed for Modal plugin development)
+- Modal account (free tier at [modal.com](https://modal.com)) — for GPU/CPU inference
 
-### Development Setup
+## Development Setup
 
-1. **Clone the repository**
+```bash
+git clone https://github.com/tong-io/tongflow.git
+cd tongflow
+pnpm install
 
-   ```bash
-   git clone https://github.com/tong-io/tongflow.git
-   cd tongflow
-   ```
+cp .env.example .env       # fill in your API keys / tokens
 
-2. **Install dependencies**
+# Optional, for running Modal plugins locally:
+pip install modal && modal setup
 
-   ```bash
-   pnpm install
-   ```
+pnpm dev                   # http://localhost:3000
+```
 
-3. **Set up environment variables**
+Project conventions (directory layout, the ABI contract, plugin authoring rules) live
+in [CLAUDE.md](CLAUDE.md). Plugin development is documented in [docs/plugins.md](docs/plugins.md).
 
-   ```bash
-   cp .env.example .env
-   # Edit .env with your API keys
-   ```
+## Submitting a Pull Request
 
-4. **Set up Modal (for GPU inference)**
-
-   ```bash
-   pip install modal
-   modal setup
-   ```
-
-5. **Start the development server**
-
-   ```bash
-   pnpm dev
-   ```
-
-   Open [http://localhost:3000](http://localhost:3000) to see the app.
-
-## How to Contribute
-
-### Reporting Bugs
-
-1. Check if the issue already exists in [GitHub Issues](https://github.com/tong-io/tongflow/issues)
-2. If not, create a new issue with:
-   - Clear title and description
-   - Steps to reproduce
-   - Expected vs actual behavior
-   - Screenshots if applicable
-   - Environment info (OS, browser, Node version)
-
-### Suggesting Features
-
-1. Open a [GitHub Issue](https://github.com/tong-io/tongflow/issues) with the "feature request" label
-2. Describe the feature and its use case
-3. Explain why it would be valuable
-
-### Submitting Pull Requests
-
-1. **Fork the repository** and create your branch from `main`
-
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
-
-2. **Make your changes** following the code style guidelines below
-
-3. **Test your changes**
+1. Fork and branch from `main`: `git checkout -b feat/your-feature`.
+2. Make your changes, following existing patterns and keeping PRs narrowly scoped.
+3. Verify before pushing:
 
    ```bash
    pnpm typecheck
-   pnpm lint
+   pnpm lint:check
    pnpm build
    ```
 
-4. **Commit your changes** with a clear message
+4. Use [Conventional Commits](https://www.conventionalcommits.org/) for messages
+   (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:` …) and open a PR against `main`.
 
-   ```bash
-   git commit -m "feat: add support for XYZ"
-   ```
+Comments in code must be in English. File names use kebab-case; React components use PascalCase.
 
-5. **Push to your fork** and open a Pull Request
+## Reporting Bugs & Requesting Features
 
-## Code Style Guidelines
-
-### TypeScript/React
-
-- Use TypeScript for all new code
-- Follow existing code patterns
-- Use functional components with hooks
-- Keep components focused and small
-
-### Formatting
-
-We use [Biome](https://biomejs.dev/) for formatting. Run before committing:
-
-```bash
-pnpm lint
-```
-
-### File Naming
-
-- Use **kebab-case** for file names: `my-component.tsx`
-- Use **PascalCase** for component names: `MyComponent`
-
-### Commit Messages
-
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
-
-- `feat:` new feature
-- `fix:` bug fix
-- `docs:` documentation changes
-- `style:` formatting changes
-- `refactor:` code refactoring
-- `test:` adding tests
-- `chore:` maintenance tasks
-
-## Project Structure
-
-```
-tongflow/
-├── src/
-│   ├── app/              # Next.js pages and API routes
-│   ├── components/       # React components
-│   │   └── workspace/    # Main workspace components
-│   │       └── nodes/    # Node implementations
-│   │           ├── add/      # Source nodes (text, image, audio, video, …)
-│   │           ├── transfer/ # Single-input transform nodes
-│   │           ├── compose/  # Multi-input combine nodes
-│   │           ├── decompose/# Split nodes (text, video)
-│   │           ├── batch/    # Batch helper nodes
-│   │           ├── modal/    # Passthrough display nodes
-│   │           └── base/     # Shared base components
-│   ├── hooks/            # Custom hooks and stores
-│   ├── lib/              # Core libraries and plugin executor
-│   ├── messages/         # i18n strings (en, zh, ja)
-│   ├── generated/        # Auto-generated code (ABI types via pnpm gen:abi)
-│   └── services/         # Server-side service layer
-├── config/               # Feature registry JSON and ABI definition
-├── scripts/              # Build, codegen, and publish scripts
-└── docs/                 # Documentation
-```
-
-## Adding a New Node
-
-1. Create a new file in `src/components/workspace/nodes/<category>/`
-2. Use `BaseNode` as the foundation
-3. Define `workflowConfig` with feature, prompts, and handlers
-4. Register the node in `src/components/workspace/types.tsx`
-5. Add translations in `src/messages/{en,zh,ja}.json`
-
-## Adding a New Plugin
-
-See [docs/feature-registry.md](docs/feature-registry.md) for plugin development guide.
-
-## Questions?
-
-- Join our [Discord](https://discord.gg/K7V8az94Zf)
-- Open a [GitHub Discussion](https://github.com/tong-io/tongflow/discussions)
+Use [GitHub Issues](https://github.com/tong-io/tongflow/issues) with the provided
+templates. For questions, join our [Discord](https://discord.gg/K7V8az94Zf).
 
 ## License & Contributor License Agreement (CLA)
 
-TongFlow is distributed under a **dual-licensing** model: [AGPL-3.0](LICENSE) for
-the community and a separate [commercial license](COMMERCIAL-LICENSE.md) for
-organizations that cannot comply with the AGPL.
+TongFlow uses a **dual-licensing** model: [AGPL-3.0](LICENSE) for the community and a
+separate [commercial license](COMMERCIAL-LICENSE.md) for organizations that cannot
+comply with the AGPL.
 
 To make this possible, **all contributions are covered by our
-[Contributor License Agreement (CLA)](CLA.md)**. By submitting a pull request you
-agree to the CLA: you keep full copyright of your contribution, and you grant
-tong-io the right to relicense it (including under the AGPL-3.0 and under
-commercial terms). Please read [CLA.md](CLA.md) before contributing.
-
-> Note: this applies to the whole repository, including the `sdk/` directory (the
-> `tongflow` PyPI package), which is licensed under **AGPL-3.0** like the rest of
-> the project.
+[Contributor License Agreement (CLA)](CLA.md)**. By submitting a pull request you agree
+to the CLA: you keep full copyright of your contribution, and you grant tong-io the
+right to relicense it (including under AGPL-3.0 and commercial terms). This applies to
+the whole repository, including the `sdk/` directory (the `tongflow` PyPI package).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+TongFlow is under active development. Security fixes are applied to the latest
+release on the `main` branch. Please make sure you are running the most recent
+version before reporting an issue.
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, report them privately so we can address the issue before it is disclosed:
+
+- Email **security@tongflow.com** with a description of the vulnerability, and
+- (Preferred) Use GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+  via the **Security** tab of this repository.
+
+Please include:
+
+- A description of the issue and its potential impact.
+- Steps to reproduce (proof of concept if possible).
+- Affected version / commit and your environment.
+
+## What to Expect
+
+- We aim to acknowledge your report within **3 business days**.
+- We will keep you informed about our progress toward a fix.
+- We ask that you give us a reasonable amount of time to release a fix before any
+  public disclosure, and we will credit you (if you wish) once the issue is resolved.
+
+## Handling Secrets
+
+TongFlow integrates with several third-party providers (Modal, OpenAI, OpenRouter,
+Gemini, PyPI, …). **Never commit real credentials.** Keep them in your local `.env`
+(which is gitignored); only `.env.example` with placeholder values is tracked. If you
+believe a secret has been exposed, rotate it immediately and notify us at the address
+above.

--- a/biome.json
+++ b/biome.json
@@ -22,6 +22,8 @@
             "!desktop/release",
             "!desktop/resources",
             "!.tongflow",
+            "!**/.tongflow",
+            "!data",
             "!.claude",
             "!plugins"
         ]

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -16,7 +16,7 @@ from tongflow.node_slots import NodeSlots
 from tongflow import current_app
 ```
 
-In this monorepo, Modal `impl.py` / stub `deploy.py` images pin **`tongflow==0.0.5`** (PyPI). Bump the version string in those files when you publish a new release.
+In this monorepo, every Modal `deploy.py` and API `entry.py` pins **`tongflow==0.0.21`** (PyPI) — matching the version in [`pyproject.toml`](pyproject.toml). Bump that pin in every plugin when you publish a new release.
 
 ## Plugin identity
 
@@ -64,7 +64,7 @@ export TWINE_PASSWORD=pypi-xxxxxxxx   # https://pypi.org/manage/account/token/
 pnpm tongflow:publish
 ```
 
-This runs [`scripts/publish-tongflow-pypi.sh`](../../scripts/publish-tongflow-pypi.sh) (clean, `python -m build`, `twine check`, `twine upload`).
+This runs [`scripts/publish-tongflow-pypi.sh`](../scripts/publish-tongflow-pypi.sh) (clean, `python -m build`, `twine check`, `twine upload`).
 
 TestPyPI: `TONGFLOW_UPLOAD_TESTPYPI=1 pnpm tongflow:publish` (use a [TestPyPI token](https://test.pypi.org/manage/account/token/)).
 

--- a/sdk/tongflow/__init__.py
+++ b/sdk/tongflow/__init__.py
@@ -3,6 +3,6 @@
 from .modal_app import current_app
 from .progress import progress
 
-__version__ = "0.0.4"
+__version__ = "0.0.21"
 
 __all__ = ["current_app", "progress"]


### PR DESCRIPTION
## Summary

Pre-open-source tidy-up. No app behavior changes — docs, CI, and lint hygiene.

- **CONTRIBUTING.md**: restored as a slim version (was staged for deletion). Drops stale how-tos and dead paths (`docs/feature-registry.md`, `src/messages`), points plugin docs to `docs/plugins.md`, keeps dev setup + CLA section.
- **SECURITY.md**: new — private vulnerability reporting + secret-handling note.
- **CI**: added a Python `sdk-tests` job running the existing `sdk/tests` pytest suite.
- **Fixed a red lint on `main`**: `src/lib/plugins/plugin-python-env.server.ts` had a committed Biome format error (CI `lint:check --error-on-warnings` would fail on a clean checkout). Reformatted it and excluded gitignored `data/` / nested `.tongflow` from Biome so local lint matches CI.
- **CLAUDE.md**: added a commit/PR checklist and a release checklist (incl. the must-match SDK version in `pyproject.toml` + `__init__.py`).
- Carried over the in-flight changes: PR template now references the CLA, SDK `__version__` aligned to `0.0.21`.

## Verification

- `pnpm lint:check` ✅
- `pnpm typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)