### PR TITLE
fix(desktop): upload release assets to a draft, then publish once

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -80,7 +80,7 @@ jobs:
               working-directory: desktop
               run: pnpm smoke
 
-            - name: Package & publish to GitHub Release
+            - name: Package & upload to draft GitHub Release
               working-directory: desktop
               run: pnpm exec electron-builder ${{ matrix.flag }} --publish always
               env:
@@ -89,3 +89,21 @@ jobs:
                   # (and APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID to
                   # notarize), then set CSC_IDENTITY_AUTO_DISCOVERY to true.
                   CSC_IDENTITY_AUTO_DISCOVERY: "false"
+
+    # All three arch jobs upload to the same DRAFT release (see
+    # desktop/electron-builder.yml `releaseType: draft`). Publish it exactly once,
+    # after every asset is attached — flipping a draft to public is the only way to
+    # ship under "Immutable releases", which rejects asset uploads to an already
+    # public release. Tag pushes only; workflow_dispatch leaves the draft for a
+    # manual publish.
+    publish:
+        needs: build
+        if: startsWith(github.ref, 'refs/tags/')
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - name: Publish the draft GitHub Release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: gh release edit "${{ github.ref_name }}" --draft=false --latest --repo "${{ github.repository }}"

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -52,8 +52,12 @@ publish:
     provider: github
     owner: tong-io
     repo: tongflow
-    # Publish the GitHub Release directly instead of electron-builder's default
-    # `draft` (which required a manual "Publish release" click and silently left
-    # builds unreleased — e.g. the v0.1.3 draft). A pushed `vX.Y.Z` tag now ships
-    # a public release immediately, which electron-updater also needs to see.
-    releaseType: release
+    # Upload assets to a DRAFT release first. A published GitHub Release is
+    # immutable the moment it goes public (repo "Immutable releases"), so
+    # electron-builder's per-arch asset uploads 422 with "Cannot upload assets
+    # to an immutable release" once the release is published. Drafts stay
+    # mutable, so all three arch jobs append their dmg/nsis/blockmap/update-feed
+    # assets to the same draft; the workflow's final `publish` job then flips it
+    # to public once (`gh release edit --draft=false`) — automated, no manual
+    # click, and electron-updater still sees a public release.
+    releaseType: draft


### PR DESCRIPTION
## Problem

The `v0.1.5` Desktop Release run failed on every arch at **Package & publish to GitHub Release**:

```
HttpError: 422 Unprocessable Entity
"Cannot upload assets to an immutable release."
```

The build succeeded; only asset upload failed. Under the repo's **Immutable releases** setting, a Release becomes immutable the instant it is published. `desktop/electron-builder.yml` used `releaseType: release` (added in #38), so electron-builder published the release immediately and then 422'd uploading the `.dmg` / `.blockmap` / update-feed assets. Result: `v0.1.5` shipped as a **published but empty** release.

## Fix

- `desktop/electron-builder.yml`: `releaseType: release` → `releaseType: draft`. Drafts stay mutable, so all three arch jobs append their assets to the same draft release.
- `.github/workflows/desktop-release.yml`: add a `publish` job (`needs: build`, tag pushes only) that runs `gh release edit <tag> --draft=false --latest` **once**, after every asset is attached.

Keeps the release fully automated (no manual "Publish" click — the #38 motivation) **without** disabling immutability. The immutable lock now happens at the single publish moment, with all assets already present.

## Follow-up (after merge)
Delete the empty published `v0.1.5` release, re-tag `v0.1.5` on the fixed `main`, and push to re-trigger the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
