### PR TITLE
chore(release): v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-06-25
+
+### Fixed
+
+- Plugins no longer crash on a non-UTF-8 system locale (notably Windows
+  Simplified-Chinese, whose ANSI code page is GBK / cp936). A spawned Python's
+  stdout/stderr defaulted to the system locale, so a plugin printing a
+  non-ASCII character — such as the `✓` emitted while downloading model
+  weights — raised `UnicodeEncodeError: 'gbk' codec can't encode character`
+  and surfaced as "downloading weights failed (exit 1)". Every Python spawn
+  site now forces UTF-8 mode (`PYTHONUTF8=1`).
+
 ## [0.1.3] - 2026-06-22
 
 ### Added

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow-desktop",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "TongFlow desktop app (Electron shell around the Next.js standalone server + portable Python).",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "A multi-modal AIGC studio for building generative AI workflows",
     "author": "tong-io",
     "keywords": [


### PR DESCRIPTION
Patch release carrying the UTF-8 spawn fix (#36).

Bumps `package.json` + `desktop/package.json` to `0.1.4` and adds the CHANGELOG entry. Once merged, pushing the `v0.1.4` tag triggers [`desktop-release.yml`](.github/workflows/desktop-release.yml) to build & publish the macOS (arm64/x64) and Windows installers.

### Included fix
Plugins no longer crash with `UnicodeEncodeError: 'gbk' codec can't encode character` on Chinese-locale Windows while downloading model weights — every Python spawn site now forces UTF-8 mode (`PYTHONUTF8=1`). The bundled SDK ships in the desktop build via `assemble`, so no separate PyPI publish is needed for end users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjnApLh11PUUWmMetQkwRr)_