### PR TITLE
feat(desktop): full auto-update with in-app update button

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -4,6 +4,7 @@ import { ensureUserDirs } from "./fs-setup";
 import { initLogFile, logFilePath, logLine, recentLogs } from "./logging";
 import { ensurePythonEnv } from "./python-manager";
 import { startServer, stopServer } from "./server-manager";
+import { initUpdater } from "./updater";
 import {
     createMainWindow,
     createSplash,
@@ -74,14 +75,14 @@ function onServerCrash(code: number | null): void {
     }
 }
 
-/** electron-updater is optional; only runs in packaged builds with a feed. */
+/** Updater IPC bridge + background checks. Never blocks or crashes startup. */
 async function maybeCheckForUpdates(): Promise<void> {
-    if (!app.isPackaged) return;
     try {
-        const { autoUpdater } = await import("electron-updater");
-        await autoUpdater.checkForUpdatesAndNotify();
+        await initUpdater(() => mainWindow, logLine);
     } catch (e) {
-        console.warn("[updater] skipped:", e);
+        logLine(
+            `[updater] skipped: ${e instanceof Error ? e.message : String(e)}`,
+        );
     }
 }
 

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -1,0 +1,20 @@
+import { contextBridge, ipcRenderer } from "electron";
+
+/**
+ * Renderer-facing bridge for the desktop shell. The web UI detects the
+ * desktop runtime via `window.tongflowDesktop` (absent in plain browsers) and
+ * uses it to render the update button. Keep this surface minimal — the web
+ * app must keep working without it.
+ */
+contextBridge.exposeInMainWorld("tongflowDesktop", {
+    getUpdateState: () => ipcRenderer.invoke("tongflow:update-get-state"),
+    checkForUpdates: () => ipcRenderer.invoke("tongflow:update-check"),
+    installUpdate: () => ipcRenderer.invoke("tongflow:update-install"),
+    onUpdateState: (callback: (state: unknown) => void) => {
+        const listener = (_event: unknown, state: unknown) => callback(state);
+        ipcRenderer.on("tongflow:update-state", listener);
+        return () => {
+            ipcRenderer.removeListener("tongflow:update-state", listener);
+        };
+    },
+});

