### PR TITLE
feat: TripoSplat image→3D plugin + Gaussian-splat viewer (SparkJS)

### DIFF
--- a/config/official-plugins.json
+++ b/config/official-plugins.json
@@ -13,6 +13,7 @@
         "tongflow-modal-infinitetalk",
         "tongflow-modal-wan-animate",
         "tongflow-modal-scail2",
+        "tongflow-modal-triposplat",
         "tongflow-modal-seedvr2",
         "tongflow-modal-gemma4",
         "tongflow-modal-qwen3asr",

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,20 @@ const nextConfig: NextConfig = {
     // server and breaks it at startup. Tracing may pull those mutable dev
     // dirs into .next/standalone on dev machines; the desktop assemble script
     // (desktop/scripts/assemble-app.mjs) skips them when bundling instead.
+    webpack: (config) => {
+        // @sparkjsdev/spark (Gaussian-splat renderer) references its WASM module
+        // via `new URL(...)`. Webpack's URL asset parser mis-resolves it and
+        // breaks the build, so disable that parsing — Spark resolves the module
+        // itself at runtime. (Official fix from sparkjsdev/spark-react-nextjs.)
+        config.module.parser = {
+            ...config.module.parser,
+            javascript: {
+                ...config.module.parser?.javascript,
+                url: false,
+            },
+        };
+        return config;
+    },
 };
 
 export default withNextIntl(nextConfig);

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "@radix-ui/react-switch": "1.2.6",
         "@radix-ui/react-tabs": "1.1.13",
         "@radix-ui/react-tooltip": "1.2.8",
+        "@sparkjsdev/spark": "2.1.0",
         "@types/three": "0.183.1",
         "@xyflow/react": "12.9.0",
         "better-sqlite3": "12.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@sparkjsdev/spark':
+        specifier: 2.1.0
+        version: 2.1.0(three@0.183.2)
       '@types/three':
         specifier: 0.183.1
         version: 0.183.1
@@ -1703,6 +1706,11 @@ packages:
 
   '@schummar/icu-type-parser@1.21.5':
     resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
+
+  '@sparkjsdev/spark@2.1.0':
+    resolution: {integrity: sha512-BRw+MuMzx0B3K8fDLQygt2OHEhYUV+41RX7btq9pZ3rCVrq42o57jW34VAIvC7JO/84DJh/1AutACV9ym6BfVg==}
+    peerDependencies:
+      three: '>=0.180.0'
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -4305,6 +4313,11 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@schummar/icu-type-parser@1.21.5': {}
+
+  '@sparkjsdev/spark@2.1.0(three@0.183.2)':
+    dependencies:
+      fflate: 0.8.2
+      three: 0.183.2
 
   '@standard-schema/spec@1.1.0': {}
 

