### PR TITLE
chore(release): v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11] - 2026-07-03
+
+### Fixed
+
+- **Plugin installs behind corporate proxies / private CAs** — installing a
+  plugin no longer fails with `git failed: unable to verify the first
+  certificate` when the network uses a TLS-inspection proxy or the plugin
+  repo is served under a privately-trusted CA. The desktop app now launches
+  its bundled Node server with `--use-system-ca`, so the OS trust store
+  (macOS Keychain / Windows certificate store) is honored in addition to
+  Node's built-in CA list.
+
 ## [0.1.10] - 2026-07-02
 
 ### Added

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow-desktop",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "description": "TongFlow desktop app (Electron shell around the Next.js standalone server + portable Python).",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "description": "A multi-modal AIGC studio for building generative AI workflows",
     "author": "tong-io",
     "keywords": [


### PR DESCRIPTION
Cut v0.1.11: fix plugin installs behind corporate TLS-inspection proxies / private CAs (`--use-system-ca` for the bundled Node server, #60).

After merge: tag `v0.1.11` to trigger the desktop release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)