### PR TITLE
chore(release): v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.5] - 2026-06-26
+## [0.1.6] - 2026-06-26
 
 ### Added
 
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alongside the aspect-ratio picker. The chosen width/height is the aspect
   ratio's base (1K) dimensions scaled by the tier, persisted directly to the
   existing `width`/`height` ABI fields (no new contract field).
+
+### Fixed
+
+- Desktop release pipeline no longer fails to publish under GitHub's immutable
+  releases. Per-arch installers are uploaded to a draft release and the draft
+  is published once after all assets are attached, instead of publishing
+  immediately and 422-ing on subsequent asset uploads. (Supersedes 0.1.5,
+  which never shipped a usable release.)
 
 ## [0.1.4] - 2026-06-25
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow-desktop",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "description": "TongFlow desktop app (Electron shell around the Next.js standalone server + portable Python).",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "description": "A multi-modal AIGC studio for building generative AI workflows",
     "author": "tong-io",
     "keywords": [


### PR DESCRIPTION
## Release v0.1.6

Re-cuts the v0.1.5 app changes as **0.1.6**. `v0.1.5` was permanently reserved by GitHub's immutable-releases feature after its run published an empty release and 422'd on asset upload, so the version number can't be reused (fix landed in #41).

### Changes
- Bump `package.json` / `desktop/package.json` to `0.1.6`
- `CHANGELOG.md`: rename the unreleased `[0.1.5]` entry to `[0.1.6]`; note the desktop release-pipeline fix
- App changes carried over: image-gen resolution tier picker (1K/2K/4K)

### Release flow
- Merge to `main` (CI: lint / typecheck / build / SDK tests)
- After merge, tag `v0.1.6` and push → `desktop-release.yml` uploads installers to a draft, then the new `publish` job flips it public once

🤖 Generated with [Claude Code](https://claude.com/claude-code)
