### PR TITLE
fix: force UTF-8 I/O for spawned Python to fix GBK crash on Chinese Windows

### DIFF
--- a/sdk/tests/test_subproc.py
+++ b/sdk/tests/test_subproc.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from tongflow.engine._subproc import utf8_env
+
+
+def test_utf8_env_forces_python_utf8_mode() -> None:
+    env = utf8_env({"FOO": "bar"})
+    assert env["PYTHONUTF8"] == "1"
+    assert env["PYTHONIOENCODING"] == "utf-8"
+    # Existing keys in the base are preserved.
+    assert env["FOO"] == "bar"
+
+
+def test_utf8_env_overrides_locale_encoding_from_base() -> None:
+    # A non-UTF-8 locale (e.g. Windows GBK / cp936) must not survive: the
+    # helper always wins so a spawned child prints non-ASCII (a "✓") safely.
+    env = utf8_env({"PYTHONIOENCODING": "gbk", "PYTHONUTF8": "0"})
+    assert env["PYTHONUTF8"] == "1"
+    assert env["PYTHONIOENCODING"] == "utf-8"
+
+
+def test_utf8_env_copies_base_without_mutating_it() -> None:
+    base = {"FOO": "bar"}
+    env = utf8_env(base)
+    assert "PYTHONUTF8" not in base
+    assert env is not base

