### PR TITLE
chore(release): v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-06-20
+
+### Added
+
+- Official plugins **TripoSplat** (single image → 3D Gaussian Splatting) and
+  **SCAIL-2** (controlled character animation) are now in the plugin registry.
+- The 3D model node renders Gaussian-splat assets (`.splat`, `.ply`, `.spz`,
+  `.ksplat`, `.sog`) in-app via SparkJS, with a free-tumble trackball camera and
+  on-demand rendering for smooth performance on large splats.
+
+### Fixed
+
+- Plugin `model` (3D) outputs are now persisted to file references and rendered
+  on the canvas; previously such outputs were dropped and the node showed
+  nothing.
+
 ## [0.1.1] - 2026-06-16
 
 ### Fixed
@@ -28,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 First public open-source release of TongFlow.
 
-[Unreleased]: https://github.com/tong-io/tongflow/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/tong-io/tongflow/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/tong-io/tongflow/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/tong-io/tongflow/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/tong-io/tongflow/releases/tag/v0.1.0

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow-desktop",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "TongFlow desktop app (Electron shell around the Next.js standalone server + portable Python).",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "A multi-modal AIGC studio for building generative AI workflows",
     "author": "tong-io",
     "keywords": [


### PR DESCRIPTION
Cut desktop app **v0.1.2**. Bumps `package.json` / `desktop/package.json` to 0.1.2 and records the changes since v0.1.1 in the changelog. The PyPI `tongflow` SDK is unchanged (stays 0.1.0).

### Included since v0.1.1
- **#29** — TripoSplat image→3D plugin + in-app Gaussian-splat viewer (SparkJS), ModelRef output-fileref fix.
- **#26** — SCAIL-2 official plugin registration + dark-mode star-history chart.

After merge, tagging `v0.1.2` triggers `desktop-release.yml` to build the macOS (arm64/x64) + Windows installers and publish the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)