### PR TITLE
feat: node-level execution cancel + plugin uninstall

### DIFF
--- a/src/app/api/plugins/official/route.ts
+++ b/src/app/api/plugins/official/route.ts
@@ -1,14 +1,25 @@
 import { NextResponse } from "next/server";
-import { listOfficialPlugins } from "@/lib/plugins/official-plugins.server";
+import {
+    listInstalledCommunityPlugins,
+    listOfficialPlugins,
+} from "@/lib/plugins/official-plugins.server";
 
 export const runtime = "nodejs";
 
 /**
  * GET /api/plugins/official
- * Lists official plugins from config/official-plugins.json with installed state.
+ * Lists official plugins from config/official-plugins.json with installed
+ * state, plus installed community plugins (custom git clones) so the plugin
+ * manager can offer uninstall for both.
  */
 export async function GET() {
-    return NextResponse.json(listOfficialPlugins(), {
-        headers: { "Cache-Control": "no-store" },
-    });
+    return NextResponse.json(
+        {
+            ...listOfficialPlugins(),
+            community: listInstalledCommunityPlugins(),
+        },
+        {
+            headers: { "Cache-Control": "no-store" },
+        },
+    );
 }

--- a/src/app/api/plugins/uninstall/route.ts
+++ b/src/app/api/plugins/uninstall/route.ts
@@ -1,0 +1,40 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import {
+    PluginInstallError,
+    uninstallPlugin,
+} from "@/lib/plugins/plugins-install.server";
+
+export const runtime = "nodejs";
+
+/**
+ * POST /api/plugins/uninstall
+ * Body: `{ id }`. Removes the plugin directory and rescans the registry.
+ */
+export async function POST(request: NextRequest) {
+    try {
+        const body = (await request.json()) as { id?: string };
+        if (!body.id) {
+            return NextResponse.json(
+                { error: "id is required" },
+                { status: 400 },
+            );
+        }
+
+        const result = await uninstallPlugin(body.id);
+
+        return NextResponse.json(result, {
+            headers: { "Cache-Control": "no-store" },
+        });
+    } catch (e) {
+        if (e instanceof PluginInstallError) {
+            return NextResponse.json(
+                { error: e.message },
+                { status: e.status },
+            );
+        }
+        const message = e instanceof Error ? e.message : String(e);
+        logger.error("[plugins] uninstall failed:", message);
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
+}

--- a/src/components/workspace/nodes/base/abi-node-shell.tsx
+++ b/src/components/workspace/nodes/base/abi-node-shell.tsx
@@ -104,6 +104,7 @@ export function AbiNodeShell<F extends NodeSlot>({
             progressLabel={exec.progressLabel}
             isExecuteMode={exec.isExecuteMode}
             onExecute={exec.run}
+            onCancel={exec.canCancel ? exec.cancel : undefined}
             executeLabel={executeLabel}
             executeIcon={executeIcon}
             executeDisabled={executeDisabled || !exec.canRun}

--- a/src/components/workspace/nodes/base/base-node-shell.tsx
+++ b/src/components/workspace/nodes/base/base-node-shell.tsx
@@ -67,6 +67,11 @@ export type BaseNodeShellProps = HTMLAttributes<HTMLDivElement> & {
      * wires it to this callback. If omitted, no execute button is rendered.
      */
     onExecute?: () => void;
+    /**
+     * When set while loading, the loading overlay exposes a cancel affordance
+     * wired to this callback (cancels the node's in-flight tasks).
+     */
+    onCancel?: () => void;
     executeLabel?: string;
     executeIcon?: ReactNode;
     executeDisabled?: boolean;
@@ -101,6 +106,7 @@ export const BaseNodeShell = forwardRef<HTMLDivElement, BaseNodeShellProps>(
             progressLabel = null,
             isExecuteMode = false,
             onExecute,
+            onCancel,
             executeLabel,
             executeIcon,
             executeDisabled,
@@ -182,6 +188,7 @@ export const BaseNodeShell = forwardRef<HTMLDivElement, BaseNodeShellProps>(
                             loading={loading}
                             elapsedSeconds={elapsedSeconds}
                             progressLabel={progressLabel}
+                            onCancel={onCancel}
                         />
 
                         {/* Stack effect background cards */}

--- a/src/components/workspace/nodes/base/node-loading-overlay.tsx
+++ b/src/components/workspace/nodes/base/node-loading-overlay.tsx
@@ -1,4 +1,5 @@
-import { Loader2 } from "lucide-react";
+import { Loader2, Square } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 import { cn } from "@/lib/utils";
 
@@ -6,13 +7,17 @@ interface NodeLoadingOverlayProps {
     loading: boolean;
     elapsedSeconds: number;
     progressLabel?: string | null;
+    /** When set, hovering the spinner reveals a stop button that cancels the run. */
+    onCancel?: () => void;
 }
 
 export function NodeLoadingOverlay({
     loading,
     elapsedSeconds,
     progressLabel,
+    onCancel,
 }: NodeLoadingOverlayProps) {
+    const t = useTranslations("Workspace.nodes.base");
     if (!loading) return null;
 
     return (
@@ -51,7 +56,23 @@ export function NodeLoadingOverlay({
                         {progressLabel}
                     </div>
                 )}
-                <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
+                {onCancel ? (
+                    <button
+                        type="button"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onCancel();
+                        }}
+                        title={t("cancelExecution")}
+                        aria-label={t("cancelExecution")}
+                        className="nodrag group/cancel relative flex h-12 w-12 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-red-500/10 dark:hover:bg-red-500/15"
+                    >
+                        <Loader2 className="h-8 w-8 animate-spin text-blue-500 transition-opacity duration-150 group-hover/cancel:opacity-0" />
+                        <Square className="absolute h-4 w-4 fill-red-500 text-red-500 opacity-0 transition-opacity duration-150 group-hover/cancel:opacity-100" />
+                    </button>
+                ) : (
+                    <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
+                )}
                 <div className="mt-1 text-lg font-semibold text-gray-700 dark:text-gray-300">
                     {elapsedSeconds}s
                 </div>

--- a/src/components/workspace/plugins-dialog.tsx
+++ b/src/components/workspace/plugins-dialog.tsx
@@ -7,10 +7,21 @@ import {
     Download,
     Loader2,
     RefreshCw,
+    Trash2,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 import toast from "react-hot-toast";
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
     Dialog,
@@ -42,6 +53,8 @@ interface OfficialPlugin {
 interface OfficialResponse {
     org: string;
     plugins: OfficialPlugin[];
+    /** Installed community plugins (custom git clones outside the manifest). */
+    community: string[];
 }
 
 interface InstallResult {
@@ -68,6 +81,11 @@ export function PluginsDialog() {
     const [loading, setLoading] = useState(false);
     const [org, setOrg] = useState("");
     const [plugins, setPlugins] = useState<OfficialPlugin[]>([]);
+    const [community, setCommunity] = useState<string[]>([]);
+    // Plugin id awaiting uninstall confirmation, or null when closed.
+    const [confirmUninstall, setConfirmUninstall] = useState<string | null>(
+        null,
+    );
     // Per-plugin in-flight state, keyed by plugin id.
     const [busy, setBusy] = useState<Record<string, boolean>>({});
     // Per-plugin update status: true = newer commit upstream, false = up to date,
@@ -86,6 +104,7 @@ export function PluginsDialog() {
             );
             setOrg(data.org);
             setPlugins(data.plugins);
+            setCommunity(data.community ?? []);
         } catch (error) {
             logger.error("Failed to load official plugins:", error);
         } finally {
@@ -158,6 +177,24 @@ export function PluginsDialog() {
             }
         },
         [reportResult, fetchOfficial, checkUpdates],
+    );
+
+    const uninstall = useCallback(
+        async (id: string) => {
+            setBusy((b) => ({ ...b, [id]: true }));
+            try {
+                await apiPost("/api/plugins/uninstall", { id });
+                toast.success(t("uninstallSuccess", { id }));
+                // Drop the plugin from node pickers without a full app reload.
+                void refreshPluginsRegistry();
+                await fetchOfficial();
+            } catch (error) {
+                logger.error("Plugin uninstall failed:", error);
+            } finally {
+                setBusy((b) => ({ ...b, [id]: false }));
+            }
+        },
+        [t, fetchOfficial],
     );
 
     const installCustom = useCallback(async () => {
@@ -327,6 +364,22 @@ export function PluginsDialog() {
                                                 </span>
                                             </Button>
                                         )}
+                                        {p.installed && (
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="icon"
+                                                disabled={busy[p.id]}
+                                                onClick={() =>
+                                                    setConfirmUninstall(p.id)
+                                                }
+                                                title={t("uninstall")}
+                                                aria-label={t("uninstall")}
+                                                className="h-8 w-8 shrink-0 text-muted-foreground hover:text-red-500"
+                                            >
+                                                <Trash2 className="h-4 w-4" />
+                                            </Button>
+                                        )}
                                     </div>
                                 ))
                             )}
@@ -360,9 +413,80 @@ export function PluginsDialog() {
                                 )}
                                 {t("cloneButton")}
                             </Button>
+
+                            {community.length > 0 && (
+                                <div className="space-y-1.5 pt-2">
+                                    <p className="text-xs font-medium text-muted-foreground">
+                                        {t("installedCommunity")}
+                                    </p>
+                                    <div className="max-h-[35vh] space-y-1.5 overflow-y-auto pr-1">
+                                        {community.map((id) => (
+                                            <div
+                                                key={id}
+                                                className="flex items-center gap-2 rounded-lg border px-3 py-2"
+                                            >
+                                                <div className="min-w-0 flex-1 truncate text-sm font-medium">
+                                                    {id}
+                                                </div>
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    disabled={busy[id]}
+                                                    onClick={() =>
+                                                        setConfirmUninstall(id)
+                                                    }
+                                                    title={t("uninstall")}
+                                                    aria-label={t("uninstall")}
+                                                    className="h-8 w-8 shrink-0 text-muted-foreground hover:text-red-500"
+                                                >
+                                                    {busy[id] ? (
+                                                        <Loader2 className="h-4 w-4 animate-spin" />
+                                                    ) : (
+                                                        <Trash2 className="h-4 w-4" />
+                                                    )}
+                                                </Button>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            )}
                         </div>
                     </TabsContent>
                 </Tabs>
+
+                <AlertDialog
+                    open={confirmUninstall !== null}
+                    onOpenChange={(isOpen) => {
+                        if (!isOpen) setConfirmUninstall(null);
+                    }}
+                >
+                    <AlertDialogContent>
+                        <AlertDialogHeader>
+                            <AlertDialogTitle>
+                                {t("uninstallConfirmTitle")}
+                            </AlertDialogTitle>
+                            <AlertDialogDescription>
+                                {t("uninstallConfirmDescription", {
+                                    id: confirmUninstall ?? "",
+                                })}
+                            </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                            <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
+                            <AlertDialogAction
+                                className="bg-red-500 text-white hover:bg-red-600"
+                                onClick={() => {
+                                    const id = confirmUninstall;
+                                    setConfirmUninstall(null);
+                                    if (id) void uninstall(id);
+                                }}
+                            >
+                                {t("uninstall")}
+                            </AlertDialogAction>
+                        </AlertDialogFooter>
+                    </AlertDialogContent>
+                </AlertDialog>
             </DialogContent>
         </Dialog>
     );

--- a/src/hooks/use-abi-execution.ts
+++ b/src/hooks/use-abi-execution.ts
@@ -75,6 +75,10 @@ export interface UseAbiExecutionOptions<F extends NodeSlot> {
 export interface UseAbiExecutionReturn {
     /** Execute one batch (single click). */
     run: () => Promise<void>;
+    /** Cancel the in-flight batch created by this node (no-op when idle). */
+    cancel: () => Promise<void>;
+    /** True while this node owns cancellable in-flight tasks. */
+    canCancel: boolean;
     loading: boolean;
     elapsedSeconds: number;
     /** Live runner status text from SSE (label / feature / message). Null when no message yet. */
@@ -283,7 +287,11 @@ export function useAbiExecution<F extends NodeSlot>(
     );
 
     const expands = useFlow((s) => s.expands);
-    const { isLoading: taskLoading, createBatchTasks } = useBatchTaskManager();
+    const {
+        isLoading: taskLoading,
+        createBatchTasks,
+        cancelTasks,
+    } = useBatchTaskManager();
     const loading = taskLoading || nodeExecutionStatus === "running";
 
     const { pluginOptions, resolveActivePluginId, resolveActiveModel } =
@@ -447,6 +455,10 @@ export function useAbiExecution<F extends NodeSlot>(
 
     return {
         run,
+        cancel: cancelTasks,
+        // Only the node's own batch can be cancelled here; workflow-level runs
+        // (nodeExecutionStatusMap) are cancelled from the smart island instead.
+        canCancel: taskLoading,
         loading,
         elapsedSeconds,
         progressLabel,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -14,7 +14,13 @@
         "installSuccess": "Installed {id}",
         "updateSuccess": "Updated {id}",
         "notRecognized": "Cloned {id}, but the scanner did not recognize it — check the directory name and required files.",
-        "openRepo": "View on GitHub"
+        "openRepo": "View on GitHub",
+        "uninstall": "Uninstall",
+        "uninstallSuccess": "Uninstalled {id}",
+        "uninstallConfirmTitle": "Uninstall plugin?",
+        "uninstallConfirmDescription": "This removes the {id} folder from disk. You can reinstall it anytime.",
+        "installedCommunity": "Installed community plugins",
+        "cancel": "Cancel"
     },
     "Settings": {
         "title": "Settings",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -222,6 +222,7 @@
             "base": {
                 "moreActions": "More options",
                 "execute": "Execute",
+                "cancelExecution": "Cancel execution",
                 "removeComment": "Remove comment",
                 "commentPlaceholder": "Add a comment for users...",
                 "clickToAddComment": "Click to add a comment...",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -14,7 +14,13 @@
         "installSuccess": "{id} をインストールしました",
         "updateSuccess": "{id} を更新しました",
         "notRecognized": "{id} をクローンしましたが、スキャナーが認識できませんでした。ディレクトリ名と必要なファイルを確認してください。",
-        "openRepo": "GitHub で表示"
+        "openRepo": "GitHub で表示",
+        "uninstall": "アンインストール",
+        "uninstallSuccess": "{id} をアンインストールしました",
+        "uninstallConfirmTitle": "プラグインをアンインストールしますか？",
+        "uninstallConfirmDescription": "{id} フォルダーをディスクから削除します。後でいつでも再インストールできます。",
+        "installedCommunity": "インストール済みのコミュニティプラグイン",
+        "cancel": "キャンセル"
     },
     "Settings": {
         "title": "設定",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -222,6 +222,7 @@
             "base": {
                 "moreActions": "その他のオプション",
                 "execute": "実行",
+                "cancelExecution": "実行をキャンセル",
                 "removeComment": "コメントを削除",
                 "commentPlaceholder": "ユーザー向けのコメントを追加...",
                 "clickToAddComment": "クリックしてコメントを追加...",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -222,6 +222,7 @@
             "base": {
                 "moreActions": "추가 옵션",
                 "execute": "실행",
+                "cancelExecution": "실행 취소",
                 "removeComment": "댓글 제거",
                 "commentPlaceholder": "사용자를 위한 댓글 추가...",
                 "clickToAddComment": "클릭하여 댓글 추가...",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -14,7 +14,13 @@
         "installSuccess": "{id} 설치 완료",
         "updateSuccess": "{id} 업데이트 완료",
         "notRecognized": "{id}를 복제했지만 스캐너가 인식하지 못했습니다 — 디렉터리 이름과 필수 파일을 확인하세요.",
-        "openRepo": "GitHub에서 보기"
+        "openRepo": "GitHub에서 보기",
+        "uninstall": "제거",
+        "uninstallSuccess": "{id} 제거 완료",
+        "uninstallConfirmTitle": "플러그인을 제거하시겠습니까?",
+        "uninstallConfirmDescription": "{id} 폴더를 디스크에서 삭제합니다. 나중에 언제든지 다시 설치할 수 있습니다.",
+        "installedCommunity": "설치된 커뮤니티 플러그인",
+        "cancel": "취소"
     },
     "Settings": {
         "title": "설정",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -222,6 +222,7 @@
             "base": {
                 "moreActions": "更多操作",
                 "execute": "执行",
+                "cancelExecution": "取消执行",
                 "removeComment": "移除注释",
                 "commentPlaceholder": "为用户添加注释...",
                 "clickToAddComment": "点击添加注释...",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -14,7 +14,13 @@
         "installSuccess": "已安装 {id}",
         "updateSuccess": "已更新 {id}",
         "notRecognized": "已克隆 {id}，但扫描器未识别——请检查目录名和必需文件。",
-        "openRepo": "在 GitHub 上查看"
+        "openRepo": "在 GitHub 上查看",
+        "uninstall": "卸载",
+        "uninstallSuccess": "已卸载 {id}",
+        "uninstallConfirmTitle": "卸载插件？",
+        "uninstallConfirmDescription": "将从磁盘删除 {id} 文件夹，之后可以随时重新安装。",
+        "installedCommunity": "已安装的社区插件",
+        "cancel": "取消"
     },
     "Settings": {
         "title": "设置",

--- a/src/lib/plugins/official-plugins.server.ts
+++ b/src/lib/plugins/official-plugins.server.ts
@@ -61,6 +61,24 @@ export function listOfficialPlugins(): {
     };
 }
 
+/**
+ * Installed plugins under the plugins dir that are not in the official
+ * manifest — i.e. community plugins cloned from a custom git URL.
+ */
+export function listInstalledCommunityPlugins(): string[] {
+    const official = new Set(loadOfficialPluginManifest().plugins);
+    let entries: string[];
+    try {
+        entries = fs.readdirSync(pluginsDir());
+    } catch {
+        // Plugins dir not created yet — nothing installed.
+        return [];
+    }
+    return entries
+        .filter((id) => !official.has(id) && isPluginInstalled(id))
+        .sort();
+}
+
 /** Update status for one installed plugin, from comparing local vs remote HEAD. */
 export interface PluginUpdateInfo {
     id: string;

--- a/src/lib/plugins/plugins-install.server.ts
+++ b/src/lib/plugins/plugins-install.server.ts
@@ -2,8 +2,10 @@ import "server-only";
 
 import fs, { existsSync } from "node:fs";
 import { join } from "node:path";
+import { and, eq, inArray } from "drizzle-orm";
 import * as git from "isomorphic-git";
 import http from "isomorphic-git/http/node";
+import { getDb, tasks } from "@/db";
 import { logger } from "@/lib/logger";
 import {
     isPluginInstalled,
@@ -39,6 +41,10 @@ export class PluginInstallError extends Error {
         super(message);
         this.name = "PluginInstallError";
     }
+}
+
+export interface UninstallResult {
+    id: string;
 }
 
 /**
@@ -153,6 +159,46 @@ export async function installPlugin(params: {
     const recognized = Boolean(registry.plugins[id]);
 
     return { id, action, recognized };
+}
+
+/**
+ * Remove an installed plugin's directory and rescan the registry.
+ * Refuses while the plugin still has pending/processing tasks.
+ */
+export async function uninstallPlugin(id: string): Promise<UninstallResult> {
+    // Also guards against path traversal — ids never contain "/" or "..".
+    assertValidPluginId(id);
+
+    const dir = join(pluginsDir(), id);
+    if (!existsSync(dir)) {
+        throw new PluginInstallError(`Plugin is not installed: ${id}`, 404);
+    }
+
+    const db = await getDb();
+    const active = await db
+        .select({ id: tasks.id })
+        .from(tasks)
+        .where(
+            and(
+                eq(tasks.pluginId, id),
+                inArray(tasks.status, ["pending", "processing"]),
+            ),
+        )
+        .limit(1);
+    if (active.length > 0) {
+        throw new PluginInstallError(
+            `Plugin ${id} still has running tasks — wait for them to finish or cancel them first.`,
+            409,
+        );
+    }
+
+    fs.rmSync(dir, { recursive: true, force: true });
+    logger.info(`[plugins] uninstalled: ${id}`);
+
+    // Rescan so the removed plugin disappears from node pickers immediately.
+    invalidatePluginsRegistry();
+
+    return { id };
 }
 
 export { isPluginInstalled };


### PR DESCRIPTION
## Summary

Two user-reported gaps, one commit each:

### 1. `feat(workspace)`: cancel a running node from its loading overlay
- The full cancel chain (`/api/task/stop` → AbortController → `child.kill()` → SSE `CANCELLED`) already existed but was only reachable from the workflow-level smart-island button.
- `useAbiExecution` now exposes `cancel` / `canCancel` (backed by the node's own `useBatchTaskManager.cancelTasks`, incl. the 10s SSE-silent fallback), wired through `AbiNodeShell` → `BaseNodeShell` → `NodeLoadingOverlay`.
- UX: the spinner in the center of the loading overlay becomes a button — hovering fades it into a red stop square; clicking cancels that node's in-flight tasks. Idle appearance is unchanged.
- Only the node's self-initiated batch is cancellable here; workflow runs keep using the global cancel.

### 2. `feat(plugins)`: uninstall installed plugins
- New `POST /api/plugins/uninstall` → `uninstallPlugin(id)`: validates the id against the plugin naming convention (also blocks path traversal), refuses with 409 while the plugin still has pending/processing tasks, removes `plugins/<id>`, and rescans the registry so node pickers update immediately.
- Plugin manager: installed official plugins get a trash button; the Git URL tab now lists installed community plugins (previously invisible after install) with the same uninstall button. Both go through a confirm dialog.
- `GET /api/plugins/official` additionally returns installed community plugin ids.

i18n added for en / zh / ja / ko.

## Test plan
- [x] `pnpm lint:check`, `pnpm typecheck` pass on the branch content (verified in a clean worktree); `pnpm build` passed locally
- [ ] Run a node, hover the spinner → stop button appears, click → task cancels and overlay clears
- [ ] Uninstall an official plugin → folder removed, node picker no longer offers it, reinstall works
- [ ] Install a plugin via Git URL → it appears under "Installed community plugins" and can be uninstalled
- [ ] Uninstall while a task of that plugin is running → 409 error toast, folder kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)