--- a/src/components/workspace/nodes/modality/model-node.tsx
+++ b/src/components/workspace/nodes/modality/model-node.tsx
@@ -149,12 +149,9 @@ const FullScreen3DModal = ({
     const animationIdRef = useRef<number | null>(null);
     // Re-arm the on-demand render loop from outside setupScene (e.g. reset view).
     const requestRenderRef = useRef<((frames?: number) => void) | null>(null);
-    // OrbitControls instance (typed loosely; imported dynamically).
+    // Camera-controls instance (typed loosely; imported dynamically).
     const controlsRef = useRef<{
-        target: THREE.Vector3;
-        update: () => boolean;
         reset: () => void;
-        saveState: () => void;
         dispose: () => void;
     } | null>(null);
     const [isLoading, setIsLoading] = useState(true);
@@ -244,22 +241,6 @@ const FullScreen3DModal = ({
                 };
                 requestRenderRef.current = requestRender;
 
-                // Standard orbit controls: left-drag orbits the camera around the
-                // model (full top-to-bottom, no ±90° lock), wheel zooms, right-drag
-                // pans. Damped for a smooth feel; redraws on demand via "change".
-                const { OrbitControls } = await import(
-                    "three/examples/jsm/controls/OrbitControls.js"
-                );
-                const controls = new OrbitControls(camera, renderer.domElement);
-                controls.enableDamping = true;
-                controls.dampingFactor = 0.08;
-                controls.rotateSpeed = 0.9;
-                controls.zoomToCursor = true;
-                controls.minDistance = 0.5;
-                controls.maxDistance = 100;
-                controls.addEventListener("change", () => requestRender(2));
-                controlsRef.current = controls;
-
                 // Keep gestures from bubbling to page scroll behind the modal.
                 const canvas = renderer.domElement;
                 const stopProp = (e: Event) => e.stopPropagation();
@@ -320,19 +301,37 @@ const FullScreen3DModal = ({
                 }
 
                 // Autoscale + center the model at the origin and position the
-                // camera; OrbitControls then orbits around that origin.
+                // camera before constructing the controls (Arcball captures the
+                // current camera pose as its "home" / reset baseline).
                 if (modelRef.current) {
                     autoScaleAndCenter(modelRef.current, camera, width, height);
                 }
-                controls.target.set(0, 0, 0);
-                controls.update();
+
+                // Virtual-trackball controls: grab-and-tumble in ANY direction
+                // with no pole/gimbal lock (unlike OrbitControls' fixed up-axis),
+                // wheel zooms, right-drag pans. Fires "change" (incl. during its
+                // own damping) so we can render on demand; no per-frame update().
+                const { ArcballControls } = await import(
+                    "three/examples/jsm/controls/ArcballControls.js"
+                );
+                const controls = new ArcballControls(
+                    camera,
+                    renderer.domElement,
+                    scene,
+                );
+                controls.enableAnimations = true;
+                controls.cursorZoom = true;
+                controls.minDistance = 0.5;
+                controls.maxDistance = 100;
+                controls.setGizmosVisible(false);
+                controls.addEventListener("change", () => requestRender(2));
                 controls.saveState(); // baseline for "reset view"
+                controlsRef.current = controls;
+                requestRender();
 
                 // requestAnimationFrame driver (renders only while armed).
                 const animate = () => {
                     animationIdRef.current = requestAnimationFrame(animate);
-                    // update() returns true while damping is still settling.
-                    if (controls.update()) requestRender(2);
                     if (renderBudget > 0) {
                         renderBudget--;
                         renderer.render(scene, camera);
@@ -598,23 +597,9 @@ const MiniModelPreview = ({
                     renderBudget = Math.max(renderBudget, frames);
                 };
 
-                // Standard orbit controls (drag to orbit, wheel to zoom; full
-                // top-to-bottom range, damped). Same scheme as the fullscreen
-                // viewer so the two feel identical.
-                const { OrbitControls } = await import(
-                    "three/examples/jsm/controls/OrbitControls.js"
-                );
-                const controls = new OrbitControls(camera, renderer.domElement);
-                controls.enableDamping = true;
-                controls.dampingFactor = 0.08;
-                controls.rotateSpeed = 0.9;
-                controls.zoomToCursor = true;
-                controls.minDistance = 0.5;
-                controls.maxDistance = 100;
-                controls.addEventListener("change", () => requestRender(2));
-
                 // Keep drag/zoom inside the node: stop the gestures from bubbling
                 // to React Flow (which would pan/zoom the canvas or drag the node).
+                // The ArcballControls instance is created later (after framing).
                 const canvas = renderer.domElement;
                 canvas.style.cursor = "grab";
                 const stopProp = (e: Event) => e.stopPropagation();
@@ -671,19 +656,36 @@ const MiniModelPreview = ({
                         height,
                     );
                 }
-                // Orbit around the model origin; nudge to a pleasant elevated
-                // 3/4 view as the default framing.
+                // Nudge to a pleasant elevated 3/4 view before constructing the
+                // controls (Arcball captures this camera pose as its home).
                 const dist = camera.position.length() || 12;
                 camera.position
                     .set(dist * 0.7, dist * 0.45, dist * 0.7)
                     .setLength(dist);
-                controls.target.set(0, 0, 0);
-                controls.update();
+                camera.lookAt(0, 0, 0);
+
+                // Virtual-trackball controls: free tumble in any direction, no
+                // pole lock. Same scheme as the fullscreen viewer. Fires "change"
+                // (incl. during damping), driving on-demand rendering.
+                const { ArcballControls } = await import(
+                    "three/examples/jsm/controls/ArcballControls.js"
+                );
+                const controls = new ArcballControls(
+                    camera,
+                    renderer.domElement,
+                    scene,
+                );
+                controls.enableAnimations = true;
+                controls.cursorZoom = true;
+                controls.minDistance = 0.5;
+                controls.maxDistance = 100;
+                controls.setGizmosVisible(false);
+                controls.addEventListener("change", () => requestRender(2));
+                requestRender();
 
                 // Animation Loop (renders only while armed; idles otherwise)
                 const animate = () => {
                     animationIdRef.current = requestAnimationFrame(animate);
-                    if (controls.update()) requestRender(2);
                     if (renderBudget > 0) {
                         renderBudget--;
                         renderer.render(scene, camera);

--- a/src/components/workspace/nodes/modality/model-node.tsx
+++ b/src/components/workspace/nodes/modality/model-node.tsx
@@ -24,18 +24,6 @@ import { ModalityPlaceholder } from "./modality-placeholder";
 
 type ModelNodeRfProps = RfDataNodeProps<"modelNode">;
 
-// Spark must stay dynamic (browser-only entry)
-// Spark WASM currently breaks Next build — disabled
-// Production can load Spark via CDN chunk
-const _SplatMesh: any = null;
-
-// Spark bootstrap — disabled for now
-async function _initSparkIfNeeded() {
-    // Spark WASM module disabled due to Next.js webpack compatibility issues
-    // Prefer CDN bundle in production
-    logger.debug("Gaussian Splatting support requires separate CDN loading");
-}
-
 // Frame camera to bound the mesh
 const _fitCameraToSelection = (
     camera: THREE.PerspectiveCamera,
@@ -79,6 +67,11 @@ const autoScaleAndCenter = (
     containerHeight: number,
 ) => {
     const box = new THREE.Box3().setFromObject(model);
+    // Some objects (e.g. a Gaussian-splat SplatMesh) expose no traversable
+    // geometry bounds; setFromObject then yields an empty box whose center is
+    // NaN, which would push the model off-screen. Leave it at its native
+    // transform in that case.
+    if (box.isEmpty()) return;
     const size = box.getSize(new THREE.Vector3());
     const center = box.getCenter(new THREE.Vector3());
 
@@ -298,7 +291,13 @@ const FullScreen3DModal = ({
                         extension === ".ksplat" ||
                         extension === ".sog"
                     ) {
-                        await loadSplat(url, scene, modelRef);
+                        await loadSplat(
+                            url,
+                            scene,
+                            modelRef,
+                            renderer,
+                            extension,
+                        );
                     } else if (extension === ".fbx") {
                         await loadFBX(url, scene, modelRef);
                     } else if (extension === ".stl") {
@@ -409,6 +408,7 @@ const FullScreen3DModal = ({
                     if (animationIdRef.current) {
                         cancelAnimationFrame(animationIdRef.current);
                     }
+                    disposeSplat(sceneRef.current, modelRef.current);
                     renderer.dispose();
                 };
             } catch (err) {
@@ -725,7 +725,7 @@ const MiniModelPreview = ({
                         ext === ".ksplat" ||
                         ext === ".sog"
                     )
-                        await loadSplat(url, scene, modelHolder);
+                        await loadSplat(url, scene, modelHolder, renderer, ext);
                     else if (ext === ".igs" || ext === ".iges")
                         await loadIGES(url, scene, modelHolder);
                     else if (ext === ".step" || ext === ".stp")
@@ -777,6 +777,7 @@ const MiniModelPreview = ({
                     window.removeEventListener("pointermove", onPointerMove);
                     window.removeEventListener("pointerup", onPointerUp);
                     canvas.removeEventListener("wheel", onWheel);
+                    disposeSplat(sceneRef.current, modelRef.current);
                     renderer.dispose();
                 };
             } catch (err) {
@@ -887,27 +888,67 @@ async function loadOBJ(
 }
 
 // Loader: Gaussian splat payload
+// Name of the per-scene SparkRenderer (one drives sorting/compositing for all
+// SplatMeshes in a scene; reused across loads).
+const SPARK_RENDERER_NAME = "__spark_renderer__";
+
+// Loader: Gaussian Splatting (.ply / .spz / .splat / .ksplat / .sog) via SparkJS.
+// Spark is imported dynamically so its WASM module is never evaluated during SSR
+// or build — only client-side when a splat is actually viewed (paired with the
+// `url: false` webpack parser tweak in next.config.ts).
 async function loadSplat(
-    _url: string,
+    url: string,
     scene: THREE.Scene,
     modelRef: React.MutableRefObject<THREE.Object3D | null>,
+    renderer: THREE.WebGLRenderer,
+    ext: string,
 ): Promise<void> {
-    // Gaussian Splatting support is temporarily disabled due to WASM compatibility issues
-    // Create a placeholder geometry to show in the scene
-    const geometry = new THREE.SphereGeometry(1, 32, 32);
-    const material = new THREE.MeshPhongMaterial({
-        color: 0x64b5f6,
-        emissive: 0x2196f3,
-        shininess: 100,
-    });
-    const mesh = new THREE.Mesh(geometry, material);
+    const { SparkRenderer, SplatMesh, SplatFileType } = await import(
+        "@sparkjsdev/spark"
+    );
 
+    // Install a SparkRenderer into the scene once; the existing
+    // renderer.render(scene, camera) loop drives it via onBeforeRender.
+    if (!scene.getObjectByName(SPARK_RENDERER_NAME)) {
+        const spark = new SparkRenderer({ renderer });
+        spark.name = SPARK_RENDERER_NAME;
+        scene.add(spark);
+    }
+
+    // .ply / .spz / .sog auto-detect from content; .splat / .ksplat need an
+    // explicit fileType (they carry no self-describing header). Inferred from
+    // the enum members via a ternary — SplatFileType is a dynamic-import value
+    // binding and can't be used in a type-annotation position.
+    const lower = ext.toLowerCase();
+    const fileType =
+        lower === ".ply"
+            ? SplatFileType.PLY
+            : lower === ".spz"
+              ? SplatFileType.SPZ
+              : lower === ".splat"
+                ? SplatFileType.SPLAT
+                : lower === ".ksplat"
+                  ? SplatFileType.KSPLAT
+                  : undefined;
+
+    const mesh = new SplatMesh(fileType ? { url, fileType } : { url });
+    // Wait for decode so downstream framing (autoScaleAndCenter) sees real bounds.
+    await mesh.initialized;
     scene.add(mesh);
     modelRef.current = mesh;
+}
 
-    logger.debug(
-        "Gaussian Splatting (.splat, .spz) files require separate CDN loading. Showing placeholder.",
-    );
+// Dispose a SplatMesh + its scene's SparkRenderer (best-effort; both expose
+// dispose()). Called from each viewer's teardown.
+function disposeSplat(
+    scene: THREE.Scene | null,
+    model: THREE.Object3D | null,
+): void {
+    (model as { dispose?: () => void } | null)?.dispose?.();
+    const spark = scene?.getObjectByName(SPARK_RENDERER_NAME) as
+        | (THREE.Object3D & { dispose?: () => void })
+        | undefined;
+    spark?.dispose?.();
 }
 
 // Loader: Autodesk FBX

--- a/src/components/workspace/nodes/modality/model-node.tsx
+++ b/src/components/workspace/nodes/modality/model-node.tsx
@@ -59,6 +59,33 @@ const _fitCameraToSelection = (
     controls.update();
 };
 
+// Object-space bounds that also work for a Gaussian-splat SplatMesh. A SplatMesh
+// has no traversable triangle geometry, so Box3.setFromObject returns empty;
+// fall back to expanding over splat centers via Spark's forEachSplat.
+type SplatLike = {
+    forEachSplat?: (
+        cb: (
+            index: number,
+            center: THREE.Vector3,
+            scales: THREE.Vector3,
+            quaternion: THREE.Quaternion,
+            opacity: number,
+            color: THREE.Color,
+        ) => void,
+    ) => void;
+};
+const computeObjectBounds = (model: THREE.Object3D): THREE.Box3 => {
+    const box = new THREE.Box3().setFromObject(model);
+    if (!box.isEmpty()) return box;
+    const splat = model as unknown as SplatLike;
+    if (typeof splat.forEachSplat === "function") {
+        splat.forEachSplat((_i, center) => {
+            box.expandByPoint(center);
+        });
+    }
+    return box;
+};
+
 // Naive fit + center helper
 const autoScaleAndCenter = (
     model: THREE.Object3D,
@@ -66,11 +93,9 @@ const autoScaleAndCenter = (
     containerWidth: number,
     containerHeight: number,
 ) => {
-    const box = new THREE.Box3().setFromObject(model);
-    // Some objects (e.g. a Gaussian-splat SplatMesh) expose no traversable
-    // geometry bounds; setFromObject then yields an empty box whose center is
-    // NaN, which would push the model off-screen. Leave it at its native
-    // transform in that case.
+    const box = computeObjectBounds(model);
+    // No derivable bounds (e.g. an empty/!forEachSplat object): leave the model
+    // at its native transform rather than computing a NaN center.
     if (box.isEmpty()) return;
     const size = box.getSize(new THREE.Vector3());
     const center = box.getCenter(new THREE.Vector3());
@@ -122,6 +147,8 @@ const FullScreen3DModal = ({
     const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
     const modelRef = useRef<THREE.Object3D | null>(null);
     const animationIdRef = useRef<number | null>(null);
+    // Re-arm the on-demand render loop from outside setupScene (e.g. reset view).
+    const requestRenderRef = useRef<((frames?: number) => void) | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const { url } = useFileAsyncLoader(fileKey, { priority: "high" });
@@ -163,7 +190,9 @@ const FullScreen3DModal = ({
                     alpha: true,
                 });
                 renderer.setSize(width, height);
-                renderer.setPixelRatio(window.devicePixelRatio);
+                // Cap DPR: at native retina (2–3x) Spark sorts/draws 4–9x the
+                // splats per frame, which pegs the GPU. 2 is plenty for preview.
+                renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
                 renderer.outputColorSpace = THREE.SRGBColorSpace; // Respect sRGB color space
                 rendererRef.current = renderer;
 
@@ -203,6 +232,16 @@ const FullScreen3DModal = ({
                 const rotation = { x: 0, y: 0 };
                 const targetRotation = { x: 0, y: 0 };
 
+                // On-demand rendering: only draw when something changed. A frame
+                // budget is armed on load/interaction and decremented per drawn
+                // frame; when it hits 0 the loop idles (no GPU work). The warmup
+                // budget also lets Spark's async splat sort converge after load.
+                let renderBudget = 120;
+                const requestRender = (frames = 90) => {
+                    renderBudget = Math.max(renderBudget, frames);
+                };
+                requestRenderRef.current = requestRender;
+
                 // Pointer listeners
                 const pointerdownHandler = (e: any) => {
                     // Ignore UI chrome outside WebGL canvas
@@ -211,6 +250,7 @@ const FullScreen3DModal = ({
                     e.preventDefault();
                     isDragging = true;
                     previousMousePosition = { x: e.clientX, y: e.clientY };
+                    requestRender();
                 };
 
                 const pointermoveHandler = (e: any) => {
@@ -230,6 +270,7 @@ const FullScreen3DModal = ({
                     );
 
                     previousMousePosition = { x: e.clientX, y: e.clientY };
+                    requestRender();
                 };
 
                 const pointerupHandler = (e: any) => {
@@ -252,6 +293,7 @@ const FullScreen3DModal = ({
                     const distance = camera.position.length();
                     if (distance < 1) camera.position.setLength(1);
                     if (distance > 100) camera.position.setLength(100);
+                    requestRender();
                 };
 
                 // Attach pointer observers
@@ -339,20 +381,27 @@ const FullScreen3DModal = ({
                     targetRotation.y = modelRef.current.rotation.y;
                 }
 
-                // requestAnimationFrame driver
+                // requestAnimationFrame driver (renders only while armed)
                 const animate = () => {
                     animationIdRef.current = requestAnimationFrame(animate);
 
                     if (modelRef.current) {
                         const easing = 0.1;
-                        rotation.x += (targetRotation.x - rotation.x) * easing;
-                        rotation.y += (targetRotation.y - rotation.y) * easing;
-
-                        modelRef.current.rotation.x = rotation.x;
-                        modelRef.current.rotation.y = rotation.y;
+                        const dx = targetRotation.x - rotation.x;
+                        const dy = targetRotation.y - rotation.y;
+                        if (Math.abs(dx) > 1e-4 || Math.abs(dy) > 1e-4) {
+                            rotation.x += dx * easing;
+                            rotation.y += dy * easing;
+                            modelRef.current.rotation.x = rotation.x;
+                            modelRef.current.rotation.y = rotation.y;
+                            requestRender(2);
+                        }
                     }
 
-                    renderer.render(scene, camera);
+                    if (renderBudget > 0) {
+                        renderBudget--;
+                        renderer.render(scene, camera);
+                    }
                 };
                 animate();
 
@@ -369,6 +418,7 @@ const FullScreen3DModal = ({
                     cameraRef.current.aspect = newWidth / newHeight;
                     cameraRef.current.updateProjectionMatrix();
                     rendererRef.current.setSize(newWidth, newHeight);
+                    requestRender();
                 });
 
                 if (mountRef.current) {
@@ -464,6 +514,7 @@ const FullScreen3DModal = ({
             if (modelRef.current) {
                 modelRef.current.rotation.set(0, 0, 0);
             }
+            requestRenderRef.current?.();
         }
     };
 
@@ -639,6 +690,14 @@ const MiniModelPreview = ({
                 const rotation = { x: 0, y: 0 };
                 const targetRotation = { x: 0, y: 0 };
 
+                // On-demand rendering budget (see fullscreen viewer for rationale).
+                // Critical here: an idle node preview must not render 262k splats
+                // every frame forever, or several model nodes together stall the PC.
+                let renderBudget = 120;
+                const requestRender = (frames = 90) => {
+                    renderBudget = Math.max(renderBudget, frames);
+                };
+
                 // Event Handlers
                 const onPointerDown = (e: PointerEvent) => {
                     if (e.target !== renderer.domElement) return;
@@ -649,6 +708,7 @@ const MiniModelPreview = ({
                     previousMousePosition = { x: e.clientX, y: e.clientY };
                     (renderer.domElement as HTMLElement).style.cursor =
                         "grabbing";
+                    requestRender();
                 };
 
                 const onPointerMove = (e: PointerEvent) => {
@@ -667,6 +727,7 @@ const MiniModelPreview = ({
                     );
 
                     previousMousePosition = { x: e.clientX, y: e.clientY };
+                    requestRender();
                 };
 
                 const onPointerUp = (e: PointerEvent) => {
@@ -753,18 +814,26 @@ const MiniModelPreview = ({
                     modelHolder.current.rotation.y = rotation.y;
                 }
 
-                // Animation Loop
+                // Animation Loop (renders only while armed; idles otherwise)
                 const animate = () => {
                     animationIdRef.current = requestAnimationFrame(animate);
 
                     if (modelRef.current) {
                         const easing = 0.1;
-                        rotation.x += (targetRotation.x - rotation.x) * easing;
-                        rotation.y += (targetRotation.y - rotation.y) * easing;
-                        modelRef.current.rotation.x = rotation.x;
-                        modelRef.current.rotation.y = rotation.y;
+                        const dx = targetRotation.x - rotation.x;
+                        const dy = targetRotation.y - rotation.y;
+                        if (Math.abs(dx) > 1e-4 || Math.abs(dy) > 1e-4) {
+                            rotation.x += dx * easing;
+                            rotation.y += dy * easing;
+                            modelRef.current.rotation.x = rotation.x;
+                            modelRef.current.rotation.y = rotation.y;
+                            requestRender(2);
+                        }
                     }
-                    renderer.render(scene, camera);
+                    if (renderBudget > 0) {
+                        renderBudget--;
+                        renderer.render(scene, camera);
+                    }
                 };
                 animate();
                 setIsLoading(false);

--- a/src/components/workspace/nodes/modality/model-node.tsx
+++ b/src/components/workspace/nodes/modality/model-node.tsx
@@ -149,6 +149,14 @@ const FullScreen3DModal = ({
     const animationIdRef = useRef<number | null>(null);
     // Re-arm the on-demand render loop from outside setupScene (e.g. reset view).
     const requestRenderRef = useRef<((frames?: number) => void) | null>(null);
+    // OrbitControls instance (typed loosely; imported dynamically).
+    const controlsRef = useRef<{
+        target: THREE.Vector3;
+        update: () => boolean;
+        reset: () => void;
+        saveState: () => void;
+        dispose: () => void;
+    } | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const { url } = useFileAsyncLoader(fileKey, { priority: "high" });
@@ -226,12 +234,6 @@ const FullScreen3DModal = ({
                 backLight.position.set(0, 5, -5);
                 scene.add(backLight);
 
-                // Orbit / drag damping state
-                let isDragging = false;
-                let previousMousePosition = { x: 0, y: 0 };
-                const rotation = { x: 0, y: 0 };
-                const targetRotation = { x: 0, y: 0 };
-
                 // On-demand rendering: only draw when something changed. A frame
                 // budget is armed on load/interaction and decremented per drawn
                 // frame; when it hits 0 the loop idles (no GPU work). The warmup
@@ -242,81 +244,26 @@ const FullScreen3DModal = ({
                 };
                 requestRenderRef.current = requestRender;
 
-                // Pointer listeners
-                const pointerdownHandler = (e: any) => {
-                    // Ignore UI chrome outside WebGL canvas
-                    if (e.target !== renderer.domElement) return;
-                    e.stopPropagation();
-                    e.preventDefault();
-                    isDragging = true;
-                    previousMousePosition = { x: e.clientX, y: e.clientY };
-                    requestRender();
-                };
+                // Standard orbit controls: left-drag orbits the camera around the
+                // model (full top-to-bottom, no ±90° lock), wheel zooms, right-drag
+                // pans. Damped for a smooth feel; redraws on demand via "change".
+                const { OrbitControls } = await import(
+                    "three/examples/jsm/controls/OrbitControls.js"
+                );
+                const controls = new OrbitControls(camera, renderer.domElement);
+                controls.enableDamping = true;
+                controls.dampingFactor = 0.08;
+                controls.rotateSpeed = 0.9;
+                controls.zoomToCursor = true;
+                controls.minDistance = 0.5;
+                controls.maxDistance = 100;
+                controls.addEventListener("change", () => requestRender(2));
+                controlsRef.current = controls;
 
-                const pointermoveHandler = (e: any) => {
-                    if (!isDragging || !modelRef.current) return;
-                    e.stopPropagation();
-                    e.preventDefault();
-
-                    const deltaX = e.clientX - previousMousePosition.x;
-                    const deltaY = e.clientY - previousMousePosition.y;
-
-                    targetRotation.y += deltaX * 0.01;
-                    targetRotation.x += deltaY * 0.01;
-                    // Clamp polar orbit extremes
-                    targetRotation.x = Math.max(
-                        -Math.PI / 2,
-                        Math.min(Math.PI / 2, targetRotation.x),
-                    );
-
-                    previousMousePosition = { x: e.clientX, y: e.clientY };
-                    requestRender();
-                };
-
-                const pointerupHandler = (e: any) => {
-                    e.stopPropagation();
-                    isDragging = false;
-                };
-
-                const pointerleaveHandler = (e: any) => {
-                    e.stopPropagation();
-                    isDragging = false;
-                };
-
-                const wheelHandler = (e: any) => {
-                    if (e.target !== renderer.domElement) return;
-                    e.preventDefault();
-                    e.stopPropagation();
-                    const scrollDelta = e.deltaY > 0 ? 1.1 : 0.9;
-                    camera.position.multiplyScalar(scrollDelta);
-                    // Clamp dollying distance
-                    const distance = camera.position.length();
-                    if (distance < 1) camera.position.setLength(1);
-                    if (distance > 100) camera.position.setLength(100);
-                    requestRender();
-                };
-
-                // Attach pointer observers
+                // Keep gestures from bubbling to page scroll behind the modal.
                 const canvas = renderer.domElement;
-                canvas.addEventListener(
-                    "pointerdown",
-                    pointerdownHandler,
-                    true,
-                );
-                window.addEventListener(
-                    "pointermove",
-                    pointermoveHandler,
-                    true,
-                ); // Window-level listeners for smoother drags outside canvas bounds
-                window.addEventListener("pointerup", pointerupHandler, true);
-                canvas.addEventListener(
-                    "pointerleave",
-                    pointerleaveHandler,
-                    true,
-                );
-                canvas.addEventListener("wheel", wheelHandler, {
-                    passive: false,
-                });
+                const stopProp = (e: Event) => e.stopPropagation();
+                canvas.addEventListener("wheel", stopProp, { passive: false });
 
                 // Stream chosen loader path
                 const extension = fileExtension.toLowerCase();
@@ -372,32 +319,20 @@ const FullScreen3DModal = ({
                     throw loadErr;
                 }
 
-                // Autoscale after parse completes
+                // Autoscale + center the model at the origin and position the
+                // camera; OrbitControls then orbits around that origin.
                 if (modelRef.current) {
                     autoScaleAndCenter(modelRef.current, camera, width, height);
-
-                    // Seed inertia target quaternion
-                    targetRotation.x = modelRef.current.rotation.x;
-                    targetRotation.y = modelRef.current.rotation.y;
                 }
+                controls.target.set(0, 0, 0);
+                controls.update();
+                controls.saveState(); // baseline for "reset view"
 
-                // requestAnimationFrame driver (renders only while armed)
+                // requestAnimationFrame driver (renders only while armed).
                 const animate = () => {
                     animationIdRef.current = requestAnimationFrame(animate);
-
-                    if (modelRef.current) {
-                        const easing = 0.1;
-                        const dx = targetRotation.x - rotation.x;
-                        const dy = targetRotation.y - rotation.y;
-                        if (Math.abs(dx) > 1e-4 || Math.abs(dy) > 1e-4) {
-                            rotation.x += dx * easing;
-                            rotation.y += dy * easing;
-                            modelRef.current.rotation.x = rotation.x;
-                            modelRef.current.rotation.y = rotation.y;
-                            requestRender(2);
-                        }
-                    }
-
+                    // update() returns true while damping is still settling.
+                    if (controls.update()) requestRender(2);
                     if (renderBudget > 0) {
                         renderBudget--;
                         renderer.render(scene, camera);
@@ -431,30 +366,10 @@ const FullScreen3DModal = ({
                 // Dispose geometries + textures
                 return () => {
                     resizeObserver.disconnect();
-                    window.removeEventListener(
-                        "pointermove",
-                        pointermoveHandler,
-                        true,
-                    );
-                    window.removeEventListener(
-                        "pointerup",
-                        pointerupHandler,
-                        true,
-                    );
-                    if (canvas) {
-                        canvas.removeEventListener(
-                            "pointerdown",
-                            pointerdownHandler,
-                            true,
-                        );
-                        canvas.removeEventListener(
-                            "pointerleave",
-                            pointerleaveHandler,
-                            true,
-                        );
-                        canvas.removeEventListener("wheel", wheelHandler);
-                    }
-
+                    canvas.removeEventListener("wheel", stopProp);
+                    controls.dispose();
+                    controlsRef.current = null;
+                    requestRenderRef.current = null;
                     if (animationIdRef.current) {
                         cancelAnimationFrame(animationIdRef.current);
                     }
@@ -504,18 +419,9 @@ const FullScreen3DModal = ({
     }, [url, setupScene]);
 
     const handleResetView = () => {
-        if (modelRef.current && cameraRef.current && mountRef.current) {
-            autoScaleAndCenter(
-                modelRef.current,
-                cameraRef.current,
-                mountRef.current.clientWidth,
-                mountRef.current.clientHeight,
-            );
-            if (modelRef.current) {
-                modelRef.current.rotation.set(0, 0, 0);
-            }
-            requestRenderRef.current?.();
-        }
+        // Restore the camera/target baseline captured after initial framing.
+        controlsRef.current?.reset();
+        requestRenderRef.current?.();
     };
 
     const handleDownload = () => {
@@ -684,12 +590,6 @@ const MiniModelPreview = ({
                 cameraLight.position.set(0, 0, 1);
                 camera.add(cameraLight);
 
-                // Interaction state
-                let isDragging = false;
-                let previousMousePosition = { x: 0, y: 0 };
-                const rotation = { x: 0, y: 0 };
-                const targetRotation = { x: 0, y: 0 };
-
                 // On-demand rendering budget (see fullscreen viewer for rationale).
                 // Critical here: an idle node preview must not render 262k splats
                 // every frame forever, or several model nodes together stall the PC.
@@ -698,62 +598,28 @@ const MiniModelPreview = ({
                     renderBudget = Math.max(renderBudget, frames);
                 };
 
-                // Event Handlers
-                const onPointerDown = (e: PointerEvent) => {
-                    if (e.target !== renderer.domElement) return;
-                    // CRITICAL: Stop propagation to prevent React Flow from dragging the node
-                    e.stopPropagation();
-                    e.preventDefault();
-                    isDragging = true;
-                    previousMousePosition = { x: e.clientX, y: e.clientY };
-                    (renderer.domElement as HTMLElement).style.cursor =
-                        "grabbing";
-                    requestRender();
-                };
+                // Standard orbit controls (drag to orbit, wheel to zoom; full
+                // top-to-bottom range, damped). Same scheme as the fullscreen
+                // viewer so the two feel identical.
+                const { OrbitControls } = await import(
+                    "three/examples/jsm/controls/OrbitControls.js"
+                );
+                const controls = new OrbitControls(camera, renderer.domElement);
+                controls.enableDamping = true;
+                controls.dampingFactor = 0.08;
+                controls.rotateSpeed = 0.9;
+                controls.zoomToCursor = true;
+                controls.minDistance = 0.5;
+                controls.maxDistance = 100;
+                controls.addEventListener("change", () => requestRender(2));
 
-                const onPointerMove = (e: PointerEvent) => {
-                    if (!isDragging) return;
-                    e.stopPropagation();
-                    e.preventDefault();
-
-                    const deltaX = e.clientX - previousMousePosition.x;
-                    const deltaY = e.clientY - previousMousePosition.y;
-
-                    targetRotation.y += deltaX * 0.01;
-                    targetRotation.x += deltaY * 0.01;
-                    targetRotation.x = Math.max(
-                        -Math.PI / 2,
-                        Math.min(Math.PI / 2, targetRotation.x),
-                    );
-
-                    previousMousePosition = { x: e.clientX, y: e.clientY };
-                    requestRender();
-                };
-
-                const onPointerUp = (e: PointerEvent) => {
-                    if (isDragging) {
-                        e.stopPropagation();
-                        isDragging = false;
-                        (renderer.domElement as HTMLElement).style.cursor =
-                            "grab";
-                    }
-                };
-
-                const onWheel = (e: WheelEvent) => {
-                    if (e.target !== renderer.domElement) return;
-                    // Prevent zooming the flow canvas
-                    e.stopPropagation();
-                    // Optional: Implement zoom for mini preview if needed, but might be too cluttered
-                    // For now, just stop propagation
-                };
-
-                // Attach events
+                // Keep drag/zoom inside the node: stop the gestures from bubbling
+                // to React Flow (which would pan/zoom the canvas or drag the node).
                 const canvas = renderer.domElement;
                 canvas.style.cursor = "grab";
-                canvas.addEventListener("pointerdown", onPointerDown);
-                window.addEventListener("pointermove", onPointerMove); // Window for smooth drag outside
-                window.addEventListener("pointerup", onPointerUp);
-                canvas.addEventListener("wheel", onWheel, { passive: false });
+                const stopProp = (e: Event) => e.stopPropagation();
+                canvas.addEventListener("pointerdown", stopProp);
+                canvas.addEventListener("wheel", stopProp, { passive: false });
 
                 // Load Model
                 const ext = fileExtension.toLowerCase();
@@ -804,32 +670,20 @@ const MiniModelPreview = ({
                         width,
                         height,
                     );
-
-                    // Initial nice angle
-                    targetRotation.x = -0.2;
-                    targetRotation.y = 0.5;
-                    rotation.x = -0.2;
-                    rotation.y = 0.5;
-                    modelHolder.current.rotation.x = rotation.x;
-                    modelHolder.current.rotation.y = rotation.y;
                 }
+                // Orbit around the model origin; nudge to a pleasant elevated
+                // 3/4 view as the default framing.
+                const dist = camera.position.length() || 12;
+                camera.position
+                    .set(dist * 0.7, dist * 0.45, dist * 0.7)
+                    .setLength(dist);
+                controls.target.set(0, 0, 0);
+                controls.update();
 
                 // Animation Loop (renders only while armed; idles otherwise)
                 const animate = () => {
                     animationIdRef.current = requestAnimationFrame(animate);
-
-                    if (modelRef.current) {
-                        const easing = 0.1;
-                        const dx = targetRotation.x - rotation.x;
-                        const dy = targetRotation.y - rotation.y;
-                        if (Math.abs(dx) > 1e-4 || Math.abs(dy) > 1e-4) {
-                            rotation.x += dx * easing;
-                            rotation.y += dy * easing;
-                            modelRef.current.rotation.x = rotation.x;
-                            modelRef.current.rotation.y = rotation.y;
-                            requestRender(2);
-                        }
-                    }
+                    if (controls.update()) requestRender(2);
                     if (renderBudget > 0) {
                         renderBudget--;
                         renderer.render(scene, camera);
@@ -842,10 +696,9 @@ const MiniModelPreview = ({
                 cleanup = () => {
                     if (animationIdRef.current)
                         cancelAnimationFrame(animationIdRef.current);
-                    canvas.removeEventListener("pointerdown", onPointerDown);
-                    window.removeEventListener("pointermove", onPointerMove);
-                    window.removeEventListener("pointerup", onPointerUp);
-                    canvas.removeEventListener("wheel", onWheel);
+                    canvas.removeEventListener("pointerdown", stopProp);
+                    canvas.removeEventListener("wheel", stopProp);
+                    controls.dispose();
                     disposeSplat(sceneRef.current, modelRef.current);
                     renderer.dispose();
                 };

--- a/src/lib/plugin-executor/convert-output-fileref.ts
+++ b/src/lib/plugin-executor/convert-output-fileref.ts
@@ -8,6 +8,7 @@ const FILE_REF_REFS = new Set([
     "#/$defs/ImageRef",
     "#/$defs/VideoRef",
     "#/$defs/AudioRef",
+    "#/$defs/ModelRef",
 ]);
 
 function schemaIsFileRef(schema: unknown): boolean {
@@ -27,7 +28,9 @@ function mimeToExt(mime: string): string | null {
         "audio/mpeg": "mp3",
         "audio/x-wav": "wav",
         "audio/flac": "flac",
-        "application/octet-stream": "bin",
+        // Note: generic binary (application/octet-stream) is intentionally NOT
+        // mapped — it carries no real extension, so we defer to the filename
+        // (e.g. a 3D model's `.splat` / `.ply`) and only fall back to `.bin`.
     };
     return map[m] ?? null;
 }


### PR DESCRIPTION
Adds the **TripoSplat** plugin (single image → 3D Gaussian Splatting) as the first `image-gen-model` plugin, plus the app-side fixes needed to actually view its output.

## What's here

**Plugin registration**
- Register `tongflow-modal-triposplat` in [`config/official-plugins.json`](config/official-plugins.json). The plugin package lives in its own repo: https://github.com/tong-io/tongflow-modal-triposplat (deploy/entry/download + vendored TripoSplat pipeline; outputs `.splat`).

**Plugin-executor fix (surfaced by the first `model` output)**
- `convert-output-fileref.ts` only recognized `FileRef/ImageRef/VideoRef/AudioRef`, so a plugin's `model` (ModelRef) output was passed through as raw `bytesBase64` and never persisted — the canvas got no `file_key` and silently rendered nothing. Add `ModelRef` to the set, and stop mapping generic `application/octet-stream` to `.bin` so a model's real `.splat`/`.ply` extension is preserved for the viewer.

**3D model node — real Gaussian-splat rendering**
- Replace the disabled splat path (placeholder sphere) with real 3DGS via **`@sparkjsdev/spark`** (dynamic import → WASM never evaluated during SSR/build; `next.config.ts` disables webpack `new URL()` parsing per the official spark-react-nextjs guidance).
- **Framing:** derive splat bounds from `forEachSplat` (a SplatMesh has no triangle geometry) so the camera frames it correctly.
- **Perf:** render on-demand (a frame budget armed on load/interaction, idle otherwise) instead of redrawing 262k splats every frame forever; cap the fullscreen pixel ratio at 2.
- **Camera:** **ArcballControls** (virtual trackball) — free tumble in any direction with no OrbitControls pole/gimbal lock; wheel zoom, right-drag pan, damped; drives the on-demand loop via its `change` event.

## Testing
- `pnpm typecheck`, `pnpm lint:check`, `pnpm build` all pass.
- Plugin scanner discovers `image-gen-model → tongflow-modal-triposplat` (0 errors); end-to-end on Modal verified: image → `success: true` + valid `.splat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)