### PR TITLE
chore(release): v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-06-30
+
+### Added
+
+- **Korean (`ko`) locale** — full UI translation, joining the existing
+  English / Chinese / Japanese languages.
+- Registered the **Boogu-Image** official plugin (`tongflow-modal-boogu`).
+
+### Fixed
+
+- Execution feedback is now cleared when a node's plugin is not installed,
+  instead of leaving a stale error on the node.
+
 ## [0.1.8] - 2026-06-28
 
 ### Added

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow-desktop",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "description": "TongFlow desktop app (Electron shell around the Next.js standalone server + portable Python).",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "description": "A multi-modal AIGC studio for building generative AI workflows",
     "author": "tong-io",
     "keywords": [


### PR DESCRIPTION
Release v0.1.9.

Bumps app version (`package.json` + `desktop/package.json`) to `0.1.9` and updates `CHANGELOG.md`.

### Included since 0.1.8
- feat(i18n): Korean (`ko`) locale (#47)
- chore(plugins): register `tongflow-modal-boogu` / Boogu-Image (#46)
- fix(execution): clear feedback when a node's plugin is not installed (#45)

SDK unchanged (no ABI/types changes) — desktop app release only. Tag `v0.1.9` will be pushed after merge to trigger the desktop build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)