### PR TITLE
docs: list scail2 + triposplat plugins, mark Image→3D available

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Run the preloaded example node by node, or switch to Execute Mode and hit the ru
 
 ### Other
 
-- ⬜ **Image → 3D**: single-view 3D model from an image.
+- ✅ **Image → 3D**: single-view 3D model from an image.
 - ✅ **Document → text**: extract plain text from documents.
 - ✅ **Link → text**: turn page content into text.
 
@@ -192,6 +192,8 @@ Run the preloaded example node by node, or switch to Execute Mode and hit the ru
 - [tongflow-modal-ltx](https://github.com/tong-io/tongflow-modal-ltx) — LTX-2.3 text / image-to-video
 - [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk audio-driven lip-sync (audio + video → talking-head video)
 - [tongflow-modal-wan-animate](https://github.com/tong-io/tongflow-modal-wan-animate) — Wan-Animate character swap & motion transfer (video + reference)
+- [tongflow-modal-scail2](https://github.com/tong-io/tongflow-modal-scail2) — SCAIL-2 controlled character animation (image + driving video; same two slots as wan-animate)
+- [tongflow-modal-triposplat](https://github.com/tong-io/tongflow-modal-triposplat) — TripoSplat single image → 3D Gaussian splat
 - [tongflow-modal-seedvr2](https://github.com/tong-io/tongflow-modal-seedvr2) — SeedVR2 image / video super-resolution
 - [tongflow-modal-gemma4](https://github.com/tong-io/tongflow-modal-gemma4) — Gemma-4 multimodal text (image / video understanding)
 - [tongflow-modal-qwen3asr](https://github.com/tong-io/tongflow-modal-qwen3asr) — Qwen3 speech recognition

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -148,7 +148,7 @@ TongFlowで生成AIを活用し、創造力を解き放とう！
 
 ### その他
 
-- ⬜ **画像 → 3D**: 1枚の画像から3Dモデルを生成。
+- ✅ **画像 → 3D**: 1枚の画像から3Dモデルを生成。
 - ✅ **ドキュメント → テキスト**: ドキュメントからプレーンテキストを抽出。
 - ✅ **リンク → テキスト**: ページの内容をテキストに変換。
 
@@ -184,6 +184,8 @@ TongFlowで生成AIを活用し、創造力を解き放とう！
 - [tongflow-modal-ltx](https://github.com/tong-io/tongflow-modal-ltx) — LTX-2.3 テキスト / 画像から動画生成
 - [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk 音声駆動リップシンク（音声 + 動画 → デジタルヒューマン動画）
 - [tongflow-modal-wan-animate](https://github.com/tong-io/tongflow-modal-wan-animate) — Wan-Animate キャラクター置換とモーション転送（動画 + 参照）
+- [tongflow-modal-scail2](https://github.com/tong-io/tongflow-modal-scail2) — SCAIL-2 制御可能なキャラクターアニメーション（画像 + 駆動動画；wan-animate と同じ 2 スロット）
+- [tongflow-modal-triposplat](https://github.com/tong-io/tongflow-modal-triposplat) — TripoSplat 1 枚の画像から 3D ガウシアンスプラット
 - [tongflow-modal-seedvr2](https://github.com/tong-io/tongflow-modal-seedvr2) — SeedVR2 画像 / 動画の超解像
 - [tongflow-modal-gemma4](https://github.com/tong-io/tongflow-modal-gemma4) — Gemma-4 マルチモーダルテキスト（画像 / 動画理解）
 - [tongflow-modal-qwen3asr](https://github.com/tong-io/tongflow-modal-qwen3asr) — Qwen3 音声認識

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -148,7 +148,7 @@ app 默认不预装任何插件。打开**插件管理器**（右上角的方块
 
 ### 其他
 
-- ⬜ **图像 → 3D**: 从单张图像生成 3D 模型。
+- ✅ **图像 → 3D**: 从单张图像生成 3D 模型。
 - ✅ **文档 → 文本**: 从文档中提取纯文本。
 - ✅ **链接 → 文本**: 将页面内容转换为文本。
 
@@ -184,6 +184,8 @@ app 默认不预装任何插件。打开**插件管理器**（右上角的方块
 - [tongflow-modal-ltx](https://github.com/tong-io/tongflow-modal-ltx) — LTX-2.3 文本 / 图像生视频
 - [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk 音频驱动口型同步（音频 + 视频 → 数字人视频）
 - [tongflow-modal-wan-animate](https://github.com/tong-io/tongflow-modal-wan-animate) — Wan-Animate 换角色与动作迁移（视频 + 参考）
+- [tongflow-modal-scail2](https://github.com/tong-io/tongflow-modal-scail2) — SCAIL-2 可控角色动画（角色图 + 驱动视频；与 wan-animate 相同的两个槽位）
+- [tongflow-modal-triposplat](https://github.com/tong-io/tongflow-modal-triposplat) — TripoSplat 单图生成 3D 高斯泼溅
 - [tongflow-modal-seedvr2](https://github.com/tong-io/tongflow-modal-seedvr2) — SeedVR2 图像 / 视频超分辨率
 - [tongflow-modal-gemma4](https://github.com/tong-io/tongflow-modal-gemma4) — Gemma-4 多模态文本（图像 / 视频理解）
 - [tongflow-modal-qwen3asr](https://github.com/tong-io/tongflow-modal-qwen3asr) — Qwen3 语音识别


### PR DESCRIPTION
The README official-plugins list and capability matrix (en/zh/ja) had drifted from `config/official-plugins.json`:

- **Add** `tongflow-modal-scail2` (registered in #26) and `tongflow-modal-triposplat` (#29) under **GPU/CPU plugins**, ordered to match the registry (after wan-animate).
- **Flip** the matrix **Image → 3D** entry from ⬜ to ✅ — TripoSplat is the official `image-gen-model` plugin.

Applied to `README.md`, `docs/README_ZH.md`, `docs/README_JA.md`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)