### PR TITLE
chore(plugins): register tongflow-modal-boogu (Boogu-Image-0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Run the preloaded example node by node, or switch to Execute Mode and hit the ru
 - [tongflow-modal-z-image](https://github.com/tong-io/tongflow-modal-z-image) — Z-Image text-to-image
 - [tongflow-modal-ernie-image](https://github.com/tong-io/tongflow-modal-ernie-image) — ERNIE Image text-to-image (alternative)
 - [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — FLUX.2 Klein 9B multi-reference fusion / image editing
+- [tongflow-modal-boogu](https://github.com/tong-io/tongflow-modal-boogu) — Boogu-Image-0.1 (fp8) text-to-image (dense bilingual text) & single-reference image editing
 - [tongflow-modal-ltx](https://github.com/tong-io/tongflow-modal-ltx) — LTX-2.3 text / image-to-video
 - [tongflow-modal-fastwan](https://github.com/tong-io/tongflow-modal-fastwan) — FastWan-QAD-FP8 fast text-to-video (3-step distilled Wan2.1-1.3B)
 - [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk audio-driven lip-sync (audio + image / video → talking-head video)

--- a/config/official-plugins.json
+++ b/config/official-plugins.json
@@ -10,6 +10,7 @@
         "tongflow-modal-z-image",
         "tongflow-modal-ernie-image",
         "tongflow-modal-flux2-klein9b",
+        "tongflow-modal-boogu",
         "tongflow-modal-ltx",
         "tongflow-modal-fastwan",
         "tongflow-modal-infinitetalk",

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -184,6 +184,7 @@ TongFlowで生成AIを活用し、創造力を解き放とう！
 - [tongflow-modal-z-image](https://github.com/tong-io/tongflow-modal-z-image) — Z-Image テキストから画像生成
 - [tongflow-modal-ernie-image](https://github.com/tong-io/tongflow-modal-ernie-image) — ERNIE Image テキストから画像生成（代替）
 - [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — FLUX.2 Klein 9B マルチ参照融合と画像編集
+- [tongflow-modal-boogu](https://github.com/tong-io/tongflow-modal-boogu) — Boogu-Image-0.1（fp8）テキストから画像生成（高密度な多言語テキスト）と単一参照画像編集
 - [tongflow-modal-ltx](https://github.com/tong-io/tongflow-modal-ltx) — LTX-2.3 テキスト / 画像から動画生成
 - [tongflow-modal-fastwan](https://github.com/tong-io/tongflow-modal-fastwan) — FastWan-QAD-FP8 高速テキストから動画生成（3 ステップ蒸留 Wan2.1-1.3B）
 - [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk 音声駆動リップシンク（音声 + 画像 / 動画 → デジタルヒューマン動画）

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -184,6 +184,7 @@ app 默认不预装任何插件。打开**插件管理器**（右上角的方块
 - [tongflow-modal-z-image](https://github.com/tong-io/tongflow-modal-z-image) — Z-Image 文本生图
 - [tongflow-modal-ernie-image](https://github.com/tong-io/tongflow-modal-ernie-image) — ERNIE Image 文本生图（备选）
 - [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — FLUX.2 Klein 9B 多参考融合与图像编辑
+- [tongflow-modal-boogu](https://github.com/tong-io/tongflow-modal-boogu) — Boogu-Image-0.1（fp8）文本生图（密集中英文字）与单图编辑
 - [tongflow-modal-ltx](https://github.com/tong-io/tongflow-modal-ltx) — LTX-2.3 文本 / 图像生视频
 - [tongflow-modal-fastwan](https://github.com/tong-io/tongflow-modal-fastwan) — FastWan-QAD-FP8 极速文生视频（3 步蒸馏 Wan2.1-1.3B）
 - [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk 音频驱动口型同步（音频 + 图片 / 视频 → 数字人视频）


### PR DESCRIPTION
Registers the new **tongflow-modal-boogu** plugin ([tong-io/tongflow-modal-boogu](https://github.com/tong-io/tongflow-modal-boogu)) and documents it in all three READMEs.

## What

- `config/official-plugins.json`: add `tongflow-modal-boogu` (after `flux2-klein9b`).
- `README.md` / `docs/README_ZH.md` / `docs/README_JA.md`: add one entry to the **GPU/CPU plugins** list.

The plugin exposes two ABI slots via two independent `@deploy` classes:

- `image-gen` (T2I) → **Boogu-Image-0.1-Base-fp8** — dense bilingual (Chinese/English) text rendering.
- `image-edit` (TI2I) → **Boogu-Image-0.1-Edit-fp8** — single-reference instruction editing.

Defaults to the fp8 checkpoints on **A100-40GB** (bf16 + A100-80GB documented as fallback).

## Capability matrix unchanged

Both `image-gen` and `image-edit` were already ✅ (z-image / ernie-image / flux2-klein9b), so Boogu is not the first official plugin for either node — no ⬜→✅ flips.

## ⚠️ Do not merge yet

The plugin has **not been deploy-verified** (`modal deploy`) — the fp8 load path and flash-attn build are still unvalidated. Hold merge until a real run confirms it generates images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)