### PR TITLE
fix(workspace): replace native confirm/alert with in-app dialogs

### DIFF
--- a/src/components/ui/video-recorder.tsx
+++ b/src/components/ui/video-recorder.tsx
@@ -3,6 +3,7 @@
 import { Camera, Circle, Square } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { showErrorToast } from "@/components/ui/error-toast";
 import { logger } from "@/lib/logger";
 import { cn } from "@/lib/utils";
 import { Button } from "./button";
@@ -90,7 +91,8 @@ export const VideoRecorder = ({ onRecord, className }: VideoRecorderProps) => {
             }, 1000);
         } catch (error) {
             logger.error("Failed to start recording:", error);
-            alert(t("videoPermissionError"));
+            // Avoid native alert(): it breaks renderer keyboard focus on Electron/macOS.
+            showErrorToast({ message: t("videoPermissionError") });
         }
     }, [onRecord, t]);
 

--- a/src/components/workspace/workflow-title-menu.tsx
+++ b/src/components/workspace/workflow-title-menu.tsx
@@ -14,6 +14,16 @@ import type { ChangeEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { useShallow } from "zustand/react/shallow";
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
     Dialog,
@@ -84,6 +94,7 @@ export function WorkflowTitleMenu() {
         workflowDescription || "",
     );
     const [saving, setSaving] = useState(false);
+    const [isClearConfirmOpen, setIsClearConfirmOpen] = useState(false);
 
     const importFileRef = useRef<HTMLInputElement>(null);
 
@@ -178,16 +189,22 @@ export function WorkflowTitleMenu() {
         setIsSaveDialogOpen(true);
     };
 
-    // Clear the workflow
+    // Clear the workflow. Uses an in-app dialog instead of native confirm():
+    // on Electron/macOS a native confirm() breaks renderer keyboard focus,
+    // leaving inputs unable to receive keystrokes afterwards.
     const handleClear = () => {
-        if (confirm(t("confirmClear"))) {
-            setNodes([]);
-            setEdges([]);
-            setWorkflowName(tIndex("title"));
-            setWorkflowDescription("");
-            setWorkflowId(null);
-            toast.success(t("cleared"));
-        }
+        setMenuOpen(false);
+        setIsClearConfirmOpen(true);
+    };
+
+    const confirmClear = () => {
+        setNodes([]);
+        setEdges([]);
+        setWorkflowName(tIndex("title"));
+        setWorkflowDescription("");
+        setWorkflowId(null);
+        setIsClearConfirmOpen(false);
+        toast.success(t("cleared"));
     };
 
     // Export two flavors:
@@ -405,6 +422,27 @@ export function WorkflowTitleMenu() {
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
+
+            {/* Clear confirmation */}
+            <AlertDialog
+                open={isClearConfirmOpen}
+                onOpenChange={setIsClearConfirmOpen}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>{t("clear")}</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {t("confirmClear")}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
+                        <AlertDialogAction onClick={confirmClear}>
+                            {t("clear")}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
 
             <input
                 ref={importFileRef}


### PR DESCRIPTION
## Problem

Customer report: in the **desktop app**, after clearing the canvas and adding a text node, the textarea would not accept any keyboard input. Web was unaffected.

## Root cause

The clear-workflow confirmation used native `window.confirm()`. On Electron/macOS, native `confirm()`/`alert()` dialogs corrupt renderer keyboard focus after closing — every input/textarea stops receiving keystrokes until the window is blurred and refocused. Browsers don't have this bug, which is why it only reproduced in the desktop app despite identical frontend code.

## Fix

- `workflow-title-menu.tsx`: clear-workflow confirmation now uses the existing Radix `AlertDialog` (same pattern as the delete-edge confirmation in `workspace.tsx`). All i18n keys (`clear` / `confirmClear` / `cancel` / `cleared`, en/zh/ja/ko) already existed — no message changes.
- `video-recorder.tsx`: replaced the only other native dialog in `src/` (`alert()` on camera permission error) with the existing `showErrorToast`, eliminating the same hazard.

## Verification

- `pnpm lint:check`, `pnpm typecheck`, `pnpm build` all pass.
- Manual: clear canvas → Radix confirm dialog appears → confirm → add text node → typing works (previously broken on desktop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)