### PR TITLE
fix(desktop): reliable plugin install + correct packaging on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies
@@ -68,7 +68,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -46,7 +46,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 24
                   cache: pnpm
 
             # --- Build the web app (Next standalone bundle) ---

--- a/desktop/scripts/assemble-app.mjs
+++ b/desktop/scripts/assemble-app.mjs
@@ -143,7 +143,13 @@ function assembleApp() {
             path.join(standalone, d),
         ),
     );
-    copy(standalone, appOut, (src) => !skip.has(src));
+    // `next build` (output: standalone) copies the project's .env files into
+    // .next/standalone/.env, and server.js auto-loads them into process.env at
+    // startup — baking the build machine's local environment into the app. The
+    // packaged app reads all configuration from the in-app settings store
+    // (env-store.server.ts), so strip every .env* from the bundle.
+    const isEnvFile = (p) => /^\.env(\.|$)/.test(path.basename(p));
+    copy(standalone, appOut, (src) => !skip.has(src) && !isEnvFile(src));
 
     console.log("[assemble] hoisting node_modules to a flat layout");
     hoistNodeModules(topNM, path.join(appOut, "node_modules"));
@@ -161,6 +167,86 @@ function assembleApp() {
     copy(path.join(repoRoot, "drizzle"), path.join(appOut, "drizzle"));
     copy(path.join(repoRoot, "config"), path.join(appOut, "config"));
     copySdk(path.join(repoRoot, "sdk"), path.join(appOut, "sdk"));
+}
+
+// prebuild-install lives in the repo's node_modules; pnpm nests it in the
+// virtual store, so locate it by scanning rather than bare require.resolve.
+function findPrebuildInstallBin() {
+    const candidates = [
+        path.join(repoRoot, "node_modules", "prebuild-install", "bin.js"),
+    ];
+    const pnpmDir = path.join(repoRoot, "node_modules", ".pnpm");
+    if (fs.existsSync(pnpmDir)) {
+        for (const name of fs.readdirSync(pnpmDir)) {
+            if (name.startsWith("prebuild-install@")) {
+                candidates.push(
+                    path.join(
+                        pnpmDir,
+                        name,
+                        "node_modules",
+                        "prebuild-install",
+                        "bin.js",
+                    ),
+                );
+            }
+        }
+    }
+    const found = candidates.find((p) => fs.existsSync(p));
+    if (!found) {
+        throw new Error(
+            "prebuild-install not found in node_modules — cannot rebuild better-sqlite3.",
+        );
+    }
+    return found;
+}
+
+/**
+ * The Next standalone trace ships better-sqlite3's prebuilt native binary for
+ * the ABI of whatever Node ran `next build` (e.g. a dev machine's Node 24). But
+ * the packaged app runs server.js with the *bundled* Node (pinned in
+ * fetch-runtimes), so a mismatched NODE_MODULE_VERSION makes every SQLite call
+ * throw ERR_DLOPEN_FAILED at runtime ("compiled against a different Node.js
+ * version"). Re-fetch the prebuilt binary for the bundled Node's ABI so the
+ * build is correct regardless of the builder's Node version.
+ *
+ * Only better-sqlite3 needs this: sharp is N-API / ABI-stable across Node
+ * majors. Host-arch builds only — reading the bundled Node version execs it
+ * (the release model selects arch per CI runner anyway).
+ */
+function rebuildBetterSqlite3() {
+    const pkgDir = path.join(appOut, "node_modules", "better-sqlite3");
+    if (!fs.existsSync(pkgDir)) {
+        console.log(
+            "[assemble] better-sqlite3 not in bundle — skipping native rebuild",
+        );
+        return;
+    }
+    const nodeBin = path.join(
+        desktopDir,
+        "resources",
+        "node",
+        process.platform === "win32" ? "node.exe" : "node",
+    );
+    if (!fs.existsSync(nodeBin)) {
+        throw new Error(
+            `Bundled Node not found at ${nodeBin} — run \`pnpm fetch-runtimes\` first.`,
+        );
+    }
+    const nodeVersion = execSync(`"${nodeBin}" -v`, { encoding: "utf8" })
+        .trim()
+        .replace(/^v/, "");
+
+    const prebuildInstall = findPrebuildInstallBin();
+    console.log(
+        `[assemble] rebuilding better-sqlite3 for bundled Node v${nodeVersion}`,
+    );
+    // prebuild-install is a pure-JS downloader: run it with the builder's Node
+    // but target the bundled Node's runtime/ABI. It overwrites the wrong-ABI
+    // binary under the package's build/Release with the correct prebuild.
+    execSync(
+        `"${process.execPath}" "${prebuildInstall}" --runtime node --target ${nodeVersion}`,
+        { cwd: pkgDir, stdio: "inherit" },
+    );
 }
 
 function buildWheelhouse() {
@@ -223,6 +309,7 @@ function buildWheelhouse() {
 
 assertBuilt();
 assembleApp();
+rebuildBetterSqlite3();
 assertNoSymlinks(appOut);
 buildWheelhouse();
 console.log("[assemble] done →", appOut);

--- a/desktop/scripts/fetch-runtimes.mjs
+++ b/desktop/scripts/fetch-runtimes.mjs
@@ -8,8 +8,10 @@
 //   resources/uv/{uv|uv.exe}
 //   resources/python/{bin/python3 | python.exe}
 //
-// Versions are pinned; bump deliberately. Node major must match the ABI of the
-// prebuilt better-sqlite3 / sharp inside the Next standalone bundle.
+// Versions are pinned; bump deliberately. assemble-app.mjs re-fetches
+// better-sqlite3's native binary for this Node's ABI, so the builder's own Node
+// version need not match — but keeping CI's Node aligned with NODE_VERSION
+// avoids a rebuild and keeps dev/build/runtime on one major.
 
 import { execSync } from "node:child_process";
 import fs from "node:fs";
@@ -17,7 +19,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const NODE_VERSION = "20.18.1";
+const NODE_VERSION = "24.12.0";
 const UV_VERSION = "0.5.11";
 const PY_TAG = "20241219"; // python-build-standalone release tag
 const PY_VERSION = "3.12.8";

--- a/src/components/workspace/plugins-dialog.tsx
+++ b/src/components/workspace/plugins-dialog.tsx
@@ -27,6 +27,7 @@ import {
     TooltipContent,
     TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { refreshPluginsRegistry } from "@/hooks/use-plugins-registry";
 import { apiGet, apiPost } from "@/lib/api/client";
 import { logger } from "@/lib/logger";
 
@@ -127,6 +128,10 @@ export function PluginsDialog() {
                     : t("installSuccess", { id: result.id });
             if (result.recognized) {
                 toast.success(msg);
+                // The node-facing registry store caches the registry once on
+                // load; refresh it so newly installed/updated plugins appear in
+                // node pickers without a full app reload.
+                void refreshPluginsRegistry();
             } else {
                 toast(t("notRecognized", { id: result.id }), { icon: "⚠️" });
             }

--- a/src/lib/plugins/official-plugins.server.ts
+++ b/src/lib/plugins/official-plugins.server.ts
@@ -36,9 +36,15 @@ export function officialGitUrl(org: string, id: string): string {
     return `${org}/${id}.git`;
 }
 
-/** A plugin is "installed" once its directory exists under the plugins dir. */
+/**
+ * A plugin is "installed" once it has a real git checkout under the plugins dir.
+ * We check for `.git` rather than the directory alone: an interrupted/failed
+ * clone leaves an empty (or partial) directory behind, and treating that as
+ * "installed" would hide the install button forever while the scanner ignores
+ * the empty dir — the node then reports "no implementation" with no way to fix.
+ */
 export function isPluginInstalled(id: string): boolean {
-    return existsSync(join(pluginsDir(), id));
+    return existsSync(join(pluginsDir(), id, ".git"));
 }
 
 export function listOfficialPlugins(): {

--- a/src/lib/plugins/plugins-install.server.ts
+++ b/src/lib/plugins/plugins-install.server.ts
@@ -76,8 +76,15 @@ async function cloneOrPull(
     gitUrl: string,
 ): Promise<"cloned" | "updated"> {
     const dir = join(pluginsDir(), id);
+    // A leftover directory without a .git is the corpse of an interrupted/failed
+    // earlier clone: it can never be pulled and the scanner ignores it. Wipe it
+    // so we clone fresh instead of erroring (or silently doing nothing) forever.
+    if (existsSync(dir) && !existsSync(join(dir, ".git"))) {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+    const cloning = !existsSync(dir);
     try {
-        if (existsSync(dir)) {
+        if (!cloning) {
             await git.pull({
                 fs,
                 http,
@@ -97,6 +104,13 @@ async function cloneOrPull(
         });
         return "cloned";
     } catch (e) {
+        // A failed clone leaves a partial/empty dir that would poison every
+        // future attempt (dir exists, but no usable checkout). Remove it so the
+        // next install starts clean. Don't touch a pre-existing checkout whose
+        // pull merely failed (e.g. transient network) — it's still usable.
+        if (cloning) {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
         const msg = e instanceof Error ? e.message : String(e);
         throw new PluginInstallError(`git failed: ${msg}`, 500);
     }


### PR DESCRIPTION
## Summary

A few desktop-focused fixes found while debugging "plugin installs but the node can't see it" and "Failed to save workflow" in the packaged app.

### Plugins: install reliably surfaces in node pickers
- Refresh the client-side plugins-registry store after a successful install/update. It was loaded once and cached, so newly installed plugins never appeared in node pickers without a full app reload (masked in dev by Fast Refresh).
- Treat a plugin as installed only when it has a real `.git` checkout. An empty/partial directory from an interrupted clone no longer reads as "installed" (which hid the install button and gave the scanner nothing to detect).
- `cloneOrPull` now wipes a `.git`-less leftover before cloning and cleans up a partial directory when a fresh clone fails, so a failed install can't poison later attempts.

### Desktop packaging
- Re-fetch `better-sqlite3`'s prebuilt native binary for the **bundled** Node's ABI during assemble. The Next standalone trace ships the binary for whatever Node ran `next build`; an ABI mismatch with the bundled Node makes every SQLite call throw `ERR_DLOPEN_FAILED` at runtime (saving a workflow, task polling, material persistence). `sharp` is N-API, so it needs no rebuild.
- Strip `.env*` from the bundle. `next build` (output: standalone) copies the project `.env` into `.next/standalone/.env` and `server.js` auto-loads it at startup, baking the build machine's local environment into the app. The packaged app reads all configuration from the in-app settings store, so the bundled `.env` is unnecessary.

### Node 24
- Pin the bundled Node runtime to `24.12.0` (was `20.18.1`) and move CI/release workflows to `node-version: 24`, so dev/build/runtime share one Node major and native ABIs line up by default. The assemble-time `better-sqlite3` rebuild keeps builds correct regardless of the builder's own Node version.

## Testing
- `pnpm lint:check`, `pnpm typecheck`, `pnpm build` pass.
- Built the macOS package locally on Node 24 and verified end-to-end: plugin install → node picker sees it without reload; saving a workflow works; `better-sqlite3` loads and runs under the bundled Node; no `.env` present in the assembled app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)