### PR TITLE
chore(release): v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-06-26
+
+### Added
+
+- Image generation nodes gain a **resolution tier** picker (1K / 2K / 4K)
+  alongside the aspect-ratio picker. The chosen width/height is the aspect
+  ratio's base (1K) dimensions scaled by the tier, persisted directly to the
+  existing `width`/`height` ABI fields (no new contract field).
+
 ## [0.1.4] - 2026-06-25
 
 ### Fixed

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow-desktop",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "TongFlow desktop app (Electron shell around the Next.js standalone server + portable Python).",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "A multi-modal AIGC studio for building generative AI workflows",
     "author": "tong-io",
     "keywords": [

--- a/src/components/workspace/nodes/base/resolution-picker.tsx
+++ b/src/components/workspace/nodes/base/resolution-picker.tsx
@@ -1,0 +1,53 @@
+import { Maximize2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import type { ResolutionTier } from "@/constants/media-options";
+import { cn } from "@/lib/utils";
+
+interface ResolutionPickerProps {
+    tiers: ResolutionTier[];
+    value: string;
+    onChange: (tier: ResolutionTier) => void;
+}
+
+export function ResolutionPicker({
+    tiers,
+    value,
+    onChange,
+}: ResolutionPickerProps) {
+    const t = useTranslations("Workspace.nodes");
+
+    return (
+        <Card className="p-3">
+            <div className="space-y-2">
+                <Label className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+                    <Maximize2 className="h-4 w-4" />
+                    {t("common.resolution")}
+                </Label>
+                <div className="grid grid-cols-3 gap-2">
+                    {tiers.map((tier) => {
+                        const isSelected = value === tier.value;
+                        return (
+                            <Button
+                                key={tier.value}
+                                variant={isSelected ? "default" : "outline"}
+                                size="sm"
+                                onClick={() => onChange(tier)}
+                                className={cn(
+                                    "h-auto py-2 px-1 text-xs transition-all",
+                                    isSelected
+                                        ? "bg-primary text-primary-foreground shadow-md"
+                                        : "hover:bg-accent hover:text-accent-foreground",
+                                )}
+                            >
+                                {tier.label}
+                            </Button>
+                        );
+                    })}
+                </div>
+            </div>
+        </Card>
+    );
+}

--- a/src/components/workspace/nodes/transfer/text-gen-image.tsx
+++ b/src/components/workspace/nodes/transfer/text-gen-image.tsx
@@ -1,39 +1,82 @@
 import { Atom } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { memo, useCallback } from "react";
+import { memo, useCallback, useEffect, useMemo } from "react";
 
 import {
     type AspectRatio,
     IMAGE_ASPECT_RATIOS,
+    IMAGE_RESOLUTION_TIERS,
+    type ResolutionTier,
 } from "@/constants/media-options";
 import { useAbiForm } from "@/hooks/use-abi-form";
 import { batchOn } from "@/lib/abi/sources";
 import type { TongflowPluginNodeProps } from "@/types/tongflow-flow";
 import { AbiNodeShell } from "../base/abi-node-shell";
 import { AspectRatioPicker } from "../base/aspect-ratio-picker";
+import { ResolutionPicker } from "../base/resolution-picker";
 
 type TextGenImageNodeProps = TongflowPluginNodeProps<
     "image-gen",
     "textGenImageNode"
 >;
 
+// Default: 1:1 square at the 1K tier (1024 × 1024).
+const DEFAULT_RATIO =
+    IMAGE_ASPECT_RATIOS.find((r) => r.value === "1:1") ??
+    IMAGE_ASPECT_RATIOS[0];
+const DEFAULT_TIER = IMAGE_RESOLUTION_TIERS[0];
+
 const TextGenImageNode = ({ selected, data }: TextGenImageNodeProps) => {
     const t = useTranslations("Workspace.nodes");
     const { texts = [] } = data;
     const form = useAbiForm("image-gen");
 
-    const width = (form.state.width as number | undefined) ?? 1024;
-    const height = (form.state.height as number | undefined) ?? 1024;
-    const currentRatio =
-        IMAGE_ASPECT_RATIOS.find(
-            (r) => r.width === width && r.height === height,
-        ) ?? IMAGE_ASPECT_RATIOS[0];
+    const width =
+        (form.state.width as number | undefined) ?? DEFAULT_RATIO.width;
+    const height =
+        (form.state.height as number | undefined) ?? DEFAULT_RATIO.height;
 
-    const handleSelectRatio = useCallback(
-        (ratio: AspectRatio) => {
-            form.patch({ width: ratio.width, height: ratio.height });
+    // ABI stores only width/height. Recover the (aspect ratio, tier) pair from
+    // the persisted size: width/height = ratio base dims × tier scale.
+    const { ratio: currentRatio, tier: currentTier } = useMemo(() => {
+        for (const tier of IMAGE_RESOLUTION_TIERS) {
+            const ratio = IMAGE_ASPECT_RATIOS.find(
+                (r) =>
+                    r.width * tier.scale === width &&
+                    r.height * tier.scale === height,
+            );
+            if (ratio) return { ratio, tier };
+        }
+        return { ratio: DEFAULT_RATIO, tier: DEFAULT_TIER };
+    }, [width, height]);
+
+    // Persist the displayed default so execution sends the same size the picker
+    // shows (otherwise the plugin falls back to its own default resolution).
+    useEffect(() => {
+        if (form.state.width === undefined || form.state.height === undefined)
+            form.patch({
+                width: DEFAULT_RATIO.width * DEFAULT_TIER.scale,
+                height: DEFAULT_RATIO.height * DEFAULT_TIER.scale,
+            });
+    }, [form.state.width, form.state.height, form.patch]);
+
+    const applySize = useCallback(
+        (ratio: AspectRatio, tier: ResolutionTier) => {
+            form.patch({
+                width: ratio.width * tier.scale,
+                height: ratio.height * tier.scale,
+            });
         },
         [form],
+    );
+
+    const handleSelectRatio = useCallback(
+        (ratio: AspectRatio) => applySize(ratio, currentTier),
+        [applySize, currentTier],
+    );
+    const handleSelectTier = useCallback(
+        (tier: ResolutionTier) => applySize(currentRatio, tier),
+        [applySize, currentRatio],
     );
 
     return (
@@ -54,9 +97,14 @@ const TextGenImageNode = ({ selected, data }: TextGenImageNodeProps) => {
             <div className="p-4 space-y-4">
                 <AspectRatioPicker
                     ratios={IMAGE_ASPECT_RATIOS}
-                    value={currentRatio}
+                    value={{ ...currentRatio, width, height }}
                     onChange={handleSelectRatio}
                     showSize
+                />
+                <ResolutionPicker
+                    tiers={IMAGE_RESOLUTION_TIERS}
+                    value={currentTier.value}
+                    onChange={handleSelectTier}
                 />
             </div>
         </AbiNodeShell>

--- a/src/constants/media-options.ts
+++ b/src/constants/media-options.ts
@@ -10,12 +10,26 @@ export interface Duration {
     label: string;
 }
 
+export interface ResolutionTier {
+    value: string;
+    label: string;
+    scale: number;
+}
+
 export const IMAGE_ASPECT_RATIOS: AspectRatio[] = [
     { value: "9:16", label: "portrait", width: 720, height: 1280 },
     { value: "16:9", label: "landscape", width: 1280, height: 720 },
     { value: "1:1", label: "square", width: 1024, height: 1024 },
     { value: "4:3", label: "standard", width: 1024, height: 768 },
     { value: "3:4", label: "verticalStandard", width: 768, height: 1024 },
+];
+
+// Resolution tiers scale an aspect ratio's base (1K) dimensions. The picked
+// width/height = ratio base × tier scale; there is no separate ABI field.
+export const IMAGE_RESOLUTION_TIERS: ResolutionTier[] = [
+    { value: "1k", label: "1K", scale: 1 },
+    { value: "2k", label: "2K", scale: 2 },
+    { value: "4k", label: "4K", scale: 4 },
 ];
 
 export const VIDEO_ASPECT_RATIOS: AspectRatio[] = [


### PR DESCRIPTION
## Release v0.1.5

Bumps the desktop app to **0.1.5** and ships the accompanying UI work.

### Changes
- Bump `package.json` / `desktop/package.json` to `0.1.5`
- `CHANGELOG.md`: add `[0.1.5] - 2026-06-26`
- `text-gen-image` node: resolution picker support
- New `resolution-picker` shared component + `media-options` entries

### Release flow
- Merge to `main` (CI: lint / typecheck / build / SDK tests)
- After merge, tag `v0.1.5` and push → `desktop-release.yml` builds macOS (arm64/x64) + Windows installers and publishes the GitHub Release

Note: SDK (`tongflow` PyPI) version is unchanged — desktop-only release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