--- a/desktop/src/updater.ts
+++ b/desktop/src/updater.ts
@@ -1,0 +1,414 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { app, type BrowserWindow, dialog, ipcMain, net, shell } from "electron";
+
+/**
+ * App-update state machine. Both platforms fully auto-update:
+ *  - Windows: electron-updater — silent download from the GitHub release feed,
+ *    then install-and-relaunch (unsigned NSIS builds are fine).
+ *  - macOS: our builds are unsigned and Squirrel.Mac refuses to apply unsigned
+ *    updates, so we do it ourselves: download the release dmg (sha512-verified
+ *    against the update feed when available), mount it, swap the .app bundle
+ *    in place, and relaunch. If the swap fails (e.g. the install dir isn't
+ *    writable) we open the downloaded dmg for a manual drag-install.
+ *
+ * State is pushed to the renderer over IPC so the web UI can render an update
+ * button (version info, manual check, live download progress).
+ */
+
+const execFileP = promisify(execFile);
+
+// Owner/repo must match the `publish` block in electron-builder.yml.
+const LATEST_RELEASE_API =
+    "https://api.github.com/repos/tong-io/tongflow/releases/latest";
+const RELEASE_DOWNLOAD_BASE =
+    "https://github.com/tong-io/tongflow/releases/download";
+
+const RECHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
+
+export type UpdateStatus =
+    | "idle"
+    | "checking"
+    | "up-to-date"
+    | "available"
+    | "downloading"
+    | "downloaded"
+    | "error";
+
+export interface UpdateState {
+    status: UpdateStatus;
+    /** Kept for the renderer contract; both platforms are "auto" today. */
+    mode: "auto" | "manual";
+    currentVersion: string;
+    latestVersion: string | null;
+    /** Download progress 0-100, only meaningful while `downloading`. */
+    percent: number | null;
+    error: string | null;
+}
+
+let state: UpdateState = {
+    status: "idle",
+    mode: "auto",
+    currentVersion: app.getVersion(),
+    latestVersion: null,
+    percent: null,
+    error: null,
+};
+
+let getWindow: () => BrowserWindow | null = () => null;
+let log: (line: string) => void = () => {};
+let downloadedDmgPath: string | null = null;
+
+function setState(patch: Partial<UpdateState>): void {
+    state = { ...state, ...patch };
+    const win = getWindow();
+    if (win && !win.isDestroyed()) {
+        win.webContents.send("tongflow:update-state", state);
+    }
+}
+
+/**
+ * Wire IPC + start the boot check and the periodic re-check. The download is
+ * ~200 MB, so a boot-only check rarely completes on slow links — long-running
+ * apps get retries every few hours. Never blocks or crashes startup.
+ */
+export async function initUpdater(
+    getMainWindow: () => BrowserWindow | null,
+    logLine: (line: string) => void,
+): Promise<void> {
+    getWindow = getMainWindow;
+    log = logLine;
+
+    ipcMain.handle("tongflow:update-get-state", () => state);
+    ipcMain.handle("tongflow:update-check", () => {
+        void check();
+    });
+    ipcMain.handle("tongflow:update-install", () => install());
+
+    if (!app.isPackaged) return;
+
+    if (process.platform === "win32") await setupWindowsAutoUpdater();
+    setInterval(() => void check(), RECHECK_INTERVAL_MS);
+    await check(true);
+}
+
+async function check(promptWhenReady = false): Promise<void> {
+    // Already busy, or an update is sitting ready — nothing to re-check.
+    if (
+        state.status === "checking" ||
+        state.status === "downloading" ||
+        state.status === "downloaded"
+    ) {
+        return;
+    }
+    if (!app.isPackaged) {
+        // Dev build: report reality instead of comparing against releases.
+        setState({ status: "up-to-date", latestVersion: state.currentVersion });
+        return;
+    }
+    setState({ status: "checking", error: null });
+    try {
+        if (process.platform === "win32") {
+            // electron-updater events drive the rest of the state machine.
+            const { autoUpdater } = await import("electron-updater");
+            await autoUpdater.checkForUpdates();
+        } else {
+            await checkMacUpdate(promptWhenReady);
+        }
+    } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        log(`[updater] check failed: ${message}`);
+        setState({ status: "error", error: message });
+    }
+}
+
+/** Install the downloaded update and relaunch into the new version. */
+async function install(): Promise<void> {
+    if (state.status !== "downloaded") return;
+    if (process.platform === "win32") {
+        const { autoUpdater } = await import("electron-updater");
+        autoUpdater.quitAndInstall(true, true);
+        return;
+    }
+    if (!downloadedDmgPath) return;
+    try {
+        await installMacUpdateAndRelaunch(downloadedDmgPath);
+    } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        log(`[updater] install failed: ${message} — opening dmg instead`);
+        setState({ error: message });
+        // Fall back to a manual drag-install of the already-downloaded dmg.
+        await shell.openPath(downloadedDmgPath);
+    }
+}
+
+/** "Restart now / Later" prompt once an update is downloaded and ready. */
+async function promptRestart(version: string): Promise<void> {
+    const options = {
+        type: "info" as const,
+        title: "Update ready",
+        message: `TongFlow ${version} has been downloaded`,
+        detail: "Restart now to install it. You can also do this later from the update button in the top-right corner.",
+        buttons: ["Restart now", "Later"],
+        defaultId: 0,
+        cancelId: 1,
+    };
+    const win = getWindow();
+    const { response } = win
+        ? await dialog.showMessageBox(win, options)
+        : await dialog.showMessageBox(options);
+    if (response === 0) await install();
+}
+
+// --- Windows: electron-updater ----------------------------------------------
+
+async function setupWindowsAutoUpdater(): Promise<void> {
+    const { autoUpdater } = await import("electron-updater");
+
+    // Every updater step goes to the log file — update failures on user
+    // machines must be diagnosable from a bug report.
+    autoUpdater.logger = {
+        info: (m: unknown) => log(`[updater] ${String(m)}`),
+        warn: (m: unknown) => log(`[updater] warn: ${String(m)}`),
+        error: (m: unknown) => log(`[updater] error: ${String(m)}`),
+        debug: (m: unknown) => log(`[updater] ${String(m)}`),
+    };
+
+    autoUpdater.on("update-available", (info) => {
+        setState({ status: "available", latestVersion: info.version });
+    });
+    autoUpdater.on("update-not-available", (info) => {
+        setState({ status: "up-to-date", latestVersion: info.version });
+    });
+    autoUpdater.on("error", (err) => {
+        setState({ status: "error", error: err.message });
+    });
+
+    let lastLoggedPercent = -25;
+    autoUpdater.on("download-progress", (p) => {
+        setState({ status: "downloading", percent: p.percent });
+        if (p.percent - lastLoggedPercent >= 25) {
+            lastLoggedPercent = p.percent;
+            log(`[updater] downloading: ${Math.round(p.percent)}%`);
+        }
+    });
+
+    autoUpdater.on("update-downloaded", (info) => {
+        lastLoggedPercent = -25;
+        setState({
+            status: "downloaded",
+            latestVersion: info.version,
+            percent: 100,
+        });
+        // "Later" still updates: autoInstallOnAppQuit installs on quit.
+        void promptRestart(info.version);
+    });
+}
+
+// --- macOS: download + swap-install (unsigned builds) ------------------------
+
+interface GitHubRelease {
+    tag_name?: string;
+    html_url?: string;
+    assets?: Array<{ name?: string; browser_download_url?: string }>;
+}
+
+function macArch(): "arm64" | "x64" {
+    return process.arch === "arm64" ? "arm64" : "x64";
+}
+
+function updatesDir(): string {
+    return path.join(app.getPath("userData"), "updates");
+}
+
+async function checkMacUpdate(promptWhenReady: boolean): Promise<void> {
+    const res = await net.fetch(LATEST_RELEASE_API, {
+        headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!res.ok) throw new Error(`release lookup failed: HTTP ${res.status}`);
+    const release = (await res.json()) as GitHubRelease;
+    const latest = (release.tag_name ?? "").replace(/^v/, "");
+    const current = state.currentVersion;
+    if (!isNewerVersion(latest, current)) {
+        log(`[updater] up to date (current ${current}, latest ${latest})`);
+        fs.rmSync(updatesDir(), { recursive: true, force: true });
+        setState({ status: "up-to-date", latestVersion: latest || null });
+        return;
+    }
+
+    log(`[updater] update available: ${current} -> ${latest}`);
+    const assetName = `TongFlow-mac-${macArch()}.dmg`;
+    const asset = release.assets?.find((a) => a.name === assetName);
+    if (!asset?.browser_download_url) {
+        throw new Error(`release v${latest} has no ${assetName}`);
+    }
+    setState({ status: "available", latestVersion: latest });
+
+    downloadedDmgPath = await downloadMacUpdate(
+        latest,
+        asset.browser_download_url,
+    );
+    setState({ status: "downloaded", percent: 100 });
+    log(`[updater] update ${latest} downloaded: ${downloadedDmgPath}`);
+    if (promptWhenReady) await promptRestart(latest);
+}
+
+/**
+ * Download the dmg with live progress, verifying sha512 against the update
+ * feed when the feed has an entry for this artifact. The final filename is
+ * only created by a completed download (rename from .partial), so an existing
+ * file is a completed download from an earlier session.
+ */
+async function downloadMacUpdate(
+    version: string,
+    url: string,
+): Promise<string> {
+    const dir = updatesDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, `TongFlow-${version}-${macArch()}.dmg`);
+    if (fs.existsSync(file)) return file;
+    for (const stale of fs.readdirSync(dir)) {
+        fs.rmSync(path.join(dir, stale), { force: true });
+    }
+
+    const expectedSha512 = await fetchExpectedSha512(version);
+    if (!expectedSha512) {
+        log("[updater] no checksum in the update feed; skipping verification");
+    }
+
+    setState({ status: "downloading", percent: 0 });
+    const res = await net.fetch(url);
+    if (!res.ok || !res.body) {
+        throw new Error(`download failed: HTTP ${res.status}`);
+    }
+    const total = Number(res.headers.get("content-length") ?? 0);
+    const partial = `${file}.partial`;
+    const out = fs.createWriteStream(partial);
+    const hash = createHash("sha512");
+    const reader = res.body.getReader();
+    let received = 0;
+    let lastSentPercent = -1;
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            const chunk = Buffer.from(value);
+            hash.update(chunk);
+            received += chunk.byteLength;
+            if (!out.write(chunk)) {
+                await new Promise<void>((resolve) =>
+                    out.once("drain", () => resolve()),
+                );
+            }
+            if (total > 0) {
+                const percent = Math.min((received / total) * 100, 100);
+                if (percent - lastSentPercent >= 1) {
+                    lastSentPercent = percent;
+                    setState({ status: "downloading", percent });
+                }
+            }
+        }
+        await new Promise<void>((resolve, reject) => {
+            out.on("error", reject);
+            out.end(() => resolve());
+        });
+    } catch (e) {
+        out.destroy();
+        fs.rmSync(partial, { force: true });
+        throw e;
+    }
+    if (expectedSha512 && hash.digest("base64") !== expectedSha512) {
+        fs.rmSync(partial, { force: true });
+        throw new Error("update download failed sha512 verification");
+    }
+    fs.renameSync(partial, file);
+    return file;
+}
+
+/** sha512 for this arch's dmg from electron-builder's latest-mac.yml, if listed. */
+async function fetchExpectedSha512(version: string): Promise<string | null> {
+    try {
+        const res = await net.fetch(
+            `${RELEASE_DOWNLOAD_BASE}/v${version}/latest-mac.yml`,
+        );
+        if (!res.ok) return null;
+        const feed = await res.text();
+        // Minimal parse of the feed's `files:` entries: a `url:` line followed
+        // by its `sha512:` line.
+        const entry = new RegExp(
+            `url:\\s*TongFlow-mac-${macArch()}\\.dmg\\s+sha512:\\s*(\\S+)`,
+        ).exec(feed);
+        return entry ? entry[1] : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Swap the running .app bundle with the one inside the downloaded dmg, then
+ * relaunch. The dmg was downloaded by us (no quarantine attribute), so the
+ * replaced bundle launches without Gatekeeper prompts.
+ */
+async function installMacUpdateAndRelaunch(dmgPath: string): Promise<void> {
+    // …/TongFlow.app/Contents/MacOS/TongFlow → …/TongFlow.app
+    const bundle = path.resolve(app.getPath("exe"), "..", "..", "..");
+    if (!bundle.endsWith(".app")) {
+        throw new Error(`not an app bundle: ${bundle}`);
+    }
+
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "tongflow-update-"));
+    const mountPoint = path.join(workDir, "mnt");
+    const staged = path.join(workDir, "staged.app");
+    await execFileP("hdiutil", [
+        "attach",
+        dmgPath,
+        "-nobrowse",
+        "-readonly",
+        "-mountpoint",
+        mountPoint,
+    ]);
+    try {
+        const appName = fs
+            .readdirSync(mountPoint)
+            .find((name) => name.endsWith(".app"));
+        if (!appName) throw new Error("no .app inside the update dmg");
+        await execFileP("ditto", [path.join(mountPoint, appName), staged]);
+    } finally {
+        await execFileP("hdiutil", ["detach", mountPoint, "-force"]).catch(
+            () => {},
+        );
+    }
+    // Defense in depth: make sure nothing tagged the staged copy.
+    await execFileP("xattr", ["-cr", staged]).catch(() => {});
+
+    log(`[updater] swapping ${bundle}`);
+    const previous = path.join(workDir, "previous.app");
+    await execFileP("mv", [bundle, previous]);
+    try {
+        // ditto, not mv: temp and the install dir may be different volumes.
+        await execFileP("ditto", [staged, bundle]);
+    } catch (e) {
+        await execFileP("rm", ["-rf", bundle]).catch(() => {});
+        await execFileP("mv", [previous, bundle]);
+        throw e;
+    }
+    log("[updater] update installed, relaunching");
+    app.relaunch();
+    app.quit();
+}
+
+/** True when `candidate` is a well-formed x.y.z strictly newer than `current`. */
+function isNewerVersion(candidate: string, current: string): boolean {
+    const next = candidate.split(".").map(Number);
+    const cur = current.split(".").map(Number);
+    if (next.length !== 3 || next.some(Number.isNaN)) return false;
+    for (let i = 0; i < 3; i++) {
+        const diff = (next[i] ?? 0) - (cur[i] ?? 0);
+        if (diff !== 0) return diff > 0;
+    }
+    return false;
+}

