### PR TITLE
fix(desktop): trust the OS certificate store when cloning plugins

### DIFF
--- a/desktop/src/server-manager.ts
+++ b/desktop/src/server-manager.ts
@@ -40,7 +40,12 @@ export async function startServer(
         PYTHON: venvPython(),
     };
 
-    child = spawn(bundledNode(), [serverEntry()], {
+    // --use-system-ca: Node only trusts its bundled Mozilla CA list by default,
+    // so HTTPS from the server (e.g. isomorphic-git cloning plugins) fails with
+    // "unable to verify the first certificate" behind corporate TLS-inspection
+    // proxies or private CAs. The flag adds the OS trust store (supported by
+    // the bundled Node ≥ 22.15).
+    child = spawn(bundledNode(), ["--use-system-ca", serverEntry()], {
         cwd: appResourcesDir(),
         env,
         windowsHide: true,


### PR DESCRIPTION
## Summary

Users behind corporate TLS-inspection proxies (or with plugin repos served under a private CA) hit `git failed: unable to verify the first certificate` when installing custom plugins. Plugin installs clone over HTTPS with isomorphic-git inside the bundled Node server, and Node only trusts its built-in Mozilla CA list — not the OS trust store.

## Fix

Launch the bundled Node server with `--use-system-ca` (supported since Node 22.15; we bundle 24.12), so the macOS Keychain / Windows certificate store are honored too. One flag covers both custom and official plugin clones.

## Testing

- `pnpm build:main` in `desktop/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)