### PR TITLE
feat(plugins): per-node model picker for router-style plugins + tongflow-api-apimart

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Run the preloaded example node by node, or switch to Execute Mode and hit the ru
 - [tongflow-api-gemini](https://github.com/tong-io/tongflow-api-gemini) — Google Gemini for `gen_text` and image generation / editing / fusion (Nano Banana)
 - [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — OpenAI for `gen_text` and image generation / editing / fusion (`gpt-image-2`)
 - [tongflow-api-bytedance](https://github.com/tong-io/tongflow-api-bytedance) — Volcengine Ark (Doubao Seedance 2.0) for text/image/audio → video
+- [tongflow-api-apimart](https://github.com/tong-io/tongflow-api-apimart) — APIMart gateway with a per-node **model picker**: image gen/edit (Z-Image, Seedream, Nano Banana, GPT-Image), text/image → video (Kling, VEO3, Sora2, Seedance), `gen_text` (GPT-5, Claude, Gemini), Whisper transcription and TTS
 
 ### GPU/CPU plugins
 

--- a/config/official-plugins.json
+++ b/config/official-plugins.json
@@ -5,6 +5,7 @@
         "tongflow-api-gemini",
         "tongflow-api-openai",
         "tongflow-api-bytedance",
+        "tongflow-api-apimart",
         "tongflow-modal-ffmpeg",
         "tongflow-modal-pyscenedetect",
         "tongflow-modal-z-image",

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -176,6 +176,7 @@ TongFlowで生成AIを活用し、創造力を解き放とう！
 - [tongflow-api-gemini](https://github.com/tong-io/tongflow-api-gemini) — Google Gemini ベースの `gen_text` および画像生成 / 編集 / 合成（Nano Banana）
 - [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — OpenAI ベースの `gen_text` および画像生成 / 編集 / 融合（`gpt-image-2`）
 - [tongflow-api-bytedance](https://github.com/tong-io/tongflow-api-bytedance) — Volcengine Ark（Doubao Seedance 2.0）ベースのテキスト / 画像 / 音声 → 動画
+- [tongflow-api-apimart](https://github.com/tong-io/tongflow-api-apimart) — APIMart ゲートウェイ。ノード上で**モデルを選択**可能：画像生成 / 編集（Z-Image、Seedream、Nano Banana、GPT-Image）、テキスト / 画像 → 動画（Kling、VEO3、Sora2、Seedance）、`gen_text`（GPT-5、Claude、Gemini）、Whisper 文字起こしと TTS
 
 ### GPU/CPU プラグイン
 

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -176,6 +176,7 @@ app 默认不预装任何插件。打开**插件管理器**（右上角的方块
 - [tongflow-api-gemini](https://github.com/tong-io/tongflow-api-gemini) — 基于 Google Gemini 的 `gen_text` 及图像生成 / 编辑 / 融合（Nano Banana）
 - [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — 基于 OpenAI 的 `gen_text` 及图像生成 / 编辑 / 融合（`gpt-image-2`）
 - [tongflow-api-bytedance](https://github.com/tong-io/tongflow-api-bytedance) — 基于火山方舟（豆包 Seedance 2.0）的 文 / 图 / 音 → 视频
+- [tongflow-api-apimart](https://github.com/tong-io/tongflow-api-apimart) — APIMart 聚合网关，支持节点上**按模型选择**：图像生成 / 编辑（Z-Image、Seedream、Nano Banana、GPT-Image）、文 / 图 → 视频（可灵、VEO3、Sora2、Seedance）、`gen_text`（GPT-5、Claude、Gemini）、Whisper 转录与 TTS
 
 ### GPU/CPU 插件
 

--- a/drizzle/0001_smart_morgan_stark.sql
+++ b/drizzle/0001_smart_morgan_stark.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tasks` ADD `model` text;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,357 @@
+{
+    "version": "6",
+    "dialect": "sqlite",
+    "id": "b59d33bf-9f17-4102-a83a-d0ffa44a81b3",
+    "prevId": "0943e841-c635-4c6b-85c6-fa05a9cf3533",
+    "tables": {
+        "materials": {
+            "name": "materials",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "integer",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "autoincrement": true
+                },
+                "task_id": {
+                    "name": "task_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "workflow_id": {
+                    "name": "workflow_id",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "type": {
+                    "name": "type",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "content": {
+                    "name": "content",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "thumbnail": {
+                    "name": "thumbnail",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "is_favorite": {
+                    "name": "is_favorite",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": false
+                },
+                "is_cover": {
+                    "name": "is_cover",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+                },
+                "deleted": {
+                    "name": "deleted",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": false
+                }
+            },
+            "indexes": {
+                "materials_deleted_idx": {
+                    "name": "materials_deleted_idx",
+                    "columns": ["deleted"],
+                    "isUnique": false
+                },
+                "materials_type_deleted_idx": {
+                    "name": "materials_type_deleted_idx",
+                    "columns": ["type", "deleted"],
+                    "isUnique": false
+                },
+                "materials_task_id_idx": {
+                    "name": "materials_task_id_idx",
+                    "columns": ["task_id"],
+                    "isUnique": false
+                },
+                "materials_workflow_id_idx": {
+                    "name": "materials_workflow_id_idx",
+                    "columns": ["workflow_id"],
+                    "isUnique": false
+                }
+            },
+            "foreignKeys": {
+                "materials_workflow_id_workflows_id_fk": {
+                    "name": "materials_workflow_id_workflows_id_fk",
+                    "tableFrom": "materials",
+                    "tableTo": "workflows",
+                    "columnsFrom": ["workflow_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "checkConstraints": {}
+        },
+        "tasks": {
+            "name": "tasks",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "workflow_id": {
+                    "name": "workflow_id",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "node_id": {
+                    "name": "node_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "feature": {
+                    "name": "feature",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "plugin_id": {
+                    "name": "plugin_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": "''"
+                },
+                "model": {
+                    "name": "model",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "prompt": {
+                    "name": "prompt",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "status": {
+                    "name": "status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": "'pending'"
+                },
+                "progress": {
+                    "name": "progress",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": 0
+                },
+                "result": {
+                    "name": "result",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "error": {
+                    "name": "error",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+                }
+            },
+            "indexes": {
+                "tasks_status_idx": {
+                    "name": "tasks_status_idx",
+                    "columns": ["status"],
+                    "isUnique": false
+                },
+                "tasks_created_idx": {
+                    "name": "tasks_created_idx",
+                    "columns": ["created_at"],
+                    "isUnique": false
+                }
+            },
+            "foreignKeys": {
+                "tasks_workflow_id_workflows_id_fk": {
+                    "name": "tasks_workflow_id_workflows_id_fk",
+                    "tableFrom": "tasks",
+                    "tableTo": "workflows",
+                    "columnsFrom": ["workflow_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "checkConstraints": {}
+        },
+        "workflows": {
+            "name": "workflows",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "integer",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "autoincrement": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "flow": {
+                    "name": "flow",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false
+                },
+                "executable": {
+                    "name": "executable",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "cover": {
+                    "name": "cover",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "autoincrement": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+                },
+                "deleted": {
+                    "name": "deleted",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "autoincrement": false,
+                    "default": false
+                }
+            },
+            "indexes": {
+                "workflows_deleted_idx": {
+                    "name": "workflows_deleted_idx",
+                    "columns": ["deleted"],
+                    "isUnique": false
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "checkConstraints": {}
+        }
+    },
+    "views": {},
+    "enums": {},
+    "_meta": {
+        "schemas": {},
+        "tables": {},
+        "columns": {}
+    },
+    "internal": {
+        "indexes": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
             "when": 1778746777793,
             "tag": "0000_burly_romulus",
             "breakpoints": true
+        },
+        {
+            "idx": 1,
+            "version": "6",
+            "when": 1782985139446,
+            "tag": "0001_smart_morgan_stark",
+            "breakpoints": true
         }
     ]
 }

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tongflow"
-version = "0.1.2"
+version = "0.2.0"
 description = "Python SDK for TongFlow — author plugins and run multi-modal GenAI workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/tests/test_scan.py
+++ b/sdk/tests/test_scan.py
@@ -1,0 +1,102 @@
+"""Scanner tests for the optional TONGFLOW_SLOT_MODELS declaration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tongflow.scan import scan
+
+_ABI = {
+    "version": 1,
+    "$defs": {"Asset": {"type": "object"}, "ImageRef": {"type": "object"}},
+    "nodes": [
+        {
+            "nodeSlot": "image-gen",
+            "inputs": {"type": "object", "properties": {"text": {"type": "string"}}},
+            "outputs": {
+                "type": "object",
+                "properties": {"image": {"$ref": "#/$defs/ImageRef"}},
+            },
+        },
+        {
+            "nodeSlot": "gen-text",
+            "inputs": {"type": "object", "properties": {"text": {"type": "string"}}},
+            "outputs": {
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+            },
+        },
+    ],
+}
+
+_HANDLERS = '''
+from tongflow.slots import node_slot, NodeSlots
+from tongflow.models.image_gen import ImageGenInput, ImageGenOutput
+
+@node_slot(NodeSlots.IMAGE_GEN)
+def image_gen(input: ImageGenInput) -> ImageGenOutput:
+    ...
+'''
+
+
+def _write_abi(tmp_path: Path) -> Path:
+    p = tmp_path / "abi.json"
+    p.write_text(json.dumps(_ABI), encoding="utf-8")
+    return p
+
+
+def _write_plugin(tmp_path: Path, entry_src: str) -> Path:
+    root = tmp_path / "plugins"
+    pdir = root / "tongflow-api-fake"
+    pdir.mkdir(parents=True)
+    (pdir / "entry.py").write_text(entry_src, encoding="utf-8")
+    return root
+
+
+def _entry(root: Path, abi: Path) -> dict:
+    payload = scan(root, abi)
+    return payload  # type: ignore[return-value]
+
+
+def test_scan_without_models_is_unchanged(tmp_path):
+    payload = _entry(_write_plugin(tmp_path, _HANDLERS), _write_abi(tmp_path))
+    assert payload["errors"] == []
+    entry = payload["plugins"]["tongflow-api-fake"]["methodsByNodeSlot"]["image-gen"]
+    assert entry == {"methodName": "image_gen"}
+
+
+def test_scan_with_models_attaches_list(tmp_path):
+    src = (
+        'TONGFLOW_SLOT_MODELS = {"image-gen": ["z-image-turbo", "seedream-4.5"]}\n'
+        + _HANDLERS
+    )
+    payload = _entry(_write_plugin(tmp_path, src), _write_abi(tmp_path))
+    assert payload["errors"] == []
+    entry = payload["plugins"]["tongflow-api-fake"]["methodsByNodeSlot"]["image-gen"]
+    assert entry["models"] == ["z-image-turbo", "seedream-4.5"]
+
+
+def test_scan_models_slot_without_handler_errors(tmp_path):
+    src = 'TONGFLOW_SLOT_MODELS = {"gen-text": ["gpt-5"]}\n' + _HANDLERS
+    payload = _entry(_write_plugin(tmp_path, src), _write_abi(tmp_path))
+    assert any("no @node_slot handler" in e["message"] for e in payload["errors"])
+    entry = payload["plugins"]["tongflow-api-fake"]["methodsByNodeSlot"]["image-gen"]
+    assert "models" not in entry
+
+
+def test_scan_models_non_literal_errors(tmp_path):
+    src = (
+        '_M = ["a"]\n'
+        "TONGFLOW_SLOT_MODELS = {\"image-gen\": _M}\n" + _HANDLERS
+    )
+    payload = _entry(_write_plugin(tmp_path, src), _write_abi(tmp_path))
+    assert any("list literal" in e["message"] for e in payload["errors"])
+
+
+def test_scan_models_duplicate_model_errors(tmp_path):
+    src = (
+        'TONGFLOW_SLOT_MODELS = {"image-gen": ["a", "a"]}\n' + _HANDLERS
+    )
+    payload = _entry(_write_plugin(tmp_path, src), _write_abi(tmp_path))
+    assert any("duplicate model" in e["message"] for e in payload["errors"])

--- a/sdk/tongflow/__init__.py
+++ b/sdk/tongflow/__init__.py
@@ -11,6 +11,6 @@ from .deploy_marker import deploy
 from .engine import run_workflow
 from .progress import progress
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"
 
 __all__ = ["deploy", "progress", "run_workflow"]

--- a/sdk/tongflow/_ast_utils.py
+++ b/sdk/tongflow/_ast_utils.py
@@ -99,6 +99,101 @@ def decorator_name(expr: ast.expr) -> str | None:
     return None
 
 
+SLOT_MODELS_CONST = "TONGFLOW_SLOT_MODELS"
+
+
+def extract_slot_models(
+    tree: ast.Module,
+) -> tuple[dict[str, list[str]], list[tuple[int, str]]]:
+    """
+    Parse the optional module-level ``TONGFLOW_SLOT_MODELS`` constant:
+    a pure dict literal mapping an ABI node slot to the list of model ids the
+    plugin exposes for it, e.g. ``{"image-gen": ["z-image-turbo", "seedream-4.5"]}``.
+
+    Only literal ``dict[str, list[str]]`` shapes are accepted — the scanner never
+    imports plugin code, so computed values cannot be resolved. Returns
+    ``(models_by_slot, problems)`` where each problem is ``(lineno, reason)``;
+    a malformed constant is reported instead of silently ignored.
+    """
+
+    models_by_slot: dict[str, list[str]] = {}
+    problems: list[tuple[int, str]] = []
+
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+        else:
+            continue
+        if value is None:
+            continue
+        if not any(
+            isinstance(t, ast.Name) and t.id == SLOT_MODELS_CONST for t in targets
+        ):
+            continue
+
+        if not isinstance(value, ast.Dict):
+            problems.append(
+                (node.lineno, f"{SLOT_MODELS_CONST} must be a dict literal")
+            )
+            continue
+        for key, val in zip(value.keys, value.values):
+            if not (isinstance(key, ast.Constant) and isinstance(key.value, str) and key.value):
+                problems.append(
+                    (
+                        getattr(key, "lineno", node.lineno),
+                        f"{SLOT_MODELS_CONST} keys must be non-empty string literals",
+                    )
+                )
+                continue
+            slot = key.value
+            if slot in models_by_slot:
+                problems.append(
+                    (key.lineno, f"{SLOT_MODELS_CONST} has duplicate slot {slot!r}")
+                )
+                continue
+            if not isinstance(val, ast.List):
+                problems.append(
+                    (
+                        getattr(val, "lineno", node.lineno),
+                        f"{SLOT_MODELS_CONST}[{slot!r}] must be a list literal of strings",
+                    )
+                )
+                continue
+            models: list[str] = []
+            ok = True
+            for item in val.elts:
+                if not (
+                    isinstance(item, ast.Constant)
+                    and isinstance(item.value, str)
+                    and item.value.strip()
+                ):
+                    problems.append(
+                        (
+                            getattr(item, "lineno", val.lineno),
+                            f"{SLOT_MODELS_CONST}[{slot!r}] items must be non-empty string literals",
+                        )
+                    )
+                    ok = False
+                    break
+                if item.value in models:
+                    problems.append(
+                        (item.lineno, f"{SLOT_MODELS_CONST}[{slot!r}] has duplicate model {item.value!r}")
+                    )
+                    ok = False
+                    break
+                models.append(item.value)
+            if not ok:
+                continue
+            if models:
+                models_by_slot[slot] = models
+
+    return models_by_slot, problems
+
+
 def extract_node_slot_decorators(
     fn: ast.FunctionDef | ast.AsyncFunctionDef,
 ) -> tuple[str, ...]:

--- a/sdk/tongflow/engine/invoker.py
+++ b/sdk/tongflow/engine/invoker.py
@@ -70,6 +70,7 @@ def invoke_plugin(
     prompt: dict[str, Any],
     sdk_root: Path,
     task_id: str = "tongflow-engine",
+    model: Optional[str] = None,
     env_extra: Optional[dict[str, str]] = None,
     on_progress: Optional[ProgressCb] = None,
 ) -> dict[str, Any]:
@@ -78,6 +79,9 @@ def invoke_plugin(
             "pluginId": plugin_id,
             "nodeSlot": node_slot,
             "taskId": task_id,
+            # Optional per-node model choice for router-style plugins; omitted
+            # when unset so the envelope stays stable for existing plugins.
+            **({"model": model} if model else {}),
             "prompt": prompt,
         }
     )

--- a/sdk/tongflow/engine/runner.py
+++ b/sdk/tongflow/engine/runner.py
@@ -274,6 +274,7 @@ def run_workflow(
             label = node.get("label") or node.get("feature") or ""
             slot = (node.get("feature") or "").strip()
             plugin_id = (node.get("pluginId") or "").strip()
+            model = (node.get("model") or "").strip() or None
             emit(
                 {
                     "type": "node_started",
@@ -313,6 +314,7 @@ def run_workflow(
                     prompt=business_input,
                     sdk_root=SDK_ROOT,
                     task_id=task_id,
+                    model=model,
                     on_progress=on_progress,
                 )
                 result = convert_asset_outputs_to_file_refs(slot, raw, abi, store)

--- a/sdk/tongflow/scan.py
+++ b/sdk/tongflow/scan.py
@@ -6,10 +6,15 @@ import json
 from pathlib import Path
 
 from .abi import load_abi
-from ._ast_utils import extract_node_slot_decorators, looks_like_sdk_model_type
+from ._ast_utils import (
+    SLOT_MODELS_CONST,
+    extract_node_slot_decorators,
+    extract_slot_models,
+    looks_like_sdk_model_type,
+)
 from .parse_deploy import _slot_to_ident, parse_deploy_py
 
-SCANNER_VERSION = 1
+SCANNER_VERSION = 2
 
 SKIP_DIR_NAMES = frozenset(
     {
@@ -133,12 +138,54 @@ def _scan_methods_by_slot_in_file(path: Path) -> dict[str, str]:
 
 def _scan_methods_by_slot_in_dir(plugin_dir: Path) -> dict[str, str]:
     out: dict[str, str] = {}
-    for p in plugin_dir.rglob("*.py"):
-        if any(part in {"__pycache__", ".venv", "node_modules"} for part in p.parts):
-            continue
+    for p in _iter_plugin_py_files(plugin_dir):
         for slot_ident, method in _scan_methods_by_slot_in_file(p).items():
             out.setdefault(slot_ident, method)
     return out
+
+
+def _iter_plugin_py_files(plugin_dir: Path) -> list[Path]:
+    return [
+        p
+        for p in plugin_dir.rglob("*.py")
+        if not any(part in {"__pycache__", ".venv", "node_modules"} for part in p.parts)
+    ]
+
+
+def _scan_slot_models_in_dir(
+    plugin_dir: Path,
+) -> tuple[dict[str, list[str]], list[str]]:
+    """Collect TONGFLOW_SLOT_MODELS declarations across the plugin's files."""
+
+    models_by_slot: dict[str, list[str]] = {}
+    problems: list[str] = []
+    for p in _iter_plugin_py_files(plugin_dir):
+        try:
+            tree = ast.parse(p.read_text(encoding="utf-8"), filename=str(p))
+        except (OSError, SyntaxError):
+            continue
+        found, file_problems = extract_slot_models(tree)
+        for lineno, reason in file_problems:
+            problems.append(
+                _scan_error(
+                    p,
+                    reason,
+                    "declare a pure literal dict[str, list[str]]",
+                    line=lineno,
+                )
+            )
+        for slot, models in found.items():
+            if slot in models_by_slot:
+                problems.append(
+                    _scan_error(
+                        p,
+                        f"{SLOT_MODELS_CONST} declares slot {slot!r} more than once across files",
+                        "keep one declaration per slot",
+                    )
+                )
+                continue
+            models_by_slot[slot] = models
+    return models_by_slot, problems
 
 
 def scan(plugins_root: Path, abi_path: Path) -> dict[str, object]:
@@ -208,6 +255,27 @@ def scan(plugins_root: Path, abi_path: Path) -> dict[str, object]:
 
         if not llm_methods:
             continue
+
+        # Optional per-slot model lists (router-style plugins). Purely additive:
+        # plugins that declare no TONGFLOW_SLOT_MODELS are untouched.
+        models_by_slot, model_problems = _scan_slot_models_in_dir(pdir)
+        for message in model_problems:
+            errors.append({"pluginId": plugin_id, "message": message})
+        for slot, models in models_by_slot.items():
+            if slot not in llm_methods:
+                errors.append(
+                    {
+                        "pluginId": plugin_id,
+                        "message": _scan_error(
+                            pdir / "entry.py",
+                            f"{SLOT_MODELS_CONST} declares models for slot {slot!r} "
+                            "but the plugin has no @node_slot handler for it",
+                            "remove the entry or add the matching handler",
+                        ),
+                    }
+                )
+                continue
+            llm_methods[slot]["models"] = models
 
         plugins[plugin_id] = {
             "localSubdir": plugin_id,

--- a/src/app/api/task/create/route.ts
+++ b/src/app/api/task/create/route.ts
@@ -14,20 +14,22 @@ function isAbiNodeSlot(s: string): s is NodeSlot {
 /**
  * POST /api/task/create
  *
- * Wire shape: `{ feature, pluginId, prompt, nodeId, workflowId? }`. `prompt`
- * holds only ABI business fields — routing/pluginId live at the top level and
- * are persisted in their own column.
+ * Wire shape: `{ feature, pluginId, model?, prompt, nodeId, workflowId? }`.
+ * `prompt` holds only ABI business fields — routing (pluginId, and the optional
+ * model for router-style plugins) lives at the top level and is persisted in
+ * its own column.
  */
 export async function POST(request: NextRequest) {
     try {
         const body = (await request.json()) as {
             feature: string;
             pluginId: string;
+            model?: string;
             prompt: Record<string, unknown>;
             nodeId: string;
             workflowId?: number;
         };
-        const { feature, pluginId, prompt, nodeId, workflowId } = body;
+        const { feature, pluginId, model, prompt, nodeId, workflowId } = body;
 
         if (!feature || typeof feature !== "string") {
             return NextResponse.json(
@@ -101,6 +103,8 @@ export async function POST(request: NextRequest) {
         // materializes Asset bytes; the persisted prompt stores the slim form
         // (fileKey strings) to keep the DB row small.
 
+        const trimmedModel = typeof model === "string" ? model.trim() : "";
+
         const db = await getDb();
 
         const taskId = nanoid();
@@ -111,6 +115,7 @@ export async function POST(request: NextRequest) {
                 nodeId,
                 feature: canonicalFeature,
                 pluginId: trimmedPluginId,
+                model: trimmedModel || null,
                 prompt: JSON.stringify(prompt),
                 status: "pending",
                 progress: 0,

--- a/src/components/workspace/nodes/base/base-node-shell.tsx
+++ b/src/components/workspace/nodes/base/base-node-shell.tsx
@@ -37,6 +37,7 @@ import {
 } from "./node-header";
 import { NodeLoadingOverlay } from "./node-loading-overlay";
 import { NodePluginIdSelect } from "./node-plugin-id-select";
+import { NodePluginModelSelect } from "./node-plugin-model-select";
 
 /* ------------------------------------------------------------------ */
 /* Props                                                               */
@@ -236,8 +237,12 @@ export const BaseNodeShell = forwardRef<HTMLDivElement, BaseNodeShellProps>(
 
                         {/* Auto plugin select */}
                         {renderPluginSelect && (
-                            <div className="p-4 pb-0">
+                            <div className="p-4 pb-0 space-y-2">
                                 <NodePluginIdSelect
+                                    nodeSlot={feature}
+                                    data={data ?? { feature }}
+                                />
+                                <NodePluginModelSelect
                                     nodeSlot={feature}
                                     data={data ?? { feature }}
                                 />

--- a/src/components/workspace/nodes/base/node-plugin-model-select.tsx
+++ b/src/components/workspace/nodes/base/node-plugin-model-select.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useNodeId } from "@xyflow/react";
+import { useTranslations } from "next-intl";
+import { useEffect, useMemo } from "react";
+import useFlow from "@/hooks/use-flow";
+import { useNodePluginModels } from "@/hooks/use-plugins-registry";
+import type { BaseNodeData } from "@/types/nodes";
+import { useResolvedPluginId } from "./node-plugin-id-select";
+import { NodePluginSelect } from "./node-plugin-select";
+
+type NodePluginModelSelectProps = {
+    nodeSlot: string;
+    data: BaseNodeData;
+};
+
+/**
+ * Model selector for router-style plugins that declare per-slot model lists
+ * (`TONGFLOW_SLOT_MODELS`). Renders nothing when the active plugin declares no
+ * models, so single-model plugins are visually unchanged. The selection is
+ * stored as `data.pluginModel` and travels top-level (like `pluginId`) through
+ * the create-task API and workflow export.
+ */
+export function NodePluginModelSelect({
+    nodeSlot,
+    data,
+}: NodePluginModelSelectProps) {
+    const id = useNodeId()!;
+    const updates = useFlow((s) => s.updates);
+    const t = useTranslations("Workspace.nodes.base");
+
+    const { resolved: pluginId } = useResolvedPluginId(nodeSlot, data);
+    const models = useNodePluginModels(nodeSlot, pluginId);
+
+    const current = String(data.pluginModel ?? "").trim();
+    const resolved = models.includes(current) ? current : (models[0] ?? "");
+
+    // Persist the default (or replace a stale model after a plugin switch)
+    // after paint, mirroring the pluginId default write in
+    // useNodePluginResolver.
+    useEffect(() => {
+        if (resolved === current) return;
+        updates(id, { ...data, pluginModel: resolved });
+    }, [id, data, current, resolved, updates]);
+
+    const options = useMemo(
+        () => models.map((m) => ({ value: m, label: m })),
+        [models],
+    );
+
+    if (options.length === 0) return null;
+
+    return (
+        <NodePluginSelect
+            value={resolved}
+            onValueChange={(value) =>
+                updates(id, { ...data, pluginModel: value })
+            }
+            options={options}
+            title={t("pluginModelTitle")}
+        />
+    );
+}

--- a/src/components/workspace/nodes/base/node-plugin-select.tsx
+++ b/src/components/workspace/nodes/base/node-plugin-select.tsx
@@ -20,6 +20,8 @@ type NodePluginSelectProps = {
     value: string;
     onValueChange: (value: string) => void;
     options: NodePluginSelectOption[];
+    /** Card label; defaults to the plugin implementation title. */
+    title?: string;
 };
 
 /**
@@ -29,13 +31,14 @@ export function NodePluginSelect({
     value,
     onValueChange,
     options,
+    title,
 }: NodePluginSelectProps) {
     const t = useTranslations("Workspace.nodes.base");
     return (
         <Card className="p-3">
             <div className="space-y-2">
                 <Label className="text-sm font-medium text-muted-foreground">
-                    {t("pluginImplementationTitle")}
+                    {title ?? t("pluginImplementationTitle")}
                 </Label>
                 <Select value={value} onValueChange={onValueChange}>
                     <SelectTrigger className="w-full" size="sm">

--- a/src/db/workspace.schema.ts
+++ b/src/db/workspace.schema.ts
@@ -33,6 +33,8 @@ export const tasks = sqliteTable(
         nodeId: text("node_id").notNull(),
         feature: text("feature").notNull(),
         pluginId: text("plugin_id").notNull().default(""),
+        // Selected model for router-style plugins; null = plugin default
+        model: text("model"),
         prompt: text("prompt").notNull(), // JSON string (business fields only)
         status: text("status").notNull().default("pending"),
         progress: integer("progress").default(0).notNull(),

--- a/src/hooks/use-abi-execution.ts
+++ b/src/hooks/use-abi-execution.ts
@@ -286,7 +286,7 @@ export function useAbiExecution<F extends NodeSlot>(
     const { isLoading: taskLoading, createBatchTasks } = useBatchTaskManager();
     const loading = taskLoading || nodeExecutionStatus === "running";
 
-    const { pluginOptions, resolveActivePluginId } =
+    const { pluginOptions, resolveActivePluginId, resolveActiveModel } =
         useNodePluginResolver(feature);
     // The scanned registry only contains installed plugins; `isLoaded` lets the
     // run() guard distinguish "registry not fetched yet" from "nothing installed".
@@ -415,10 +415,13 @@ export function useAbiExecution<F extends NodeSlot>(
             prompt: prompts.length === 1 ? prompts[0] : prompts,
         });
 
+        const model = resolveActiveModel();
+
         try {
             const taskConfigs = prompts.map((prompt) => ({
                 feature,
                 pluginId,
+                ...(model ? { model } : {}),
                 prompt,
                 nodeId,
             }));
@@ -434,6 +437,7 @@ export function useAbiExecution<F extends NodeSlot>(
         updateNodeData,
         createBatchTasks,
         resolveActivePluginId,
+        resolveActiveModel,
         pluginOptions,
         pluginsRegistryLoaded,
         transformPrompts,

--- a/src/hooks/use-node-plugin-resolver.ts
+++ b/src/hooks/use-node-plugin-resolver.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect } from "react";
 import {
     useNodePluginIds,
     usePluginsRegistry,
+    usePluginsRegistryStore,
 } from "@/hooks/use-plugins-registry";
 
 /**
@@ -66,9 +67,33 @@ export function useNodePluginResolver(feature: string | undefined) {
         return validData || defaultPluginIdFromRegistry;
     }, [nodeId, getNode, defaultPluginIdFromRegistry, pluginOptions]);
 
+    /**
+     * Model for router-style plugins: the node's `pluginModel` when it is one
+     * of the active plugin's declared models, else that plugin's default
+     * (first declared model). `undefined` when the plugin declares none — the
+     * create-task API then omits the field entirely.
+     */
+    const resolveActiveModel = useCallback((): string | undefined => {
+        if (!feature) return undefined;
+        const pluginId = resolveActivePluginId();
+        if (!pluginId) return undefined;
+        const registry = usePluginsRegistryStore.getState().registry;
+        const models =
+            registry?.plugins?.[pluginId]?.methodsByNodeSlot?.[feature]
+                ?.models ?? [];
+        if (models.length === 0) return undefined;
+        const n = nodeId ? getNode(nodeId) : undefined;
+        const fromData = String(
+            (n?.data as { pluginModel?: string } | undefined)?.pluginModel ??
+                "",
+        ).trim();
+        return models.includes(fromData) ? fromData : models[0];
+    }, [feature, nodeId, getNode, resolveActivePluginId]);
+
     return {
         pluginOptions,
         defaultPluginIdFromRegistry,
         resolveActivePluginId,
+        resolveActiveModel,
     };
 }

--- a/src/hooks/use-plugins-registry.ts
+++ b/src/hooks/use-plugins-registry.ts
@@ -8,7 +8,15 @@ export type PluginsRegistryPayload = {
     generatedAt: string;
     scannerVersion?: number;
     nodePluginMap: Record<string, string[]>;
-    plugins: Record<string, unknown>;
+    plugins: Record<
+        string,
+        {
+            methodsByNodeSlot?: Record<
+                string,
+                { methodName: string; models?: string[] }
+            >;
+        }
+    >;
     errors?: Array<{ pluginId: string; message: string }>;
 };
 
@@ -104,6 +112,21 @@ export function useNodePluginIds(nodeSlot: string): string[] {
     const registry = usePluginsRegistryStore((s) => s.registry);
     const list = registry?.nodePluginMap?.[nodeSlot] ?? [];
     return dedupeIds(list);
+}
+
+/**
+ * Model ids a plugin declares for one ABI `nodeSlot` (empty for single-model
+ * plugins — the model dropdown is hidden in that case).
+ */
+export function useNodePluginModels(
+    nodeSlot: string,
+    pluginId: string,
+): string[] {
+    const registry = usePluginsRegistryStore((s) => s.registry);
+    const models =
+        registry?.plugins?.[pluginId]?.methodsByNodeSlot?.[nodeSlot]?.models ??
+        [];
+    return dedupeIds(models);
 }
 
 /**

--- a/src/hooks/use-task.ts
+++ b/src/hooks/use-task.ts
@@ -116,6 +116,8 @@ export interface TaskState {
 export interface TaskCreationConfig {
     feature: string;
     pluginId: string;
+    /** Selected model for router-style plugins; omitted otherwise. */
+    model?: string;
     prompt: Record<string, unknown>;
     nodeId: string;
     workflowId?: number;

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -258,6 +258,7 @@
                 "modalDeployingAction": "Deploying…",
                 "modalDeployProgressHint": "Deployed {done}/{total}",
                 "pluginImplementationTitle": "Implementation",
+                "pluginModelTitle": "Model",
                 "pluginImplementationLoading": "Loading plugin implementations…",
                 "pluginImplementationEmpty": "No plugin implementations were scanned for this capability. Add Modal or API plugins under the repo's plugins/ directory (see README), then reload this page.",
                 "pluginRegistryLoadError": "Could not load the plugin registry: {message}",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -258,6 +258,7 @@
                 "modalDeployingAction": "デプロイ中…",
                 "modalDeployProgressHint": "{done}/{total} をデプロイ済み",
                 "pluginImplementationTitle": "実装",
+                "pluginModelTitle": "モデル",
                 "pluginImplementationLoading": "プラグイン実装一覧を読み込み中…",
                 "pluginImplementationEmpty": "この機能向けのプラグイン実装がスキャン結果にありません。リポジトリの plugins/ に Modal または API プラグインを追加してください（README 参照）。ページを再読み込みしてください。",
                 "pluginRegistryLoadError": "プラグイン登録情報を読み込めませんでした：{message}",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -258,6 +258,7 @@
                 "modalDeployingAction": "배포 중…",
                 "modalDeployProgressHint": "{done}/{total} 배포됨",
                 "pluginImplementationTitle": "구현",
+                "pluginModelTitle": "모델",
                 "pluginImplementationLoading": "플러그인 구현을 불러오는 중…",
                 "pluginImplementationEmpty": "이 기능에 대해 스캔된 플러그인 구현이 없습니다. 저장소의 plugins/ 디렉터리 아래에 Modal 또는 API 플러그인을 추가한 후(README 참조) 이 페이지를 새로 고치세요.",
                 "pluginRegistryLoadError": "플러그인 레지스트리를 불러올 수 없습니다: {message}",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -258,6 +258,7 @@
                 "modalDeployingAction": "部署中…",
                 "modalDeployProgressHint": "已部署 {done}/{total}",
                 "pluginImplementationTitle": "实现",
+                "pluginModelTitle": "模型",
                 "pluginImplementationLoading": "正在加载插件实现列表…",
                 "pluginImplementationEmpty": "未扫描到适用于该能力的插件实现。请在仓库的 plugins/ 目录下添加 Modal 或 API 插件（见 README），然后刷新页面。",
                 "pluginRegistryLoadError": "无法加载插件注册表：{message}",

--- a/src/lib/api/task.ts
+++ b/src/lib/api/task.ts
@@ -20,6 +20,8 @@ export interface Task {
 export interface CreateTaskRequest {
     feature: string;
     pluginId: string;
+    /** Selected model for router-style plugins; omitted otherwise. */
+    model?: string;
     prompt: Record<string, unknown>;
     nodeId: string;
     workflowId?: number;

--- a/src/lib/plugin-executor/runners/generic.ts
+++ b/src/lib/plugin-executor/runners/generic.ts
@@ -64,6 +64,9 @@ export async function execPlugin<S extends NodeSlot>(
         pluginId: req.pluginId,
         nodeSlot: req.nodeSlot,
         taskId: req.taskId,
+        // Optional per-node model choice for router-style plugins; omitted
+        // when unset so the envelope stays stable for existing plugins.
+        ...(req.model ? { model: req.model } : {}),
         prompt,
     };
 

--- a/src/lib/plugin-executor/types.ts
+++ b/src/lib/plugin-executor/types.ts
@@ -3,6 +3,8 @@ import type { NodeSlot, SlotInput, SlotOutput } from "@/generated/abi";
 export type PluginExecRequest<S extends NodeSlot = NodeSlot> = {
     pluginId: string;
     nodeSlot: S;
+    /** Selected model for router-style plugins; omitted = plugin default. */
+    model?: string;
     /** Strong typed input object (ABI compile-time + Phase 2.4 ajv at boundaries). */
     input: SlotInput<S>;
     /** Task id for streaming notifyTask */

--- a/src/lib/plugins/plugins-registry-schema.ts
+++ b/src/lib/plugins/plugins-registry-schema.ts
@@ -13,6 +13,10 @@ import { z } from "zod";
  */
 export const PluginMethodSchema = z.object({
     methodName: z.string().min(1),
+    /** Optional per-slot model ids a router-style plugin exposes
+     * (`TONGFLOW_SLOT_MODELS` in the plugin source); first entry is the
+     * default. Absent for single-model plugins. */
+    models: z.array(z.string().min(1)).optional(),
 });
 
 export const PluginConfigSchema = z.object({

--- a/src/lib/task/runner.ts
+++ b/src/lib/task/runner.ts
@@ -26,6 +26,8 @@ export interface TaskData {
     taskId: string;
     nodeSlot: NodeSlot;
     pluginId: string;
+    /** Selected model for router-style plugins; undefined = plugin default. */
+    model?: string;
     prompt: Record<string, unknown>;
     nodeId: string;
     workflowId?: number | null;
@@ -62,6 +64,7 @@ export async function loadTaskData(taskId: string): Promise<TaskData | null> {
         taskId: task.id,
         nodeSlot,
         pluginId,
+        model: (task.model ?? "").trim() || undefined,
         prompt,
         nodeId: task.nodeId,
         workflowId: task.workflowId,
@@ -176,6 +179,7 @@ export async function executeTask(taskId: string): Promise<void> {
         const result = await executePlugin({
             pluginId: taskData.pluginId,
             nodeSlot: taskData.nodeSlot,
+            model: taskData.model,
             input: businessInput as never,
             taskId,
             signal: controller.signal,

--- a/src/lib/workflow/executable-workflow.ts
+++ b/src/lib/workflow/executable-workflow.ts
@@ -81,6 +81,9 @@ export interface ExecutableNode {
     feature: string;
     /** Plugin implementation chosen on the canvas (`tongflow-<runner>-*`). */
     pluginId: string;
+    /** Model chosen on the canvas for router-style plugins that declare
+     * per-slot model lists; absent = plugin default. */
+    model?: string;
     /** Node display name (used for mobile execution progress display) */
     label?: string;
     /** Node comment */

--- a/src/lib/workflow/exporter.ts
+++ b/src/lib/workflow/exporter.ts
@@ -630,12 +630,17 @@ export class WorkflowExporter {
             typeof nodeData.pluginId === "string"
                 ? nodeData.pluginId.trim()
                 : "";
+        const model =
+            typeof nodeData.pluginModel === "string"
+                ? nodeData.pluginModel.trim()
+                : "";
 
         return {
             id: node.id,
             type: nodeType,
             feature: ns.reg.feature,
             pluginId,
+            ...(model ? { model } : {}),
             label,
             comment,
             locked,

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -70,6 +70,9 @@ export interface BaseNodeData extends Record<string, unknown> {
     prompt?: Record<string, unknown>;
     /** Currently selected plugin ID (registry `nodeSlot` → `pluginIds`) */
     pluginId?: string;
+    /** Selected model for router-style plugins that declare per-slot model
+     * lists; empty/absent means the plugin's default. */
+    pluginModel?: string;
 
     /** Composition linkage (`useNodesData`) */
     ids?: string[];


### PR DESCRIPTION
## Summary

A plugin can now declare per-slot model lists via a `TONGFLOW_SLOT_MODELS` module constant (pure literal, AST-scanned). The node UI shows a **model dropdown** next to the plugin selector; the selection travels top-level like `pluginId` (create-task body → `tasks.model` column → stdin envelope → workflow export → SDK engine) and never touches the ABI `prompt`.

**Opt-in and fully backward compatible:**
- Plugins that declare no models: no dropdown, no envelope change — zero impact.
- New plugins on old runtimes: old AST scanners ignore the constant; the plugin runs with its per-slot default model (no crash — this is why a constant was chosen over a `@node_slot(models=...)` kwarg, which would TypeError on import with an old SDK).
- Old saved workflows (no `model` field) fall back to the plugin default.
- `slots.py` runtime is untouched; Modal plugins pinned to 0.1.2 are unaffected.

## Changes

- **SDK 0.2.0**: scanner emits `methodsByNodeSlot[slot].models` (+ cross-validation: declared slot without a handler / dupes / non-literals → scan errors); engine invoker/runner forward `model`; 5 new scan tests.
- **Platform**: `NodePluginModelSelect` component, `data.pluginModel` node field, optional `model` through the create-task wire + nullable `tasks.model` column (drizzle migration 0001), executor envelope, workflow exporter (`ExecutableNode.model`). i18n keys in en/zh/ja/ko.
- **Registers `tongflow-api-apimart`**: router plugin for the APIMart gateway — 7 slots, 46 doc-verified model entries (image gen/edit: Z-Image, Seedream, Nano Banana, GPT-Image, Imagen, Qwen, Wan, Grok; video: Kling, VEO3.1, Sora2, Seedance; text: GPT-5, Claude, Gemini, DeepSeek; Whisper + TTS). Plugin source lives in its own repo (`plugins/` is gitignored); this PR adds the registry entry + README rows.

## Follow-ups (not in this PR)

- Publish SDK 0.2.0 to PyPI (`pnpm tongflow:publish`) before the standalone engine needs model passthrough.
- Push the `tongflow-api-apimart` repo to the org.
- Mechanical chore: bump Modal plugins' `tongflow==` pins to 0.2.0 (nothing breaks at 0.1.2).
- Models support for deploy-first (Modal) plugins' `parse_deploy.py` path — intentionally out of scope; single-model plugins are unaffected.

## Test plan

- `pnpm lint:check` / `pnpm typecheck` / `pnpm build` pass; `cd sdk && pytest` 37 passed.
- Scanner over the local `plugins/` dir: apimart registers all 7 slots with model lists, zero errors; other plugins' registry entries unchanged.
- Offline smoke tests: unknown model / missing API key / unsupported slot / veo3.1-lite rejected for image-gen-video — all return clean ABI errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)