--- a/desktop/src/window.ts
+++ b/desktop/src/window.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { BrowserWindow } from "electron";
 import { logFilePath, recentLogs } from "./logging";
 
@@ -58,7 +59,12 @@ export function createMainWindow(url: string): BrowserWindow {
         minHeight: 640,
         show: false,
         backgroundColor: "#0b0b0f",
-        webPreferences: { contextIsolation: true, nodeIntegration: false },
+        webPreferences: {
+            contextIsolation: true,
+            nodeIntegration: false,
+            // Exposes window.tongflowDesktop (updater state/actions) to the UI.
+            preload: path.join(__dirname, "preload.js"),
+        },
     });
     win.once("ready-to-show", () => win.show());
     win.webContents.on(

--- a/src/components/workspace/update-button.tsx
+++ b/src/components/workspace/update-button.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+/**
+ * App-update button, desktop app only. The Electron preload exposes
+ * `window.tongflowDesktop`; in a plain browser it is absent and this component
+ * renders nothing. State (version info, download progress) is pushed from the
+ * Electron main process — see desktop/src/updater.ts.
+ */
+
+import { CircleArrowUp, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Progress } from "@/components/ui/progress";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+/** Mirror of UpdateState in desktop/src/updater.ts (separate TS projects). */
+interface DesktopUpdateState {
+    status:
+        | "idle"
+        | "checking"
+        | "up-to-date"
+        | "available"
+        | "downloading"
+        | "downloaded"
+        | "error";
+    /** Kept for contract compatibility; both platforms auto-update today. */
+    mode: "auto" | "manual";
+    currentVersion: string;
+    latestVersion: string | null;
+    percent: number | null;
+    error: string | null;
+}
+
+interface TongflowDesktopBridge {
+    getUpdateState: () => Promise<DesktopUpdateState>;
+    checkForUpdates: () => Promise<void>;
+    installUpdate: () => Promise<void>;
+    onUpdateState: (
+        callback: (state: DesktopUpdateState) => void,
+    ) => () => void;
+}
+
+declare global {
+    interface Window {
+        tongflowDesktop?: TongflowDesktopBridge;
+    }
+}
+
+export function UpdateButton({ className }: { className?: string }) {
+    const t = useTranslations("Updater");
+    const [state, setState] = useState<DesktopUpdateState | null>(null);
+
+    useEffect(() => {
+        const bridge = window.tongflowDesktop;
+        if (!bridge) return;
+        let cancelled = false;
+        void bridge.getUpdateState().then((s) => {
+            if (!cancelled) setState(s);
+        });
+        const unsubscribe = bridge.onUpdateState((s) => setState(s));
+        return () => {
+            cancelled = true;
+            unsubscribe();
+        };
+    }, []);
+
+    // Not running inside the desktop app (or bridge not ready yet).
+    if (!state) return null;
+
+    const { status } = state;
+    // The download starts right after "available", so render that transient
+    // state as a 0% download.
+    const downloading = status === "downloading" || status === "available";
+    const hasUpdate =
+        status === "available" || downloading || status === "downloaded";
+
+    const statusText = (() => {
+        if (status === "checking") return t("checking");
+        if (downloading)
+            return state.latestVersion
+                ? t("available", { version: state.latestVersion })
+                : t("downloading");
+        if (status === "downloaded") return t("downloaded");
+        if (status === "error") return t("error");
+        if (status === "up-to-date") return t("upToDate");
+        return null;
+    })();
+
+    return (
+        <DropdownMenu>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <DropdownMenuTrigger asChild>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className={`relative ${className ?? ""}`}
+                            aria-label={t("title")}
+                        >
+                            <CircleArrowUp className="h-5 w-5" />
+                            {hasUpdate ? (
+                                <span className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-red-500" />
+                            ) : null}
+                        </Button>
+                    </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{t("title")}</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end" className="w-64 p-3">
+                <div className="mb-2 flex items-baseline justify-between">
+                    <span className="text-sm font-medium">TongFlow</span>
+                    <span className="text-xs text-muted-foreground">
+                        {t("currentVersion")} v{state.currentVersion}
+                    </span>
+                </div>
+                {statusText ? (
+                    <p className="mb-2 text-xs text-muted-foreground">
+                        {statusText}
+                    </p>
+                ) : null}
+                {state.error ? (
+                    <p className="mb-2 break-all text-xs text-red-500">
+                        {state.error}
+                    </p>
+                ) : null}
+                {downloading ? (
+                    <div className="mb-2 flex items-center gap-2">
+                        <Progress
+                            value={state.percent ?? 0}
+                            className="h-1.5"
+                        />
+                        <span className="w-9 text-right text-xs text-muted-foreground">
+                            {Math.round(state.percent ?? 0)}%
+                        </span>
+                    </div>
+                ) : null}
+                {status === "downloaded" ? (
+                    <Button
+                        type="button"
+                        size="sm"
+                        className="w-full"
+                        onClick={() =>
+                            void window.tongflowDesktop?.installUpdate()
+                        }
+                    >
+                        {t("restart")}
+                    </Button>
+                ) : status === "checking" || downloading ? (
+                    <Button
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        className="w-full"
+                        disabled
+                    >
+                        <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                        {status === "checking"
+                            ? t("checking")
+                            : t("downloading")}
+                    </Button>
+                ) : (
+                    <Button
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        className="w-full"
+                        onClick={() =>
+                            void window.tongflowDesktop?.checkForUpdates()
+                        }
+                    >
+                        {t("checkNow")}
+                    </Button>
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/src/components/workspace/workspace-nav.tsx
+++ b/src/components/workspace/workspace-nav.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/tooltip";
 import { PluginsDialog } from "@/components/workspace/plugins-dialog";
 import { SettingsDialog } from "@/components/workspace/settings-dialog";
+import { UpdateButton } from "@/components/workspace/update-button";
 
 const LOCALE_OPTIONS = [
     { code: "zh", label: "中文" },
@@ -147,6 +148,7 @@ export function WorkspaceNav() {
     const t = useTranslations("Navigation");
     return (
         <div className="flex items-center gap-2">
+            <UpdateButton className={navBtnClass} />
             <PluginsDialog />
             <SettingsDialog />
             <ThemeToggleButton />

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -36,6 +36,19 @@
     "Index": {
         "title": "New Idea"
     },
+    "Updater": {
+        "title": "Updates",
+        "currentVersion": "Current version",
+        "checking": "Checking for updates…",
+        "upToDate": "You're on the latest version",
+        "available": "New version {version} available",
+        "downloading": "Downloading update…",
+        "downloaded": "Update downloaded — restart to install",
+        "error": "Update check failed",
+        "checkNow": "Check for updates",
+        "download": "Download",
+        "restart": "Restart to update"
+    },
     "Navigation": {
         "toggleTheme": "Toggle theme",
         "language": "Language",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -36,6 +36,19 @@
     "Index": {
         "title": "新しいアイデア"
     },
+    "Updater": {
+        "title": "アップデート",
+        "currentVersion": "現在のバージョン",
+        "checking": "更新を確認中…",
+        "upToDate": "最新バージョンです",
+        "available": "新しいバージョン {version} が利用可能です",
+        "downloading": "更新をダウンロード中…",
+        "downloaded": "更新のダウンロードが完了しました。再起動してインストールします",
+        "error": "更新の確認に失敗しました",
+        "checkNow": "更新を確認",
+        "download": "ダウンロード",
+        "restart": "再起動して更新"
+    },
     "Navigation": {
         "toggleTheme": "テーマ切り替え",
         "language": "言語",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -36,6 +36,19 @@
     "Index": {
         "title": "새 아이디어"
     },
+    "Updater": {
+        "title": "업데이트",
+        "currentVersion": "현재 버전",
+        "checking": "업데이트 확인 중…",
+        "upToDate": "최신 버전입니다",
+        "available": "새 버전 {version} 사용 가능",
+        "downloading": "업데이트 다운로드 중…",
+        "downloaded": "업데이트 다운로드 완료 — 다시 시작하여 설치",
+        "error": "업데이트 확인 실패",
+        "checkNow": "업데이트 확인",
+        "download": "다운로드",
+        "restart": "다시 시작하여 업데이트"
+    },
     "Navigation": {
         "toggleTheme": "테마 전환",
         "language": "언어",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -36,6 +36,19 @@
     "Index": {
         "title": "新创意"
     },
+    "Updater": {
+        "title": "更新",
+        "currentVersion": "当前版本",
+        "checking": "正在检查更新…",
+        "upToDate": "已是最新版本",
+        "available": "发现新版本 {version}",
+        "downloading": "正在下载更新…",
+        "downloaded": "更新已下载，重启后即可安装",
+        "error": "检查更新失败",
+        "checkNow": "检查更新",
+        "download": "下载",
+        "restart": "重启并更新"
+    },
     "Navigation": {
         "toggleTheme": "切换主题",
         "language": "语言",


### PR DESCRIPTION
## Summary

Users reported never receiving desktop updates. The old flow was a single silent `checkForUpdatesAndNotify()` at boot: every failure was swallowed into `console.warn`, macOS could never install (unsigned builds + dmg-only target), and on Windows a ~180 MB download that didn't finish before quit was simply lost. This PR replaces it with a real auto-update pipeline plus a visible update button.

### Desktop main process
- **`desktop/src/updater.ts`** — update state machine (`checking / available / downloading / downloaded / error`), pushed to the renderer over IPC.
  - **Windows**: electron-updater as before (silent download from the GitHub feed, install on restart/quit), now with full logging and a restart prompt.
  - **macOS**: unsigned builds can't use Squirrel.Mac, so the updater downloads the release dmg in-app (sha512-verified against `latest-mac.yml` when the feed lists this arch), mounts it, swaps the `.app` bundle in place and relaunches. On swap failure it rolls back the old bundle and opens the downloaded dmg for a manual drag-install.
  - Checks at boot + every 4 h; completed downloads are cached in `userData/updates` and reused across restarts; every step goes to `tongflow.log` so user reports are diagnosable.
- **`desktop/src/preload.ts`** — exposes `window.tongflowDesktop` (get state / check / install / subscribe).

### Web UI
- **`UpdateButton`** in the top-right nav (desktop only — renders nothing in a browser): current version, status line, manual "check for updates", live download progress bar, and a "restart to update" action. Localized in en/zh/ja/ko.

## Testing
- `pnpm lint:check`, `pnpm typecheck`, `pnpm build`, `desktop pnpm build:main` all pass.
- Packaged a local mac-arm64 build at version 0.1.10 (with `pnpm smoke` passing) and verified it detects v0.1.11, downloads with live progress in the panel, and prompts to restart-install.

## Known follow-ups (not in this PR)
- Published `latest-mac.yml` only contains the x64 entry — the two mac CI jobs overwrite each other's feed despite `max-parallel: 1`, so arm64 checksum verification is skipped (logged). Worth fixing in the release workflow.
- Users on ≤0.1.11 still run the old silent updater and need one manual download to get onto this pipeline.
- GitHub-hosted downloads remain slow/unreliable for users in China; a CDN/mirror feed is the structural fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)