### PR TITLE
fix(execution): clear feedback when a node's plugin is not installed

### DIFF
--- a/src/app/api/task/create/route.ts
+++ b/src/app/api/task/create/route.ts
@@ -4,6 +4,7 @@ import { getDb } from "@/db";
 import { tasks } from "@/db/schema";
 import { ABI_NODES, type NodeSlot } from "@/generated/abi";
 import { logger } from "@/lib/logger";
+import { getPluginConfig } from "@/lib/plugins/plugins-registry.server";
 import { getAbiNodeBySlot } from "@/lib/schema/tongflow-abi";
 
 function isAbiNodeSlot(s: string): s is NodeSlot {
@@ -79,6 +80,20 @@ export async function POST(request: NextRequest) {
                     error: "Node slot is inconsistent with the generated ABI; contact an administrator",
                 },
                 { status: 500 },
+            );
+        }
+
+        // The scanned registry only contains installed plugins. Reject up front
+        // when the plugin isn't installed so the user gets a clear, actionable
+        // message instead of a generic "Task execution failed" at runtime.
+        if (!getPluginConfig(trimmedPluginId)) {
+            return NextResponse.json(
+                {
+                    error: `Plugin not installed: ${trimmedPluginId}. Install it from the plugin manager before running this node.`,
+                    code: "PLUGIN_NOT_INSTALLED",
+                    pluginId: trimmedPluginId,
+                },
+                { status: 400 },
             );
         }
 

--- a/src/app/api/workflow/execute/route.ts
+++ b/src/app/api/workflow/execute/route.ts
@@ -10,6 +10,7 @@ import { getDb } from "@/db";
 import { tasks, workflows } from "@/db/schema";
 import { logger } from "@/lib/logger";
 import { getFeatureByName } from "@/lib/plugins/feature-registry.server";
+import { getPluginConfig } from "@/lib/plugins/plugins-registry.server";
 import type { ExecutableWorkflow } from "@/lib/workflow/executable-workflow";
 
 const DEFAULT_CONCURRENT_TASKS = 3;
@@ -109,6 +110,40 @@ export async function POST(request: NextRequest) {
             workflow.executableNodes?.map((n) => `${n.id}(${n.feature})`),
         );
         logger.debug(`${"=".repeat(60)}\n`);
+
+        // Pre-flight: the scanned registry only contains installed plugins, so a
+        // node whose plugin isn't installed would fail mid-run with a generic
+        // error. Reject before creating the task with a clear, actionable list.
+        const missing: { nodeId: string; feature: string; pluginId: string }[] =
+            [];
+        for (const node of workflow.executableNodes ?? []) {
+            const pid = (node.pluginId ?? "").trim();
+            if (!pid || !getPluginConfig(pid)) {
+                missing.push({
+                    nodeId: node.id,
+                    feature: node.feature,
+                    pluginId: pid,
+                });
+            }
+        }
+        if (missing.length > 0) {
+            const list = missing
+                .map(
+                    (m) =>
+                        `${m.feature}${m.pluginId ? ` (${m.pluginId})` : ""}`,
+                )
+                .join(", ");
+            const message = `Cannot run workflow: ${missing.length} node(s) have no installed plugin: ${list}. Install them from the plugin manager.`;
+            return NextResponse.json(
+                {
+                    error: message,
+                    message,
+                    code: "PLUGIN_NOT_INSTALLED",
+                    missing,
+                },
+                { status: 400 },
+            );
+        }
 
         const featureMap: Record<string, { type: string; function: string }> =
             {};

--- a/src/hooks/use-abi-execution.ts
+++ b/src/hooks/use-abi-execution.ts
@@ -13,6 +13,7 @@ import { useNodeId, useReactFlow, useStore, useStoreApi } from "@xyflow/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { NodeSlot } from "@/generated/abi";
 import useFlow from "@/hooks/use-flow";
