### PR TITLE
feat(workspace): reconnect-only canvas with ABI validation (v0.1.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-06-27
+
+### Changed
+
+- Canvas edges are no longer created by dragging from a handle. Handles set
+  `isConnectableStart={false}`, so connections are created only via the
+  operation panel (expands/compose). Users can still **reconnect** an existing
+  edge's endpoint to another node.
+
+### Added
+
+- Reconnecting an edge endpoint is validated against the ABI contract: the
+  upstream modality must match the target handle, single-value (non-array)
+  input handles accept only one edge, `add` nodes fan out to a single edge,
+  and modality nodes can't feed each other.
+- Dropping a dragged edge endpoint on empty canvas prompts to delete the
+  connection. The reconnect preview line matches the edge style so it stays
+  visible and tracks the cursor.
+
+### Fixed
+
+- Aspect-ratio picker labels no longer overflow their button in English; long
+  labels wrap onto multiple lines instead of clipping past the border.
+
 ## [0.1.6] - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Run the preloaded example node by node, or switch to Execute Mode and hit the ru
 
 - [tongflow-api-openrouter-free](https://github.com/tong-io/tongflow-api-openrouter-free) — default `gen_text` route via OpenRouter's free models
 - [tongflow-api-gemini](https://github.com/tong-io/tongflow-api-gemini) — Google Gemini for `gen_text` and other Gemini multimodal handlers
-- [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — OpenAI for `gen_text`
+- [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — OpenAI for `gen_text` and image generation / editing / fusion (`gpt-image-2`)
 
 ### GPU/CPU plugins
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow-desktop",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "TongFlow desktop app (Electron shell around the Next.js standalone server + portable Python).",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -172,7 +172,7 @@ TongFlowで生成AIを活用し、創造力を解き放とう！
 
 - [tongflow-api-openrouter-free](https://github.com/tong-io/tongflow-api-openrouter-free) — デフォルトの `gen_text` ルート、OpenRouter の無料モデルを使用
 - [tongflow-api-gemini](https://github.com/tong-io/tongflow-api-gemini) — Google Gemini ベースの `gen_text` およびマルチモーダル処理
-- [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — OpenAI ベースの `gen_text`
+- [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — OpenAI ベースの `gen_text` および画像生成 / 編集 / 融合（`gpt-image-2`）
 
 ### GPU/CPU プラグイン
 

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -172,7 +172,7 @@ app 默认不预装任何插件。打开**插件管理器**（右上角的方块
 
 - [tongflow-api-openrouter-free](https://github.com/tong-io/tongflow-api-openrouter-free) — 默认 `gen_text` 路由，使用 OpenRouter 免费模型
 - [tongflow-api-gemini](https://github.com/tong-io/tongflow-api-gemini) — 基于 Google Gemini 的 `gen_text` 及多模态处理
-- [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — 基于 OpenAI 的 `gen_text`
+- [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — 基于 OpenAI 的 `gen_text` 及图像生成 / 编辑 / 融合（`gpt-image-2`）
 
 ### GPU/CPU 插件
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "A multi-modal AIGC studio for building generative AI workflows",
     "author": "tong-io",
     "keywords": [

--- a/src/components/workspace/nodes/add/add-audio-node.tsx
+++ b/src/components/workspace/nodes/add/add-audio-node.tsx
@@ -226,6 +226,7 @@ export const AddAudioNode: React.FC<NodeProps> = ({ selected, data }) => {
                 type="source"
                 position={Position.Right}
                 id="out:audioNode"
+                isConnectableStart={false}
             />
             <div className="p-4 space-y-2">
                 <Tabs

--- a/src/components/workspace/nodes/add/add-file-node.tsx
+++ b/src/components/workspace/nodes/add/add-file-node.tsx
@@ -132,7 +132,12 @@ const AddFileNode = ({ selected, data }: NodeProps) => {
             isInputNode
             showPluginSelect={false}
         >
-            <Handle type="source" position={Position.Right} id="out:fileNode" />
+            <Handle
+                type="source"
+                position={Position.Right}
+                id="out:fileNode"
+                isConnectableStart={false}
+            />
             <div className="p-4 space-y-2">
                 <Tabs
                     value={activeTab}

--- a/src/components/workspace/nodes/add/add-image-node.tsx
+++ b/src/components/workspace/nodes/add/add-image-node.tsx
@@ -426,6 +426,7 @@ export const AddImageNode: React.FC<NodeProps> = ({ selected, data }) => {
                 type="source"
                 position={Position.Right}
                 id="out:imageNode"
+                isConnectableStart={false}
             />
             <div className="p-4 space-y-2">
                 <Tabs

--- a/src/components/workspace/nodes/add/add-model-node.tsx
+++ b/src/components/workspace/nodes/add/add-model-node.tsx
@@ -176,6 +176,7 @@ export const AddModelNode: React.FC<NodeProps> = ({ selected, data }) => {
                 type="source"
                 position={Position.Right}
                 id="out:modelNode"
+                isConnectableStart={false}
             />
             <div className="p-4 space-y-2">
                 <Tabs

--- a/src/components/workspace/nodes/add/add-text-node.tsx
+++ b/src/components/workspace/nodes/add/add-text-node.tsx
@@ -151,7 +151,12 @@ const AddTextNode: React.FC<NodeProps> = ({ selected, data }) => {
             isInputNode
             showPluginSelect={false}
         >
-            <Handle type="source" position={Position.Right} id="out:textNode" />
+            <Handle
+                type="source"
+                position={Position.Right}
+                id="out:textNode"
+                isConnectableStart={false}
+            />
             <div className="p-4 space-y-2">
                 <Tabs
                     value={activeTab}

--- a/src/components/workspace/nodes/add/add-video-node.tsx
+++ b/src/components/workspace/nodes/add/add-video-node.tsx
@@ -255,6 +255,7 @@ export const AddVideoNode: React.FC<NodeProps> = ({ selected, data }) => {
                 type="source"
                 position={Position.Right}
                 id="out:videoNode"
+                isConnectableStart={false}
             />
             <div className="p-4 space-y-2">
                 <Tabs

--- a/src/components/workspace/nodes/base/abi-handles.tsx
+++ b/src/components/workspace/nodes/base/abi-handles.tsx
@@ -97,6 +97,8 @@ export function AbiHandles<F extends NodeSlot>({
                     }
                     id={h.id}
                     isConnectable={true}
+                    // Disallow starting a new connection by hand; reconnect only.
+                    isConnectableStart={false}
                     className={handleClassName}
                     style={{ top: `${(h.offset * 100).toFixed(2)}%` }}
                 />

--- a/src/components/workspace/nodes/base/aspect-ratio-picker.tsx
+++ b/src/components/workspace/nodes/base/aspect-ratio-picker.tsx
@@ -42,7 +42,7 @@ export function AspectRatioPicker({
                                 size="sm"
                                 onClick={() => onChange(ratio)}
                                 className={cn(
-                                    "h-auto py-2 px-1 flex flex-row items-center gap-1 text-xs transition-all",
+                                    "h-auto min-w-0 py-2 px-1 flex flex-row items-center gap-1 text-xs whitespace-normal transition-all",
                                     isSelected
                                         ? "bg-primary text-primary-foreground shadow-md"
                                         : "hover:bg-accent hover:text-accent-foreground",
@@ -58,7 +58,7 @@ export function AspectRatioPicker({
                                     style={iconSize}
                                 />
                                 <div className="flex flex-col items-start min-w-0">
-                                    <span className="text-xs font-medium leading-tight truncate">
+                                    <span className="text-xs font-medium leading-tight wrap-break-word text-left">
                                         {t(`options.${ratio.label}`)}
                                     </span>
                                     <span className="text-xs opacity-70 leading-tight">

--- a/src/components/workspace/nodes/modality/audio-node.tsx
+++ b/src/components/workspace/nodes/modality/audio-node.tsx
@@ -229,11 +229,13 @@ const AudioNode = ({ selected, data }: AudioNodeRfProps) => {
                     type="target"
                     position={Position.Left}
                     id="in:audioNode"
+                    isConnectableStart={false}
                 />
                 <Handle
                     type="source"
                     position={Position.Right}
                     id="out:audioNode"
+                    isConnectableStart={false}
                 />
                 <NodeHeader>
                     <NodeHeaderIcon>

--- a/src/components/workspace/nodes/modality/file-node.tsx
+++ b/src/components/workspace/nodes/modality/file-node.tsx
@@ -168,8 +168,18 @@ const FileNode = ({ selected, data }: FileNodeRfProps) => {
 
     return (
         <BaseNodeShell selected={selected} count={count}>
-            <Handle type="target" position={Position.Left} id="in:fileNode" />
-            <Handle type="source" position={Position.Right} id="out:fileNode" />
+            <Handle
+                type="target"
+                position={Position.Left}
+                id="in:fileNode"
+                isConnectableStart={false}
+            />
+            <Handle
+                type="source"
+                position={Position.Right}
+                id="out:fileNode"
+                isConnectableStart={false}
+            />
             <NodeHeader>
                 <NodeHeaderIcon>
                     <FileIcon />

--- a/src/components/workspace/nodes/modality/image-node.tsx
+++ b/src/components/workspace/nodes/modality/image-node.tsx
@@ -274,11 +274,13 @@ const ImageNode = ({ selected, data }: ImageNodeRfProps) => {
                     type="target"
                     position={Position.Left}
                     id="in:imageNode"
+                    isConnectableStart={false}
                 />
                 <Handle
                     type="source"
                     position={Position.Right}
                     id="out:imageNode"
+                    isConnectableStart={false}
                 />
                 <NodeHeader>
                     <NodeHeaderIcon>

--- a/src/components/workspace/nodes/modality/model-node.tsx
+++ b/src/components/workspace/nodes/modality/model-node.tsx
@@ -1237,11 +1237,13 @@ const ModelNode = ({ selected, data }: ModelNodeRfProps) => {
                     type="target"
                     position={Position.Left}
                     id="in:modelNode"
+                    isConnectableStart={false}
                 />
                 <Handle
                     type="source"
                     position={Position.Right}
                     id="out:modelNode"
+                    isConnectableStart={false}
                 />
                 <NodeHeader>
                     <NodeHeaderIcon>
@@ -1261,11 +1263,13 @@ const ModelNode = ({ selected, data }: ModelNodeRfProps) => {
                     type="target"
                     position={Position.Left}
                     id="in:modelNode"
+                    isConnectableStart={false}
                 />
                 <Handle
                     type="source"
                     position={Position.Right}
                     id="out:modelNode"
+                    isConnectableStart={false}
                 />
                 <NodeHeader>
                     <NodeHeaderIcon>

--- a/src/components/workspace/nodes/modality/text-node.tsx
+++ b/src/components/workspace/nodes/modality/text-node.tsx
@@ -113,11 +113,13 @@ const TextNode = ({ selected, data }: TextNodeRfProps) => {
                     type="target"
                     position={Position.Left}
                     id="in:textNode"
+                    isConnectableStart={false}
                 />
                 <Handle
                     type="source"
                     position={Position.Right}
                     id="out:textNode"
+                    isConnectableStart={false}
                 />
                 <NodeHeader>
                     <NodeHeaderIcon>

--- a/src/components/workspace/nodes/modality/video-node.tsx
+++ b/src/components/workspace/nodes/modality/video-node.tsx
@@ -367,11 +367,13 @@ const VideoNode = ({ selected, data }: VideoNodeRfProps) => {
                     type="target"
                     position={Position.Left}
                     id="in:videoNode"
+                    isConnectableStart={false}
                 />
                 <Handle
                     type="source"
                     position={Position.Right}
                     id="out:videoNode"
+                    isConnectableStart={false}
                 />
                 <NodeHeader>
                     <NodeHeaderIcon>

--- a/src/components/workspace/workspace.tsx
+++ b/src/components/workspace/workspace.tsx
@@ -5,19 +5,37 @@
  * ReactFlow canvas managing nodes and edges
  */
 
-import type { Connection, Edge, IsValidConnection, Node } from "@xyflow/react";
+import type {
+    Connection,
+    Edge,
+    FinalConnectionState,
+    IsValidConnection,
+    Node,
+    OnReconnect,
+} from "@xyflow/react";
 import {
     Background,
     Controls,
     Panel,
     ReactFlow,
     ReactFlowProvider,
+    reconnectEdge,
     useReactFlow,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useLocale, useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { usePreloadFeatures } from "@/hooks/use-features";
 import type { FlowState } from "@/hooks/use-flow";
 import { useFlow } from "@/hooks/use-flow";
@@ -63,15 +81,60 @@ function WorkspaceInner({
 
     const isValidConnection = useCallback<IsValidConnection<Edge>>(
         (connection) => {
-            const { nodes, edges } = useFlow.getState();
+            const { nodes, edges, reconnectingEdgeId } = useFlow.getState();
             return isValidFlowConnection(
                 connection as Connection,
                 nodes,
                 edges,
+                reconnectingEdgeId ?? undefined,
             );
         },
         [],
     );
+
+    const tEdges = useTranslations("Workspace.edges");
+    // Edge whose endpoint was dropped on empty canvas → confirm deletion.
+    const [pendingDeleteEdgeId, setPendingDeleteEdgeId] = useState<
+        string | null
+    >(null);
+
+    // Manual edge creation is disabled (handles set isConnectableStart=false).
+    // Users may only reconnect an existing edge's endpoint to another handle;
+    // isValidConnection above enforces the ABI contract on the new endpoint.
+    const onReconnectStart = useCallback((_event: unknown, edge: Edge) => {
+        useFlow.getState().setReconnectingEdgeId(edge.id);
+    }, []);
+
+    const onReconnect = useCallback<OnReconnect<Edge>>(
+        (oldEdge, newConnection) => {
+            const { edges, setEdges } = useFlow.getState();
+            setEdges(reconnectEdge(oldEdge, newConnection, edges));
+        },
+        [],
+    );
+
+    const onReconnectEnd = useCallback(
+        (
+            _event: MouseEvent | TouchEvent,
+            edge: Edge,
+            _handleType: unknown,
+            connectionState: FinalConnectionState,
+        ) => {
+            useFlow.getState().setReconnectingEdgeId(null);
+            // Dropped on empty canvas (no target handle) → ask to delete.
+            if (!connectionState.toHandle) {
+                setPendingDeleteEdgeId(edge.id);
+            }
+        },
+        [],
+    );
+
+    const confirmDeleteEdge = useCallback(() => {
+        if (!pendingDeleteEdgeId) return;
+        const { edges, setEdges } = useFlow.getState();
+        setEdges(edges.filter((e) => e.id !== pendingDeleteEdgeId));
+        setPendingDeleteEdgeId(null);
+    }, [pendingDeleteEdgeId]);
 
     // Listen for theme changes
     useEffect(() => {
@@ -293,12 +356,26 @@ function WorkspaceInner({
                 onEdgesChange={onEdgesChange}
                 onConnect={onConnect}
                 isValidConnection={isValidConnection}
+                // Manual new connections are disabled at the handle level
+                // (isConnectableStart={false}); users may only reconnect an
+                // existing edge's endpoint, validated by isValidConnection.
+                onReconnect={onReconnect}
+                onReconnectStart={onReconnectStart}
+                onReconnectEnd={onReconnectEnd}
                 nodeTypes={NODE_TYPES}
                 edgeTypes={EDGE_TYPES}
                 defaultEdgeOptions={{
                     type: "custom-edge",
                     selectable: false,
                     focusable: false,
+                }}
+                // While reconnecting, ReactFlow hides the original edge and
+                // shows this connection-line preview following the cursor.
+                // Match the custom-edge style so it stays visible/cursor-tracked.
+                connectionLineStyle={{
+                    strokeWidth: 3,
+                    stroke: "#94a3b8",
+                    strokeLinecap: "round",
                 }}
                 onSelectionChange={onSelectionChange}
                 onNodeDoubleClick={handleNodeDoubleClick}
@@ -330,6 +407,32 @@ function WorkspaceInner({
             <div className="absolute right-4 bottom-5 z-10">
                 <ModeSwitch />
             </div>
+
+            <AlertDialog
+                open={pendingDeleteEdgeId !== null}
+                onOpenChange={(open) => {
+                    if (!open) setPendingDeleteEdgeId(null);
+                }}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>
+                            {tEdges("deleteConfirmTitle")}
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {tEdges("deleteConfirmDescription")}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>
+                            {tEdges("cancel")}
+                        </AlertDialogCancel>
+                        <AlertDialogAction onClick={confirmDeleteEdge}>
+                            {tEdges("delete")}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/src/hooks/use-flow.ts
+++ b/src/hooks/use-flow.ts
@@ -98,6 +98,9 @@ export interface FlowState {
     onConnect: OnConnect;
     setNodes: (nodes: Node[]) => void;
     setEdges: (edges: Edge[]) => void;
+    /** Id of the edge currently being reconnected (excluded from validation). */
+    reconnectingEdgeId: string | null;
+    setReconnectingEdgeId: (id: string | null) => void;
     expands: (nodeId: string | null, possibleNodes: PossibleNode[]) => string[];
     compose: (newNode: { type: string; data: unknown }) => string;
     updates: (nodeId: string, data: Record<string, unknown>) => void;
@@ -124,6 +127,7 @@ export const useFlow = create<FlowState>((set, get) => ({
     // Multi-select compose mode tracking
     comboMode: false,
     comboSelectedIds: new Set<string>(),
+    reconnectingEdgeId: null,
 
     nodeCreatedCallbacks: new Set(),
     onNodeCreated: (callback) => {
@@ -195,6 +199,7 @@ export const useFlow = create<FlowState>((set, get) => ({
         set({ edges });
         debouncedSaveEdges(edges);
     },
+    setReconnectingEdgeId: (id) => set({ reconnectingEdgeId: id }),
     updates: (nodeId: string, data: Record<string, unknown>) => {
         const newNodes = get().nodes.map((node) => {
             if (node.id === nodeId) {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -48,6 +48,12 @@
         }
     },
     "Workspace": {
+        "edges": {
+            "deleteConfirmTitle": "Delete connection?",
+            "deleteConfirmDescription": "This connection isn't attached to any node. Delete it?",
+            "delete": "Delete",
+            "cancel": "Cancel"
+        },
         "handles": {
             "text": "Text",
             "image": "Image",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -48,6 +48,12 @@
         }
     },
     "Workspace": {
+        "edges": {
+            "deleteConfirmTitle": "接続を削除しますか？",
+            "deleteConfirmDescription": "この接続はどのノードにも接続されていません。削除しますか？",
+            "delete": "削除",
+            "cancel": "キャンセル"
+        },
         "handles": {
             "text": "テキスト",
             "image": "画像",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -48,6 +48,12 @@
         }
     },
     "Workspace": {
+        "edges": {
+            "deleteConfirmTitle": "删除连线？",
+            "deleteConfirmDescription": "这条连线没有连接到任何节点，是否删除它？",
+            "delete": "删除",
+            "cancel": "取消"
+        },
         "handles": {
             "text": "文本",
             "image": "图片",

--- a/src/lib/workflow/connection-rules.test.ts
+++ b/src/lib/workflow/connection-rules.test.ts
@@ -1,0 +1,166 @@
+import type { Connection, Edge, Node } from "@xyflow/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { registerAbiNode, unregisterAbiNode } from "@/lib/abi/node-registry";
+import { isValidFlowConnection } from "./connection-rules";
+
+/** Non-data RF type; the ABI slot is read from the registry, not node.data. */
+function abiNode(id: string): Node {
+    return { id, type: "abiNode", position: { x: 0, y: 0 }, data: {} };
+}
+
+function conn(
+    source: string,
+    sourceHandle: string,
+    target: string,
+    targetHandle: string,
+): Connection {
+    return { source, sourceHandle, target, targetHandle };
+}
+
+function edge(
+    id: string,
+    source: string,
+    sourceHandle: string,
+    target: string,
+    targetHandle: string,
+): Edge {
+    return { id, source, sourceHandle, target, targetHandle };
+}
+
+const registered: string[] = [];
+function register(nodeId: string, feature: string) {
+    registerAbiNode({ nodeId, feature: feature as never, sourceSpec: {} });
+    registered.push(nodeId);
+}
+afterEach(() => {
+    for (const id of registered.splice(0)) unregisterAbiNode(id);
+});
+
+describe("isValidFlowConnection — modality gate", () => {
+    it("rejects a video output into an image input handle", () => {
+        register("vid", "image-gen-video"); // out:video (VideoRef)
+        register("img", "image-edit"); // in:image (Asset, scalar)
+        const c = conn("vid", "out:video", "img", "in:image");
+        expect(
+            isValidFlowConnection(c, [abiNode("vid"), abiNode("img")], []),
+        ).toBe(false);
+    });
+
+    it("allows an image output into an image input handle", () => {
+        register("src", "image-gen"); // out:image (ImageRef)
+        register("dst", "image-edit"); // in:image
+        const c = conn("src", "out:image", "dst", "in:image");
+        expect(
+            isValidFlowConnection(c, [abiNode("src"), abiNode("dst")], []),
+        ).toBe(true);
+    });
+});
+
+describe("isValidFlowConnection — single-edge (non-array) handles", () => {
+    it("rejects a second edge into an already-occupied scalar handle", () => {
+        register("s1", "image-gen");
+        register("s2", "image-gen");
+        register("t", "image-edit"); // in:image is scalar → single edge
+        const existing = edge("e1", "s1", "out:image", "t", "in:image");
+        const c = conn("s2", "out:image", "t", "in:image");
+        expect(
+            isValidFlowConnection(
+                c,
+                [abiNode("s1"), abiNode("s2"), abiNode("t")],
+                [existing],
+            ),
+        ).toBe(false);
+    });
+
+    it("allows multiple edges into an array handle", () => {
+        register("s1", "image-gen");
+        register("s2", "image-gen");
+        register("t", "image-fusion"); // in:images is array → multi-connect
+        const existing = edge("e1", "s1", "out:image", "t", "in:images");
+        const c = conn("s2", "out:image", "t", "in:images");
+        expect(
+            isValidFlowConnection(
+                c,
+                [abiNode("s1"), abiNode("s2"), abiNode("t")],
+                [existing],
+            ),
+        ).toBe(true);
+    });
+});
+
+describe("isValidFlowConnection — add node out handle is single-edge", () => {
+    const addNode = (id: string): Node => ({
+        id,
+        type: "addTextNode",
+        position: { x: 0, y: 0 },
+        data: {},
+    });
+    const textNode = (id: string): Node => ({
+        id,
+        type: "textNode",
+        position: { x: 0, y: 0 },
+        data: {},
+    });
+
+    it("rejects a second outgoing edge from an add node", () => {
+        const existing = edge("e1", "a", "out:textNode", "t1", "in:textNode");
+        const c = conn("a", "out:textNode", "t2", "in:textNode");
+        const nodes = [addNode("a"), textNode("t1"), textNode("t2")];
+        expect(isValidFlowConnection(c, nodes, [existing])).toBe(false);
+    });
+
+    it("allows reconnecting the add node's own existing edge", () => {
+        const e1 = edge("e1", "a", "out:textNode", "t1", "in:textNode");
+        // Drag e1's target endpoint from t1 to t2; source (add node) unchanged.
+        const c = conn("a", "out:textNode", "t2", "in:textNode");
+        const nodes = [addNode("a"), textNode("t1"), textNode("t2")];
+        expect(isValidFlowConnection(c, nodes, [e1])).toBe(false);
+        expect(isValidFlowConnection(c, nodes, [e1], "e1")).toBe(true);
+    });
+});
+
+describe("isValidFlowConnection — reconnect excludes the dragged edge", () => {
+    it("does not flag the edge being reconnected as a duplicate", () => {
+        register("s1", "image-gen");
+        register("s2", "image-gen");
+        register("t", "image-edit");
+        // Reconnecting e1's source from s1 to s2; target handle unchanged.
+        const e1 = edge("e1", "s1", "out:image", "t", "in:image");
+        const c = conn("s2", "out:image", "t", "in:image");
+        const nodes = [abiNode("s1"), abiNode("s2"), abiNode("t")];
+        // Without ignoreEdgeId, e1 itself collides → rejected.
+        expect(isValidFlowConnection(c, nodes, [e1])).toBe(false);
+        // Excluding the dragged edge → allowed.
+        expect(isValidFlowConnection(c, nodes, [e1], "e1")).toBe(true);
+    });
+});
+
+describe("isValidFlowConnection — modality nodes can't feed each other", () => {
+    const textNode = (id: string): Node => ({
+        id,
+        type: "textNode",
+        position: { x: 0, y: 0 },
+        data: {},
+    });
+    const addTextNode = (id: string): Node => ({
+        id,
+        type: "addTextNode",
+        position: { x: 0, y: 0 },
+        data: {},
+    });
+
+    it("rejects modality text → modality text", () => {
+        const c = conn("a", "out:textNode", "b", "in:textNode");
+        expect(
+            isValidFlowConnection(c, [textNode("a"), textNode("b")], []),
+        ).toBe(false);
+    });
+
+    it("still allows add node → modality text", () => {
+        const c = conn("a", "out:textNode", "b", "in:textNode");
+        expect(
+            isValidFlowConnection(c, [addTextNode("a"), textNode("b")], []),
+        ).toBe(true);
+    });
+});

--- a/src/lib/workflow/connection-rules.ts
+++ b/src/lib/workflow/connection-rules.ts
@@ -1,43 +1,75 @@
 /**
  * React Flow connection validation: logical output types, ABI schema checks,
- * and optional duplicate-edge rules for single-slot text handles.
+ * and duplicate-edge rules for single-value (non-array) target handles.
+ *
+ * Manual edge creation is disabled in the UI (handles set `isConnectableStart`
+ * to false); this validator runs when users *reconnect* an existing edge's
+ * endpoint, so it must enforce the full ABI contract on the new endpoint.
  */
 
 import type { Connection, Edge, Node } from "@xyflow/react";
-import { getAbiNodeRegistration } from "@/lib/abi/node-registry";
 import {
-    resolveSpec,
-    singleEdgeTextScalarTargetHandles,
-} from "@/lib/abi/resolve";
+    parseTargetHandleId,
+    targetHandleId,
+} from "@/lib/abi/handle-introspect";
+import { getAbiNodeRegistration } from "@/lib/abi/node-registry";
+import { resolveSpec } from "@/lib/abi/resolve";
 import type { FieldSourceOverride } from "@/lib/abi/sources";
 import { tryAbiCompatibility } from "@/lib/workflow/connection-validator";
 import { DATA_NODE_TYPES } from "./executable-workflow";
-import { getEffectiveOutputType } from "./flow-connection-shared";
+import {
+    ADD_NODE_OUTPUT_TYPE,
+    getEffectiveOutputType,
+} from "./flow-connection-shared";
 
 export {
     ADD_NODE_OUTPUT_TYPE,
     getEffectiveOutputType,
 } from "./flow-connection-shared";
 
-function singleEdgeHandlesForTarget(targetNodeId: string): ReadonlySet<string> {
+function resolveSpecForNode(targetNodeId: string) {
     const reg = getAbiNodeRegistration(targetNodeId);
-    if (!reg) return new Set();
-    return new Set(
-        singleEdgeTextScalarTargetHandles(
-            reg.feature,
-            reg.sourceSpec as Record<string, FieldSourceOverride>,
-        ),
+    if (!reg) return undefined;
+    return resolveSpec(
+        reg.feature,
+        reg.sourceSpec as Record<string, FieldSourceOverride> | undefined,
     );
+}
+
+/**
+ * Target handles that accept only a single edge: every ABI handle field whose
+ * plugin shape is a scalar (`!array`) and that isn't a batch/collect fan-in
+ * (those legitimately receive multiple upstream values).
+ */
+function singleEdgeHandlesForTarget(targetNodeId: string): ReadonlySet<string> {
+    const spec = resolveSpecForNode(targetNodeId);
+    if (!spec) return new Set();
+    const out = new Set<string>();
+    for (const [field, f] of Object.entries(spec.fields)) {
+        if (f.kind !== "handle") continue;
+        if (f.array || f.batch || f.collect) continue;
+        out.add(targetHandleId(field));
+    }
+    return out;
+}
+
+/** Modality (RF nodeType) that a specific ABI target handle expects, if resolvable. */
+function expectedTargetHandleType(
+    targetNodeId: string,
+    targetHandle: string | null | undefined,
+): string | undefined {
+    const field = parseTargetHandleId(targetHandle);
+    if (!field) return undefined;
+    const spec = resolveSpecForNode(targetNodeId);
+    if (!spec) return undefined;
+    const f = spec.fields[field];
+    return f?.kind === "handle" ? f.nodeType : undefined;
 }
 
 /** Set of upstream node types this target accepts on any handle. */
 function collectUpstreamTypesForTarget(targetNodeId: string): Set<string> {
-    const reg = getAbiNodeRegistration(targetNodeId);
-    if (!reg) return new Set();
-    const spec = resolveSpec(
-        reg.feature,
-        reg.sourceSpec as Record<string, FieldSourceOverride> | undefined,
-    );
+    const spec = resolveSpecForNode(targetNodeId);
+    if (!spec) return new Set();
     const out = new Set<string>();
     for (const f of Object.values(spec.fields)) {
         if (f.kind === "handle") out.add(f.nodeType);
@@ -47,11 +79,14 @@ function collectUpstreamTypesForTarget(targetNodeId: string): Set<string> {
 
 /**
  * Check whether an incoming edge already occupies the same targetHandle for
- * handles that only allow a single connection (e.g. text-scalar `in:tags`).
+ * handles that only allow a single connection. `ignoreEdgeId` excludes the edge
+ * currently being reconnected, so dragging an edge's source endpoint (target
+ * handle unchanged) isn't rejected as a self-collision.
  */
 export function hasDuplicateTargetHandle(
     edges: Edge[],
     connection: Connection,
+    ignoreEdgeId?: string,
 ): boolean {
     const targetId = connection.target;
     if (!targetId) return false;
@@ -59,27 +94,63 @@ export function hasDuplicateTargetHandle(
     if (!th) return false;
     const singleEdge = singleEdgeHandlesForTarget(targetId);
     if (!singleEdge.has(th)) return false;
-    return edges.some((e) => e.target === targetId && e.targetHandle === th);
+    return edges.some(
+        (e) =>
+            e.id !== ignoreEdgeId &&
+            e.target === targetId &&
+            e.targetHandle === th,
+    );
+}
+
+/**
+ * Add nodes own a single out handle and represent one created asset, so their
+ * output fans out to at most one downstream edge. `ignoreEdgeId` excludes the
+ * edge being reconnected (so dragging its target endpoint isn't a self-collision).
+ */
+export function hasDuplicateAddSourceEdge(
+    edges: Edge[],
+    connection: Connection,
+    sourceType: string | undefined,
+    ignoreEdgeId?: string,
+): boolean {
+    if (!sourceType || !(sourceType in ADD_NODE_OUTPUT_TYPE)) return false;
+    const sourceId = connection.source;
+    if (!sourceId) return false;
+    return edges.some((e) => e.id !== ignoreEdgeId && e.source === sourceId);
 }
 
 /**
  * Validate whether a connection is allowed. Unknown configurations are allowed
  * by default so unregistered or non-ABI nodes remain connectable.
+ *
+ * `ignoreEdgeId` is the edge being reconnected (excluded from duplicate checks).
  */
 export function isValidFlowConnection(
     connection: Connection,
     nodes: Node[],
     edges: Edge[],
+    ignoreEdgeId?: string,
 ): boolean {
     const source = connection.source;
     const target = connection.target;
     if (!source || !target || source === target) return false;
 
-    if (hasDuplicateTargetHandle(edges, connection)) return false;
+    if (hasDuplicateTargetHandle(edges, connection, ignoreEdgeId)) return false;
 
     const sourceNode = nodes.find((n) => n.id === source);
     const targetNode = nodes.find((n) => n.id === target);
     if (!sourceNode || !targetNode) return false;
+
+    if (
+        hasDuplicateAddSourceEdge(
+            edges,
+            connection,
+            sourceNode.type,
+            ignoreEdgeId,
+        )
+    ) {
+        return false;
+    }
 
     const outType = getEffectiveOutputType(
         sourceNode.id,
@@ -90,12 +161,25 @@ export function isValidFlowConnection(
     /** Must stay before ABI refinement (stricter behavioural guardrails). */
     if (!outType) return true;
 
+    const sourceType = sourceNode.type ?? "";
     const targetType = targetNode.type ?? "";
 
-    // Data node as target: only accepts upstream whose "logical output type" matches its own type
+    // Data node as target: only accepts upstream whose "logical output type"
+    // matches its own type. Modality nodes are asset carriers, not transforms,
+    // so they can't feed each other — reject modality → modality.
     if (targetType in DATA_NODE_TYPES) {
+        if (sourceType in DATA_NODE_TYPES) return false;
         return outType === targetType;
     }
+
+    // Modality gate: a resolvable ABI target handle dictates the exact upstream
+    // modality. XRef/Asset schemas are isomorphic across media types, so the
+    // schema-level check below cannot distinguish image/video/audio — enforce it here.
+    const expected = expectedTargetHandleType(
+        targetNode.id,
+        connection.targetHandle,
+    );
+    if (expected && expected !== outType) return false;
 
     const abiDecision = tryAbiCompatibility(connection, nodes);
     if (abiDecision !== undefined) return abiDecision;


### PR DESCRIPTION
## Summary

Reworks how canvas connections are made and ships **v0.1.7**.

- **Disable manual edge creation**: handles set `isConnectableStart={false}`, so users can't draw new edges by hand. Connections come from the operation panel (`expands`/`compose`).
- **Validated reconnect**: users can drag an existing edge's endpoint to another node. The new endpoint is validated against the ABI contract — modality must match the target handle, single-value (non-array) input handles and `add`-node outputs accept one edge, and modality nodes can't feed each other.
- **Delete-on-drop**: dropping a dragged endpoint on empty canvas prompts to delete the edge. The reconnect preview line matches the edge style so it stays visible and tracks the cursor.
- **Fix**: aspect-ratio picker labels no longer overflow their button in English (long labels wrap).
- Bump `0.1.6 → 0.1.7` (root + desktop) and update CHANGELOG.

## Verification

`pnpm lint:check`, `pnpm typecheck`, `pnpm test` (34 passed), and `pnpm build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)