### PR TITLE
fix(ci): green CI — sync lockfile + restore wrongly-ignored source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ __pycache__/
 *.pyo
 
 # runtime-installed plugin packages (see docs/plugins.md)
-plugins/
+# Anchored to repo root so it does NOT also ignore src/lib/plugins/.
+/plugins/
 
 .claude/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       masonic:
         specifier: ^4.1.0
         version: 4.1.0(react@19.2.1)
-      modal:
-        specifier: ^0.7.3
-        version: 0.7.3
       nanoid:
         specifier: 5.1.6
         version: 5.1.6
@@ -251,36 +248,6 @@ packages:
   '@biomejs/cli-win32-x64@2.2.4':
     resolution: {integrity: sha512-3Y4V4zVRarVh/B/eSHczR4LYoSVyv3Dfuvm3cWs5w/HScccS0+Wt/lHOcDTRYeHjQmMYVC3rIRWqyN2EI52+zg==}
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [win32]
-
-  '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
-    resolution: {integrity: sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cbor-extract/cbor-extract-darwin-x64@2.2.2':
-    resolution: {integrity: sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@cbor-extract/cbor-extract-linux-arm64@2.2.2':
-    resolution: {integrity: sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@cbor-extract/cbor-extract-linux-arm@2.2.2':
-    resolution: {integrity: sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==}
-    cpu: [arm]
-    os: [linux]
-
-  '@cbor-extract/cbor-extract-linux-x64@2.2.2':
-    resolution: {integrity: sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@cbor-extract/cbor-extract-win32-x64@2.2.2':
-    resolution: {integrity: sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==}
     cpu: [x64]
     os: [win32]
 
@@ -808,15 +775,6 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
-  '@grpc/grpc-js@1.14.3':
-    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
-    engines: {node: '>=12.10.0'}
-
-  '@grpc/proto-loader@0.8.0':
-    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   '@hookform/resolvers@5.2.1':
     resolution: {integrity: sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==}
     peerDependencies:
@@ -990,9 +948,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@js-sdsl/ordered-map@4.4.2':
-    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -2043,9 +1998,6 @@ packages:
   '@xyflow/system@0.0.71':
     resolution: {integrity: sha512-O2xIK84Uv1hH8qzeY94SKsj0R1n2jXHLsX6RZnM4x1Uc4oWiVbXDFucnkbFwhnQm3IIdAxkbgd2rEDp5oTRhhQ==}
 
-  abort-controller-x@0.4.3:
-    resolution: {integrity: sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA==}
-
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -2053,14 +2005,6 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
 
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
@@ -2120,13 +2064,6 @@ packages:
   caniuse-lite@1.0.30001782:
     resolution: {integrity: sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==}
 
-  cbor-extract@2.2.2:
-    resolution: {integrity: sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==}
-    hasBin: true
-
-  cbor-x@1.6.4:
-    resolution: {integrity: sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q==}
-
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -2150,20 +2087,9 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
-
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2362,9 +2288,6 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -2406,10 +2329,6 @@ packages:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
-
-  escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2478,10 +2397,6 @@ packages:
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
-
-  get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -2566,10 +2481,6 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -2678,9 +2589,6 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  lodash.camelcase@4.3.0:
-    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -2716,9 +2624,6 @@ packages:
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-
-  modal@0.7.3:
-    resolution: {integrity: sha512-4CliqNF15sZPBGpSoCj5Y9fd8fTp1ONrBLIJiC4amm/Qzc1rn8CH45SVzSu+1DokHCIRiZqQ1xMhRKpDvDCkBw==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2775,12 +2680,6 @@ packages:
       sass:
         optional: true
 
-  nice-grpc-common@2.0.2:
-    resolution: {integrity: sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ==}
-
-  nice-grpc@2.1.14:
-    resolution: {integrity: sha512-GK9pKNxlvnU5FAdaw7i2FFuR9CqBspcE+if2tqnKXBcE0R8525wj4BZvfcwj7FjvqbssqKxRHt2nwedalbJlww==}
-
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
@@ -2796,10 +2695,6 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  node-gyp-build-optional-packages@5.1.1:
-    resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
-    hasBin: true
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -2947,10 +2842,6 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -2999,10 +2890,6 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
-  smol-toml@1.6.1:
-    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
-    engines: {node: '>= 18'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3020,16 +2907,8 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -3093,9 +2972,6 @@ packages:
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
-  ts-error@1.0.6:
-    resolution: {integrity: sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3154,10 +3030,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
 
   uuid@13.0.0:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
@@ -3260,10 +3132,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -3278,18 +3146,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-
-  yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
 
   zod@4.1.8:
     resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
@@ -3366,24 +3222,6 @@ snapshots:
     optional: true
 
   '@biomejs/cli-win32-x64@2.2.4':
-    optional: true
-
-  '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
-    optional: true
-
-  '@cbor-extract/cbor-extract-darwin-x64@2.2.2':
-    optional: true
-
-  '@cbor-extract/cbor-extract-linux-arm64@2.2.2':
-    optional: true
-
-  '@cbor-extract/cbor-extract-linux-arm@2.2.2':
-    optional: true
-
-  '@cbor-extract/cbor-extract-linux-x64@2.2.2':
-    optional: true
-
-  '@cbor-extract/cbor-extract-win32-x64@2.2.2':
     optional: true
 
   '@dimforge/rapier3d-compat@0.12.0': {}
@@ -3704,18 +3542,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@grpc/grpc-js@1.14.3':
-    dependencies:
-      '@grpc/proto-loader': 0.8.0
-      '@js-sdsl/ordered-map': 4.4.2
-
-  '@grpc/proto-loader@0.8.0':
-    dependencies:
-      lodash.camelcase: 4.3.0
-      long: 5.3.2
-      protobufjs: 7.5.4
-      yargs: 17.7.2
-
   '@hookform/resolvers@5.2.1(react-hook-form@7.62.0(react@19.2.1))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -3836,8 +3662,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -4755,19 +4579,11 @@ snapshots:
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
 
-  abort-controller-x@0.4.3: {}
-
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
 
   agent-base@7.1.4: {}
-
-  ansi-regex@5.0.1: {}
-
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
 
   aria-hidden@1.2.6:
     dependencies:
@@ -4833,22 +4649,6 @@ snapshots:
 
   caniuse-lite@1.0.30001782: {}
 
-  cbor-extract@2.2.2:
-    dependencies:
-      node-gyp-build-optional-packages: 5.1.1
-    optionalDependencies:
-      '@cbor-extract/cbor-extract-darwin-arm64': 2.2.2
-      '@cbor-extract/cbor-extract-darwin-x64': 2.2.2
-      '@cbor-extract/cbor-extract-linux-arm': 2.2.2
-      '@cbor-extract/cbor-extract-linux-arm64': 2.2.2
-      '@cbor-extract/cbor-extract-linux-x64': 2.2.2
-      '@cbor-extract/cbor-extract-win32-x64': 2.2.2
-    optional: true
-
-  cbor-x@1.6.4:
-    optionalDependencies:
-      cbor-extract: 2.2.2
-
   chai@6.2.2: {}
 
   chokidar@4.0.3:
@@ -4867,19 +4667,7 @@ snapshots:
 
   client-only@0.0.1: {}
 
-  cliui@8.0.1:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
   clsx@2.1.1: {}
-
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4977,8 +4765,6 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
-
-  emoji-regex@8.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -5089,8 +4875,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
-  escalade@3.2.0: {}
-
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -5148,8 +4932,6 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
-
-  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -5240,8 +5022,6 @@ snapshots:
   is-callable@1.2.7: {}
 
   is-extglob@2.1.1: {}
-
-  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -5338,8 +5118,6 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  lodash.camelcase@4.3.0: {}
-
   long@5.3.2: {}
 
   lucide-react@0.544.0(react@19.2.1):
@@ -5378,15 +5156,6 @@ snapshots:
       minimist: 1.2.8
 
   mkdirp-classic@0.5.3: {}
-
-  modal@0.7.3:
-    dependencies:
-      cbor-x: 1.6.4
-      long: 5.3.2
-      nice-grpc: 2.1.14
-      protobufjs: 7.5.4
-      smol-toml: 1.6.1
-      uuid: 11.1.0
 
   ms@2.1.3: {}
 
@@ -5440,16 +5209,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nice-grpc-common@2.0.2:
-    dependencies:
-      ts-error: 1.0.6
-
-  nice-grpc@2.1.14:
-    dependencies:
-      '@grpc/grpc-js': 1.14.3
-      abort-controller-x: 0.4.3
-      nice-grpc-common: 2.0.2
-
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
@@ -5463,11 +5222,6 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
-
-  node-gyp-build-optional-packages@5.1.1:
-    dependencies:
-      detect-libc: 2.1.2
-    optional: true
 
   obug@2.1.1: {}
 
@@ -5624,8 +5378,6 @@ snapshots:
 
   readdirp@4.1.2: {}
 
-  require-directory@2.1.1: {}
-
   resolve-pkg-maps@1.0.0: {}
 
   retry@0.13.1: {}
@@ -5716,8 +5468,6 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
-  smol-toml@1.6.1: {}
-
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -5731,19 +5481,9 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
 
   strip-json-comments@2.0.1: {}
 
@@ -5795,8 +5535,6 @@ snapshots:
   trie-memoize@1.2.0: {}
 
   ts-algebra@2.0.0: {}
-
-  ts-error@1.0.6: {}
 
   tslib@2.8.1: {}
 
@@ -5851,8 +5589,6 @@ snapshots:
       react: 19.2.1
 
   util-deprecate@1.0.2: {}
-
-  uuid@11.1.0: {}
 
   uuid@13.0.0: {}
 
@@ -5914,29 +5650,9 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   wrappy@1.0.2: {}
 
   ws@8.20.0: {}
-
-  y18n@5.0.8: {}
-
-  yargs-parser@21.1.1: {}
-
-  yargs@17.7.2:
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
 
   zod@4.1.8: {}
 

--- a/src/app/api/plugins/install/route.ts
+++ b/src/app/api/plugins/install/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import {
+    installPlugin,
+    PluginInstallError,
+} from "@/lib/plugins/plugins-install.server";
+
+export const runtime = "nodejs";
+
+/**
+ * POST /api/plugins/install
+ * Body: `{ id }` for an official plugin, or `{ gitUrl }` for a custom one.
+ * Clones/updates into plugins/ then rescans the registry.
+ */
+export async function POST(request: NextRequest) {
+    try {
+        const body = (await request.json()) as {
+            id?: string;
+            gitUrl?: string;
+        };
+
+        const result = await installPlugin({
+            id: body.id,
+            gitUrl: body.gitUrl,
+        });
+
+        return NextResponse.json(result, {
+            headers: { "Cache-Control": "no-store" },
+        });
+    } catch (e) {
+        if (e instanceof PluginInstallError) {
+            return NextResponse.json(
+                { error: e.message },
+                { status: e.status },
+            );
+        }
+        const message = e instanceof Error ? e.message : String(e);
+        logger.error("[plugins] install failed:", message);
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
+}

--- a/src/app/api/plugins/official/route.ts
+++ b/src/app/api/plugins/official/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { listOfficialPlugins } from "@/lib/plugins/official-plugins.server";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/plugins/official
+ * Lists official plugins from config/official-plugins.json with installed state.
+ */
+export async function GET() {
+    return NextResponse.json(listOfficialPlugins(), {
+        headers: { "Cache-Control": "no-store" },
+    });
+}

--- a/src/lib/plugins/official-plugins.server.ts
+++ b/src/lib/plugins/official-plugins.server.ts
@@ -1,0 +1,62 @@
+import "server-only";
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { pluginsDir, resourcesDir } from "@/lib/runtime/paths.server";
+
+/**
+ * The canonical official-plugin manifest lives in config/official-plugins.json
+ * and is shared with scripts/install-official-plugins.mjs — a single source of
+ * truth for both the CLI installer and the in-app plugin manager.
+ */
+export interface OfficialPluginManifest {
+    org: string;
+    plugins: string[];
+}
+
+export type PluginRunner = "modal" | "api";
+
+export interface OfficialPluginInfo {
+    id: string;
+    runner: PluginRunner;
+    installed: boolean;
+}
+
+function manifestPath(): string {
+    return join(resourcesDir(), "config", "official-plugins.json");
+}
+
+export function loadOfficialPluginManifest(): OfficialPluginManifest {
+    const raw = readFileSync(manifestPath(), "utf8");
+    return JSON.parse(raw) as OfficialPluginManifest;
+}
+
+/** Git remote URL for an official plugin id under the configured org. */
+export function officialGitUrl(org: string, id: string): string {
+    return `${org}/${id}.git`;
+}
+
+/** A plugin is "installed" once its directory exists under the plugins dir. */
+export function isPluginInstalled(id: string): boolean {
+    return existsSync(join(pluginsDir(), id));
+}
+
+/** Derive the runner from the naming convention (tongflow-modal-* / tongflow-api-*). */
+export function runnerFromId(id: string): PluginRunner {
+    return id.startsWith("tongflow-api-") ? "api" : "modal";
+}
+
+export function listOfficialPlugins(): {
+    org: string;
+    plugins: OfficialPluginInfo[];
+} {
+    const manifest = loadOfficialPluginManifest();
+    return {
+        org: manifest.org,
+        plugins: manifest.plugins.map((id) => ({
+            id,
+            runner: runnerFromId(id),
+            installed: isPluginInstalled(id),
+        })),
+    };
+}

--- a/src/lib/plugins/plugin-python-env.server.ts
+++ b/src/lib/plugins/plugin-python-env.server.ts
@@ -1,0 +1,227 @@
+import "server-only";
+
+import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { logger } from "@/lib/logger";
+import { resolvePythonLite } from "@/lib/plugins/python-lite";
+import { dataDir, resourcesDir } from "@/lib/runtime/paths.server";
+
+/**
+ * Shared Python environment for local plugin entries.
+ *
+ * In the unified plugin model the platform spawns every plugin's local entry as
+ * a subprocess. Those entries are thin adapters (the heavy compute runs in the
+ * backend / Modal image), so they share one managed venv: it holds the tongflow
+ * SDK (+ its deps: pydantic, modal) and, layered on top, each plugin's optional
+ * `requirements.txt`.
+ *
+ * Installs are cumulative and cached by content hash. Because a shared venv can
+ * in principle host conflicting version pins, every install runs `pip check` and
+ * surfaces conflicts as warnings (keep local requirements thin; heavy/pinned
+ * deps belong in the remote image).
+ */
+
+const VENV_DIR = () => join(dataDir(), ".tongflow", "plugin-venv");
+const MARKERS_DIR = () => join(VENV_DIR(), ".markers");
+
+function venvPython(): string {
+    const dir = VENV_DIR();
+    return process.platform === "win32"
+        ? join(dir, "Scripts", "python.exe")
+        : join(dir, "bin", "python");
+}
+
+function pythonIsModern(exe: string): boolean {
+    try {
+        const r = spawnSync(
+            exe,
+            [
+                "-c",
+                "import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)",
+            ],
+            { windowsHide: true },
+        );
+        return r.status === 0;
+    } catch {
+        return false;
+    }
+}
+
+/** First interpreter that runs AND is >= 3.10 (the SDK's minimum). */
+function resolveBasePython(): string | null {
+    const candidates = [
+        process.env.PYTHON?.trim(),
+        "python3.13",
+        "python3.12",
+        "python3.11",
+        "python3.10",
+        "python3",
+        "python",
+    ].filter((x): x is string => Boolean(x));
+    for (const cmd of candidates) {
+        if (pythonIsModern(cmd)) return cmd;
+    }
+    return null;
+}
+
+function runCmd(
+    exe: string,
+    args: string[],
+    cwd: string,
+): Promise<{ code: number; out: string }> {
+    return new Promise((resolve) => {
+        const child = spawn(exe, args, { cwd, windowsHide: true });
+        let out = "";
+        child.stdout?.on("data", (b: Buffer) => {
+            out += String(b);
+        });
+        child.stderr?.on("data", (b: Buffer) => {
+            out += String(b);
+        });
+        child.on("error", (e) => resolve({ code: 1, out: String(e) }));
+        child.on("exit", (code) => resolve({ code: code ?? 1, out }));
+    });
+}
+
+function hashFile(path: string): string | null {
+    try {
+        return createHash("sha256").update(readFileSync(path)).digest("hex");
+    } catch {
+        return null;
+    }
+}
+
+function readMarker(name: string): string | null {
+    try {
+        return readFileSync(join(MARKERS_DIR(), name), "utf8").trim();
+    } catch {
+        return null;
+    }
+}
+
+function writeMarker(name: string, value: string): void {
+    mkdirSync(MARKERS_DIR(), { recursive: true });
+    writeFileSync(join(MARKERS_DIR(), name), value);
+}
+
+// Serialize all venv mutations: pip is not safe to run concurrently against the
+// same environment, and parallel tasks share this one venv.
+let venvChain: Promise<void> = Promise.resolve();
+function serialize<T>(fn: () => Promise<T>): Promise<T> {
+    const next = venvChain.then(fn, fn);
+    venvChain = next.then(
+        () => undefined,
+        () => undefined,
+    );
+    return next;
+}
+
+async function pipCheck(py: string): Promise<void> {
+    const { code, out } = await runCmd(py, ["-m", "pip", "check"], VENV_DIR());
+    if (code !== 0) {
+        logger.warn(
+            `[plugin-env] pip dependency conflicts in the shared plugin venv ` +
+                `(keep local requirements thin; pin heavy deps in the remote ` +
+                `image instead):\n${out.trim()}`,
+        );
+    }
+}
+
+async function ensureSharedVenv(): Promise<string> {
+    const py = venvPython();
+    const sdkDir = join(resourcesDir(), "sdk");
+    const sdkPyproject = join(sdkDir, "pyproject.toml");
+    const sdkHash = hashFile(sdkPyproject) ?? "none";
+
+    // Venv + SDK install are cached against the SDK's pyproject (its declared
+    // deps). Live SDK *code* still comes via PYTHONPATH in the runner.
+    if (existsSync(py) && readMarker("sdk.hash") === sdkHash) {
+        return py;
+    }
+
+    const base = resolveBasePython();
+    if (!base) {
+        throw new Error(
+            "No Python >= 3.10 found for the plugin venv. Install python3.12 " +
+                "(or set PYTHON to a 3.10+ interpreter).",
+        );
+    }
+
+    if (!existsSync(py)) {
+        logger.info(`[plugin-env] creating shared plugin venv with ${base}`);
+        const mk = await runCmd(base, ["-m", "venv", VENV_DIR()], dataDir());
+        if (mk.code !== 0) {
+            throw new Error(`failed to create plugin venv: ${mk.out.trim()}`);
+        }
+    }
+
+    logger.info("[plugin-env] installing tongflow SDK into the plugin venv");
+    const ins = await runCmd(
+        py,
+        ["-m", "pip", "install", "--upgrade", sdkDir],
+        VENV_DIR(),
+    );
+    if (ins.code !== 0) {
+        throw new Error(
+            `failed to install SDK into plugin venv: ${ins.out.trim()}`,
+        );
+    }
+
+    writeMarker("sdk.hash", sdkHash);
+    return py;
+}
+
+async function ensurePluginRequirements(
+    pluginId: string,
+    pluginDir: string,
+    py: string,
+): Promise<void> {
+    const reqPath = join(pluginDir, "requirements.txt");
+    if (!existsSync(reqPath)) return;
+
+    const hash = hashFile(reqPath) ?? "none";
+    const markerName = `req-${pluginId}.hash`;
+    if (readMarker(markerName) === hash) return;
+
+    logger.info(`[plugin-env] installing requirements.txt for ${pluginId}`);
+    const ins = await runCmd(
+        py,
+        ["-m", "pip", "install", "-r", reqPath],
+        pluginDir,
+    );
+    if (ins.code !== 0) {
+        throw new Error(
+            `failed to install requirements for ${pluginId}: ${ins.out.trim()}`,
+        );
+    }
+    await pipCheck(py);
+    writeMarker(markerName, hash);
+}
+
+/**
+ * Ensure the shared plugin venv exists with the SDK + this plugin's
+ * requirements installed, and return the interpreter to run the entry with.
+ *
+ * On any provisioning failure, falls back to the lightweight resolver so an
+ * environment without venv/pip still runs plugins that need no extra deps.
+ */
+export async function ensurePluginPython(
+    pluginId: string,
+    pluginDir: string,
+): Promise<string> {
+    try {
+        return await serialize(async () => {
+            const py = await ensureSharedVenv();
+            await ensurePluginRequirements(pluginId, pluginDir, py);
+            return py;
+        });
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        logger.warn(
+            `[plugin-env] provisioning failed (${msg}); falling back to plain python`,
+        );
+        return resolvePythonLite();
+    }
+}

--- a/src/lib/plugins/plugins-install.server.ts
+++ b/src/lib/plugins/plugins-install.server.ts
@@ -1,0 +1,144 @@
+import "server-only";
+
+import fs, { existsSync } from "node:fs";
+import { join } from "node:path";
+import * as git from "isomorphic-git";
+import http from "isomorphic-git/http/node";
+import { logger } from "@/lib/logger";
+import {
+    isPluginInstalled,
+    loadOfficialPluginManifest,
+    officialGitUrl,
+} from "@/lib/plugins/official-plugins.server";
+import { invalidatePluginsRegistry } from "@/lib/plugins/plugins-registry.server";
+import { pluginsDir } from "@/lib/runtime/paths.server";
+
+// We clone with isomorphic-git (pure JS) so the host does not need a system git
+// binary. Trade-off: isomorphic-git speaks HTTP(S) only — SSH remotes are not
+// supported, which is why assertSafeGitUrl restricts custom URLs to http(s).
+const PLUGIN_GIT_AUTHOR = { name: "tongflow", email: "tongflow@local" };
+
+// The scanner only detects directories that follow the naming convention; a
+// plugin cloned under any other name is silently ignored. We enforce the prefix
+// up front so a custom git URL either yields a usable plugin or a clear error.
+const PLUGIN_ID_RE = /^tongflow-(modal|api)-[a-z0-9][a-z0-9-]*$/;
+
+export interface InstallResult {
+    id: string;
+    /** "cloned" for a fresh checkout, "updated" for a fast-forward pull. */
+    action: "cloned" | "updated";
+    /** Whether the scanner recognized the plugin after the rescan. */
+    recognized: boolean;
+}
+
+export class PluginInstallError extends Error {
+    constructor(
+        message: string,
+        readonly status = 400,
+    ) {
+        super(message);
+        this.name = "PluginInstallError";
+    }
+}
+
+/**
+ * Derive the plugin id (and on-disk directory name) from a git remote URL.
+ * Handles https / ssh / scp-style forms and strips an optional `.git` suffix.
+ */
+export function derivePluginIdFromGitUrl(gitUrl: string): string {
+    const trimmed = gitUrl.trim().replace(/\/+$/, "");
+    // Basename after the last "/" or ":" (scp-style git@host:org/repo.git).
+    const base = trimmed.split(/[/:]/).pop() ?? "";
+    return base.replace(/\.git$/i, "");
+}
+
+function assertSafeGitUrl(gitUrl: string): void {
+    // isomorphic-git only supports the HTTP(S) smart protocol — no SSH/git://.
+    if (!/^https?:\/\//i.test(gitUrl.trim())) {
+        throw new PluginInstallError(
+            "Git URL must be an http(s) URL — SSH remotes (git@…) are not supported.",
+        );
+    }
+}
+
+function assertValidPluginId(id: string): void {
+    if (!PLUGIN_ID_RE.test(id)) {
+        throw new PluginInstallError(
+            `Plugin directory "${id}" must match the tongflow-modal-* or tongflow-api-* convention, otherwise the scanner cannot detect it.`,
+        );
+    }
+}
+
+// Clone the plugin if missing, otherwise fast-forward it to the latest commit.
+// Uses isomorphic-git (pure JS) so no system git binary is required.
+async function cloneOrPull(
+    id: string,
+    gitUrl: string,
+): Promise<"cloned" | "updated"> {
+    const dir = join(pluginsDir(), id);
+    try {
+        if (existsSync(dir)) {
+            await git.pull({
+                fs,
+                http,
+                dir,
+                singleBranch: true,
+                fastForward: true,
+                author: PLUGIN_GIT_AUTHOR,
+            });
+            return "updated";
+        }
+        await git.clone({
+            fs,
+            http,
+            dir,
+            url: gitUrl,
+            singleBranch: true,
+        });
+        return "cloned";
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        throw new PluginInstallError(`git failed: ${msg}`, 500);
+    }
+}
+
+/**
+ * Install an official plugin (by id) or a custom one (by git URL), then rescan
+ * the registry. Exactly one of `id` / `gitUrl` must be provided.
+ */
+export async function installPlugin(params: {
+    id?: string;
+    gitUrl?: string;
+}): Promise<InstallResult> {
+    let id: string;
+    let gitUrl: string;
+
+    if (params.id) {
+        const manifest = loadOfficialPluginManifest();
+        if (!manifest.plugins.includes(params.id)) {
+            throw new PluginInstallError(
+                `Unknown official plugin: ${params.id}`,
+            );
+        }
+        id = params.id;
+        gitUrl = officialGitUrl(manifest.org, id);
+    } else if (params.gitUrl) {
+        assertSafeGitUrl(params.gitUrl);
+        gitUrl = params.gitUrl.trim();
+        id = derivePluginIdFromGitUrl(gitUrl);
+        assertValidPluginId(id);
+    } else {
+        throw new PluginInstallError("Provide either an id or a git URL");
+    }
+
+    const action = await cloneOrPull(id, gitUrl);
+    logger.info(`[plugins] ${action}: ${id}`);
+
+    // Rescan so the new plugin shows up in the registry without a restart.
+    const registry = invalidatePluginsRegistry();
+    const recognized = Boolean(registry.plugins[id]);
+
+    return { id, action, recognized };
+}
+
+export { isPluginInstalled };


### PR DESCRIPTION
## Summary

CI was red on `main` and a clean clone did not build. Two root causes, both pre-existing:

1. **Stale lockfile** — `modal` JS dep was removed from `package.json` but its lockfile entries lingered, so CI's frozen `pnpm install` failed (`ERR_PNPM_OUTDATED_LOCKFILE`). Regenerated `pnpm-lock.yaml` (removals only).

2. **Unanchored `.gitignore` rule** — `plugins/` (intended for the repo-root runtime dir) matched **every** `plugins/` directory, silently ignoring newer source files. A clean checkout was missing:
   - `src/lib/plugins/plugin-python-env.server.ts` (imported by `generic.ts` → the CI `TS2307`)
   - `src/lib/plugins/official-plugins.server.ts`, `plugins-install.server.ts`
   - `src/app/api/plugins/{install,official}/route.ts` (called by `plugins-dialog.tsx`)

   Anchored the rule to `/plugins/` and committed the orphaned files.

## Verification (local)

- `pnpm install --frozen-lockfile` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)