### PR TITLE
chore: register scail2 official plugin and dark-mode star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,4 +282,10 @@ PyPI package). Contributions are covered by our [CLA](CLA.md).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tong-io/tongflow&type=Date)](https://star-history.com/#tong-io/tongflow&Date)
+<a href="https://www.star-history.com/?repos=tong-io%2Ftongflow&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left" />
+ </picture>
+</a>

--- a/config/official-plugins.json
+++ b/config/official-plugins.json
@@ -12,6 +12,7 @@
         "tongflow-modal-ltx",
         "tongflow-modal-infinitetalk",
         "tongflow-modal-wan-animate",
+        "tongflow-modal-scail2",
         "tongflow-modal-seedvr2",
         "tongflow-modal-gemma4",
         "tongflow-modal-qwen3asr",

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -272,4 +272,10 @@ TongFlow は **デュアルライセンス（dual-licensing）** モデルを採
 
 ## Star 履歴
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tong-io/tongflow&type=Date)](https://star-history.com/#tong-io/tongflow&Date)
+<a href="https://www.star-history.com/?repos=tong-io%2Ftongflow&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left" />
+ </picture>
+</a>

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -272,4 +272,10 @@ TongFlow 采用 **双授权(dual-licensing)** 模式:
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tong-io/tongflow&type=Date)](https://star-history.com/#tong-io/tongflow&Date)
+<a href="https://www.star-history.com/?repos=tong-io%2Ftongflow&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left" />
+ </picture>
+</a>


### PR DESCRIPTION
## What

- **Register `tongflow-modal-scail2`** in [`config/official-plugins.json`](config/official-plugins.json) so it ships as an official plugin alongside `tongflow-modal-wan-animate` (same two slots, alternate backend).
- **Upgrade the Star History chart** in `README.md`, `docs/README_JA.md`, and `docs/README_ZH.md` to a `<picture>` element with a dark-mode variant.

## Notes

- Docs / config only — no code, ABI, or SDK changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)