### PR TITLE
chore(release): v0.1.3 — register Unlimited-OCR plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-06-22
+
+### Added
+
+- Official plugin **Unlimited-OCR** (`tongflow-modal-unlimited-ocr`) — Baidu's
+  Unlimited-OCR for long-horizon document / PDF → text on the `parse-document`
+  slot, a GPU alternative to Docling and PaddleOCR.
+
 ## [0.1.2] - 2026-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Run the preloaded example node by node, or switch to Execute Mode and hit the ru
 - [tongflow-modal-ace-step](https://github.com/tong-io/tongflow-modal-ace-step) — ACE-Step text-to-music
 - [tongflow-modal-docling](https://github.com/tong-io/tongflow-modal-docling) — Docling document → text
 - [tongflow-modal-paddle](https://github.com/tong-io/tongflow-modal-paddle) — PaddleOCR document → text
+- [tongflow-modal-unlimited-ocr](https://github.com/tong-io/tongflow-modal-unlimited-ocr) — Unlimited-OCR long-horizon document / PDF → text
 - [tongflow-modal-crawl4ai](https://github.com/tong-io/tongflow-modal-crawl4ai) — Crawl4AI URL / link → text
 - [tongflow-modal-scrapling](https://github.com/tong-io/tongflow-modal-scrapling) — Scrapling stealth-browser URL / link → text
 

--- a/config/official-plugins.json
+++ b/config/official-plugins.json
@@ -22,6 +22,7 @@
         "tongflow-modal-ace-step",
         "tongflow-modal-docling",
         "tongflow-modal-paddle",
+        "tongflow-modal-unlimited-ocr",
         "tongflow-modal-crawl4ai",
         "tongflow-modal-scrapling"
     ]

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow-desktop",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "TongFlow desktop app (Electron shell around the Next.js standalone server + portable Python).",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -194,6 +194,7 @@ TongFlowで生成AIを活用し、創造力を解き放とう！
 - [tongflow-modal-ace-step](https://github.com/tong-io/tongflow-modal-ace-step) — ACE-Step テキストから音楽生成
 - [tongflow-modal-docling](https://github.com/tong-io/tongflow-modal-docling) — Docling ドキュメント → テキスト
 - [tongflow-modal-paddle](https://github.com/tong-io/tongflow-modal-paddle) — PaddleOCR ドキュメント → テキスト
+- [tongflow-modal-unlimited-ocr](https://github.com/tong-io/tongflow-modal-unlimited-ocr) — Unlimited-OCR 長文ドキュメント / PDF → テキスト
 - [tongflow-modal-crawl4ai](https://github.com/tong-io/tongflow-modal-crawl4ai) — Crawl4AI URL / リンク → テキスト
 - [tongflow-modal-scrapling](https://github.com/tong-io/tongflow-modal-scrapling) — Scrapling ステルスブラウザ URL / リンク → テキスト
 

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -194,6 +194,7 @@ app 默认不预装任何插件。打开**插件管理器**（右上角的方块
 - [tongflow-modal-ace-step](https://github.com/tong-io/tongflow-modal-ace-step) — ACE-Step 文本生音乐
 - [tongflow-modal-docling](https://github.com/tong-io/tongflow-modal-docling) — Docling 文档 → 文本
 - [tongflow-modal-paddle](https://github.com/tong-io/tongflow-modal-paddle) — PaddleOCR 文档 → 文本
+- [tongflow-modal-unlimited-ocr](https://github.com/tong-io/tongflow-modal-unlimited-ocr) — Unlimited-OCR 长文档 / PDF → 文本
 - [tongflow-modal-crawl4ai](https://github.com/tong-io/tongflow-modal-crawl4ai) — Crawl4AI URL / 链接 → 文本
 - [tongflow-modal-scrapling](https://github.com/tong-io/tongflow-modal-scrapling) — Scrapling 隐身浏览器 URL / 链接 → 文本
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "A multi-modal AIGC studio for building generative AI workflows",
     "author": "tong-io",
     "keywords": [


### PR DESCRIPTION
## Summary

- Register official plugin **`tongflow-modal-unlimited-ocr`** (Baidu Unlimited-OCR, long-horizon document / PDF → text on the `parse-document` slot — a GPU alternative to Docling / PaddleOCR) in [`config/official-plugins.json`](config/official-plugins.json) and all three READMEs.
- Bump app version `0.1.2 → 0.1.3` ([`package.json`](package.json), [`desktop/package.json`](desktop/package.json)) and add the [`CHANGELOG.md`](CHANGELOG.md) entry.

The capability matrix already marked **Document → text** ✅ (Docling / PaddleOCR), so no matrix change is needed.

Plugin repo: https://github.com/tong-io/tongflow-modal-unlimited-ocr

> Tag `v0.1.3` after merge to trigger the desktop installer build + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)