### PR TITLE
chore(desktop): publish GitHub releases directly instead of as drafts

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -52,3 +52,8 @@ publish:
     provider: github
     owner: tong-io
     repo: tongflow
+    # Publish the GitHub Release directly instead of electron-builder's default
+    # `draft` (which required a manual "Publish release" click and silently left
+    # builds unreleased — e.g. the v0.1.3 draft). A pushed `vX.Y.Z` tag now ships
+    # a public release immediately, which electron-updater also needs to see.
+    releaseType: release


### PR DESCRIPTION
electron-builder's GitHub publisher defaults to `releaseType: draft`, so every `desktop-release.yml` run created a **draft** release that needed a manual "Publish release" click. Builds were silently left unreleased — e.g. the **v0.1.3 draft** is still sitting unpublished — and electron-updater (which only reads published releases) never saw them.

Setting `releaseType: release` makes a pushed `vX.Y.Z` tag ship a **public** release immediately.

⚠️ Trade-off: this removes the manual review step before a release goes public. That's the intended behavior here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjnApLh11PUUWmMetQkwRr)_