--- a/sdk/tongflow/engine/_subproc.py
+++ b/sdk/tongflow/engine/_subproc.py
@@ -1,0 +1,31 @@
+"""Subprocess helpers shared across the engine.
+
+Force UTF-8 I/O on spawned child processes (plugin entries, pip, git). On a
+non-UTF-8 system locale — e.g. Windows Simplified-Chinese, whose ANSI code page
+is GBK / cp936 — a child Python's stdout/stderr default to that locale encoding,
+so printing a non-ASCII character such as the "✓" (U+2713) many libraries emit
+while downloading model weights crashes with
+``UnicodeEncodeError: 'gbk' codec can't encode character``.
+
+``PYTHONUTF8=1`` enables Python's UTF-8 Mode (3.7+), which makes the standard
+streams and the default text encoding UTF-8 regardless of locale;
+``PYTHONIOENCODING`` is a belt-and-suspenders fallback for older interpreters.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+
+def utf8_env(base: Optional[dict[str, str]] = None) -> dict[str, str]:
+    """Return an environment dict with Python UTF-8 mode forced on.
+
+    Copies ``base`` (or the current process environment) and sets the UTF-8
+    knobs. Use for every spawned Python/pip subprocess so a non-UTF-8 locale
+    does not break non-ASCII output.
+    """
+    env = dict(base) if base is not None else os.environ.copy()
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    return env

--- a/sdk/tongflow/engine/invoker.py
+++ b/sdk/tongflow/engine/invoker.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from ..progress import PROGRESS_SENTINEL
+from ._subproc import utf8_env
 
 ProgressCb = Callable[[dict[str, Any]], None]
 
@@ -81,7 +82,7 @@ def invoke_plugin(
         }
     )
 
-    env = os.environ.copy()
+    env = utf8_env()
     python_path_parts = [str(sdk_root)]
     if env.get("PYTHONPATH"):
         python_path_parts.append(env["PYTHONPATH"])
@@ -97,6 +98,8 @@ def invoke_plugin(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        encoding="utf-8",
+        errors="replace",
     )
 
     stderr_log: list[str] = []

--- a/sdk/tongflow/engine/plugins.py
+++ b/sdk/tongflow/engine/plugins.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from ..scan import scan
+from ._subproc import utf8_env
 
 DEFAULT_ORG = "https://github.com/tong-io"
 
@@ -58,6 +59,9 @@ def _clone_plugin(plugin_id: str, url: str, plugins_dir: Path, log: LogCb) -> No
         ["git", "clone", "--depth", "1", url, str(dest)],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=utf8_env(),
     )
     if r.returncode != 0:
         raise RuntimeError(
@@ -126,7 +130,15 @@ def _write_marker(venv_dir: Path, name: str, value: str) -> None:
 
 
 def _run(cmd: list[str], cwd: Path) -> tuple[int, str]:
-    r = subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True)
+    r = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=utf8_env(),
+    )
     return r.returncode, (r.stdout + r.stderr)
 
 

--- a/src/lib/plugin-executor/runners/generic.ts
+++ b/src/lib/plugin-executor/runners/generic.ts
@@ -6,6 +6,7 @@ import { TaskStatus } from "@/constants/task-status";
 import type { NodeSlot } from "@/generated/abi";
 import { ensurePluginPython } from "@/lib/plugins/plugin-python-env.server";
 import { getPluginConfig } from "@/lib/plugins/plugins-registry.server";
+import { PYTHON_UTF8_ENV } from "@/lib/plugins/python-lite";
 import { pluginsDir, resourcesDir } from "@/lib/runtime/paths.server";
 import { withStoredEnv } from "@/lib/settings/env-store.server";
 import { notifyTask } from "@/lib/task/emitter";
@@ -55,6 +56,7 @@ export async function execPlugin<S extends NodeSlot>(
         process.env.PYTHONPATH?.trim(),
     ].filter((x): x is string => Boolean(x));
     const pythonEnv = withStoredEnv({
+        ...PYTHON_UTF8_ENV,
         PYTHONPATH: pythonPathParts.join(delimiter),
     });
 

--- a/src/lib/plugins/plugin-python-env.server.ts
+++ b/src/lib/plugins/plugin-python-env.server.ts
@@ -5,7 +5,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { logger } from "@/lib/logger";
-import { resolvePythonLite } from "@/lib/plugins/python-lite";
+import { PYTHON_UTF8_ENV, resolvePythonLite } from "@/lib/plugins/python-lite";
 import { dataDir, resourcesDir } from "@/lib/runtime/paths.server";
 
 /**
@@ -72,7 +72,11 @@ function runCmd(
     cwd: string,
 ): Promise<{ code: number; out: string }> {
     return new Promise((resolve) => {
-        const child = spawn(exe, args, { cwd, windowsHide: true });
+        const child = spawn(exe, args, {
+            cwd,
+            windowsHide: true,
+            env: { ...process.env, ...PYTHON_UTF8_ENV },
+        });
         let out = "";
         child.stdout?.on("data", (b: Buffer) => {
             out += String(b);

--- a/src/lib/plugins/plugins-scanner.server.ts
+++ b/src/lib/plugins/plugins-scanner.server.ts
@@ -6,6 +6,7 @@ import {
     type PluginsRegistry,
     PluginsRegistrySchema,
 } from "@/lib/plugins/plugins-registry-schema";
+import { PYTHON_UTF8_ENV } from "@/lib/plugins/python-lite";
 import { pluginsDir, resourcesDir } from "@/lib/runtime/paths.server";
 
 function pickPython(): string {
@@ -21,6 +22,7 @@ function scannerEnv(): NodeJS.ProcessEnv {
     );
     return {
         ...process.env,
+        ...PYTHON_UTF8_ENV,
         PYTHONPATH: pythonPath.join(delimiter),
     };
 }

--- a/src/lib/plugins/python-lite.ts
+++ b/src/lib/plugins/python-lite.ts
@@ -2,6 +2,25 @@ import "server-only";
 
 import { spawnSync } from "node:child_process";
 
+/**
+ * Force UTF-8 I/O in spawned Python processes.
+ *
+ * On a non-UTF-8 system locale (e.g. Windows Simplified-Chinese, whose ANSI
+ * code page is GBK / cp936) a child Python's stdout/stderr default to that
+ * locale encoding. A plugin that prints a non-ASCII character — such as the
+ * "✓" (U+2713) many libraries emit while downloading model weights — then
+ * crashes with `UnicodeEncodeError: 'gbk' codec can't encode character`.
+ *
+ * `PYTHONUTF8=1` enables Python's UTF-8 Mode (3.7+), which makes the standard
+ * streams and the default text encoding UTF-8 regardless of locale;
+ * `PYTHONIOENCODING` is a belt-and-suspenders fallback for older interpreters.
+ * Merge this into the env of every spawned Python process.
+ */
+export const PYTHON_UTF8_ENV: Record<string, string> = {
+    PYTHONUTF8: "1",
+    PYTHONIOENCODING: "utf-8",
+};
+
 function canRunPython(cmd: string): boolean {
     try {
         const r = spawnSync(cmd, ["-c", "print('ok')"], {

--- a/src/lib/task/engine-delegate.server.ts
+++ b/src/lib/task/engine-delegate.server.ts
@@ -11,7 +11,7 @@ import {
 import { getDb, tasks } from "@/db";
 import { logger } from "@/lib/logger";
 import { resolveBasePython } from "@/lib/plugins/plugin-python-env.server";
-import { resolvePythonLite } from "@/lib/plugins/python-lite";
+import { PYTHON_UTF8_ENV, resolvePythonLite } from "@/lib/plugins/python-lite";
 import { dataDir, pluginsDir, resourcesDir } from "@/lib/runtime/paths.server";
 import { withStoredEnv } from "@/lib/settings/env-store.server";
 import {
@@ -146,6 +146,7 @@ export async function executeWorkflowViaEngine(
         };
 
         const env = withStoredEnv({
+            ...PYTHON_UTF8_ENV,
             PYTHONPATH: [sdkDir, process.env.PYTHONPATH?.trim()]
                 .filter((x): x is string => Boolean(x))
                 .join(delimiter),


### PR DESCRIPTION
## Problem

On a non-UTF-8 system locale — notably **Windows Simplified-Chinese, whose ANSI code page is GBK / cp936** — a spawned Python process's `stdout`/`stderr` default to that locale encoding. TongFlow runs every plugin as a Python subprocess, so when a plugin prints a non-ASCII character (e.g. the `✓` / `U+2713` many libraries emit while downloading model weights), Python raises:

```
UnicodeEncodeError: 'gbk' codec can't encode character '✓' in position 0: illegal multibyte sequence
```

The process exits 1 and the desktop app shows **"downloading weights failed (exit 1)"**. macOS/Linux (UTF-8 by default) are unaffected — this only hits Chinese-locale Windows desktop users.

## Fix

Force Python UTF-8 Mode (`PYTHONUTF8=1`, with `PYTHONIOENCODING=utf-8` as an older-interpreter fallback) at **every** Python spawn site.

**TypeScript** (new shared `PYTHON_UTF8_ENV` constant in `python-lite.ts`):
- `runners/generic.ts` — single-node plugin execution
- `task/engine-delegate.server.ts` — workflow engine
- `plugins/plugin-python-env.server.ts` — venv create / pip install
- `plugins/plugins-scanner.server.ts` — plugin scan (Chinese titles/descriptions trigger the same crash)

**Python SDK engine** (new `engine/_subproc.py` `utf8_env()` helper, covers the standalone `run_workflow` path):
- `engine/invoker.py` — spawning plugin `entry.py`; also decodes child output as UTF-8 with `errors="replace"` so a non-UTF-8 locale can't break the parent read either
- `engine/plugins.py` — pip / git subprocesses

## Verification

- `pnpm typecheck` ✅
- `pnpm lint:check` (Biome) ✅
- `pnpm build` ✅
- `cd sdk && pytest` ✅ — 32 passed (includes 3 new regression tests in `tests/test_subproc.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjnApLh11PUUWmMetQkwRr)_