### PR TITLE
chore(sdk): bump tongflow to 0.0.22

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tongflow"
-version = "0.0.21"
+version = "0.0.22"
 description = "Tongflow plugin package (node contracts, deploy scan, ABI helpers)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/tongflow/__init__.py
+++ b/sdk/tongflow/__init__.py
@@ -3,6 +3,6 @@
 from .modal_app import current_app
 from .progress import progress
 
-__version__ = "0.0.21"
+__version__ = "0.0.22"
 
 __all__ = ["current_app", "progress"]


### PR DESCRIPTION
Cut a fresh PyPI release of the `tongflow` SDK. Bumps the version in lockstep across `sdk/pyproject.toml` and `sdk/tongflow/__init__.py` (0.0.21 → 0.0.22). No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)