+import { usePluginsRegistry } from "@/hooks/use-plugins-registry";
 import {
     type Task,
     useBatchTaskManager,
@@ -287,6 +288,9 @@ export function useAbiExecution<F extends NodeSlot>(
 
     const { pluginOptions, resolveActivePluginId } =
         useNodePluginResolver(feature);
+    // The scanned registry only contains installed plugins; `isLoaded` lets the
+    // run() guard distinguish "registry not fetched yet" from "nothing installed".
+    const { isLoaded: pluginsRegistryLoaded } = usePluginsRegistry();
 
     const handleTaskUpdate = useCallback(
         async (task: Task) => {
@@ -397,6 +401,14 @@ export function useAbiExecution<F extends NodeSlot>(
             setMissingPluginOpen(true);
             return;
         }
+        // The registry only contains installed plugins, so an id absent from the
+        // installed set is not installed (e.g. a saved workflow referencing a
+        // plugin that was never installed here). Only enforce once the registry
+        // has loaded — before that the server-side check is the backstop.
+        if (pluginsRegistryLoaded && !pluginOptions.includes(pluginId)) {
+            setMissingPluginOpen(true);
+            return;
+        }
 
         updateNodeData(nodeId, {
             feature,
@@ -422,6 +434,8 @@ export function useAbiExecution<F extends NodeSlot>(
         updateNodeData,
         createBatchTasks,
         resolveActivePluginId,
+        pluginOptions,
+        pluginsRegistryLoaded,
         transformPrompts,
     ]);
 

--- a/src/hooks/use-workflow-execution.ts
+++ b/src/hooks/use-workflow-execution.ts
@@ -176,9 +176,11 @@ export function useWorkflowExecution(
                         .catch(() => ({}))) as {
                         code?: string;
                         error?: string;
+                        message?: string;
                     };
                     throw new Error(
-                        errorData.error ||
+                        errorData.message ||
+                            errorData.error ||
                             `API request failed: ${response.status}`,
                     );
                 }
@@ -363,6 +365,15 @@ export function useWorkflowExecution(
             } catch (error) {
                 logger.error("[workflow-exec] Execution failed:", error);
                 setWorkflowExecutionStatus("failed");
+                // The pre-flight 400 (e.g. uninstalled plugins) and the
+                // concurrent-limit 429 reach here; surface them so the failure
+                // isn't silently swallowed.
+                showErrorToast({
+                    message:
+                        error instanceof Error
+                            ? error.message
+                            : tToast("taskFailed"),
+                });
             }
         },
         [
@@ -372,6 +383,7 @@ export function useWorkflowExecution(
             closeEventSource,
             setNodeExecutionStatus,
             setWorkflowExecutionStatus,
+            tToast,
         ],
     );
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -263,7 +263,7 @@
                 "pluginRegistryLoadError": "Could not load the plugin registry: {message}",
                 "pluginSelectPlaceholder": "Select a repo…",
                 "missingImplTitle": "Missing Implementation",
-                "missingImplDescription": "Please select a plugin implementation in this node before running."
+                "missingImplDescription": "No plugin is installed for this node (or none is selected). Install one from the plugin manager, or pick an installed plugin, before running."
             },
             "common": {
                 "enterInstructions": "Enter instructions...",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -263,7 +263,7 @@
                 "pluginRegistryLoadError": "プラグイン登録情報を読み込めませんでした：{message}",
                 "pluginSelectPlaceholder": "リポジトリを選択…",
                 "missingImplTitle": "実装が未選択",
-                "missingImplDescription": "実行前に、このノードのプラグイン実装を選択してください。"
+                "missingImplDescription": "このノードに利用可能なプラグインがインストールされていません（または未選択です）。実行前に、プラグインマネージャーからインストールするか、インストール済みのプラグインを選択してください。"
             },
             "common": {
                 "enterInstructions": "指示を入力してください...",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -263,7 +263,7 @@
                 "pluginRegistryLoadError": "无法加载插件注册表：{message}",
                 "pluginSelectPlaceholder": "选择一个仓库…",
                 "missingImplTitle": "未配置实现",
-                "missingImplDescription": "请先在该节点中选择一个插件实现，然后再运行。"
+                "missingImplDescription": "该节点尚未安装可用插件（或未选择）。请先在插件管理中安装一个插件，或选择一个已安装的插件，然后再运行。"
             },
             "common": {
                 "enterInstructions": "请输入指令...",


### PR DESCRIPTION
## 背景

用户反馈：当节点对应的插件**未安装**时，执行按钮仍可点击，点击后任务失败，但失败提示完全没有告诉用户"插件未安装"。

根因：扫描出的插件注册表只包含**已安装**插件，但单节点与工作流两条执行路径在运行前都没有检查安装状态。引用未安装插件的节点会照常建任务，运行到一半才以泛化的 "Task execution failed" 失败；工作流路径甚至直接把启动失败静默吞掉（catch 只 log）。

## 改动

- **单节点（客户端）**：`run()` 在解析出 `pluginId` 后，若注册表已加载且该 id 不在已安装集合里，则复用现有 missing-plugin 弹窗并阻止执行（用 `isLoaded` 守卫避免加载竞态误报）。
- **单节点（服务端）**：`/api/task/create` 在建任务前用 `getPluginConfig` 检查，未安装返回带 `code: PLUGIN_NOT_INSTALLED` 的清晰 400（经 `apiClient` 自动弹 Toast）。
- **工作流（服务端）**：`/api/workflow/execute` 建任务前预检所有节点插件，缺失则返回 400 并列出缺失清单。
- **工作流（客户端）**：catch 里补 Toast，让执行启动失败可见（顺带修复一直被静默的并发上限 429）。
- **i18n**：扩展 `missingImplDescription`（en/zh/ja）以涵盖"未安装"场景。

## 验证

- `pnpm lint:check`、`pnpm typecheck`、`pnpm build` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)