### PR TITLE
feat(settings): per-plugin env var cards from tongflow.plugin.json manifests

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -74,9 +74,12 @@ The exact scan rules and the annotations a handler must carry are in
 ## 3. Directory & naming conventions
 
 A plugin is a directory under `plugins/`; the directory name **is** the plugin id. **There is
-no manifest file** — nothing to register, declare, or list. The scanner derives everything from
-the SDK decorator + type annotations in your Python (the slot bindings — see
-[§5](#5-what-registers-a-handler)).
+no registration manifest** — handlers are never registered or listed anywhere; the scanner
+derives everything from the SDK decorator + type annotations in your Python (the slot
+bindings — see [§5](#5-what-registers-a-handler)). A plugin *may* additionally ship an optional
+`tongflow.plugin.json` that declares the env vars it reads, purely so the Settings dialog can
+render them as a pre-filled card (see [§6.1](#61-declaring-environment-variables--tongflowpluginjson));
+it plays no part in discovery or execution.
 
 The naming convention the scanner enforces:
 
@@ -167,7 +170,7 @@ Helpers in [`sdk/tongflow/protocol.py`](../sdk/tongflow/protocol.py):
 
 ## 5. What registers a handler
 
-There is no registration list and no manifest. The scanner discovers a slot handler **purely
+There is no registration list and no registration manifest. The scanner discovers a slot handler **purely
 from the SDK annotations on your function** — it matches exactly three things, all from
 `tongflow`:
 
@@ -257,6 +260,43 @@ progress("Generating frames", percent=40)
 
 It writes a sentinel-framed line to stderr that the platform forwards to the task stream — it
 works identically from a local entry or from inside a Modal method.
+
+### 6.1 Declaring environment variables — `tongflow.plugin.json`
+
+Users supply env vars (API keys, tokens, tuning knobs) through the Settings dialog; the platform
+injects the stored values into your plugin's process on every run. To have the dialog render
+your plugin as a card with its keys pre-filled, ship an optional **`tongflow.plugin.json`** at
+the plugin root:
+
+```json
+{
+    "env": [
+        { "key": "OPENAI_API_KEY", "required": true, "description": "OpenAI API key", "url": "https://platform.openai.com/api-keys" },
+        { "key": "OPENAI_BASE_URL", "default": "https://api.openai.com/v1", "description": "OpenAI-compatible base URL" },
+        { "key": "OPENAI_CHAT_MODEL", "default": "gpt-4o-mini" }
+    ]
+}
+```
+
+Field semantics:
+
+- **`key`** — the env var name (`UPPER_SNAKE`), exactly as your code reads it via
+  `os.environ.get(...)`.
+- **`required`** — required keys render flat in the card with a required marker; everything
+  else is collapsed under an "Advanced" toggle.
+- **`default`** — the value your code falls back to when the var is unset; shown as the input
+  placeholder. Declare it on optional tuning knobs so users see the effective default.
+- **`description`** — a short hint rendered under the input.
+- **`url`** — where to obtain the credential (e.g. the provider's API-keys page); rendered as a
+  link next to the key.
+
+Keys declared by **two or more installed plugins** (e.g. `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`
+for every Modal plugin, or `HF_TOKEN`) are automatically hoisted into a single "Shared" card
+listing the plugins that use them — the value is stored once and reaches all of them.
+
+The file is optional and presentation-only: a plugin without one still runs exactly the same,
+its users just set the keys under "Custom variables" instead. An unreadable or invalid file is
+logged and ignored — it never breaks the Settings dialog.
 
 ---
 

--- a/src/app/api/settings/env/route.ts
+++ b/src/app/api/settings/env/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { loadPluginEnvDecls } from "@/lib/plugins/plugin-env-manifests.server";
 import {
     type EnvStore,
     loadEnvStore,
@@ -9,11 +10,13 @@ export const runtime = "nodejs";
 
 /**
  * GET /api/settings/env
- * Returns the user-managed environment key/value map (settings.json).
+ * Returns the user-managed environment key/value map (settings.json) plus
+ * the env vars declared by installed plugins (`tongflow.plugin.json`), so
+ * the settings dialog gets values and declarations in one fetch.
  */
 export async function GET() {
     return NextResponse.json(
-        { env: loadEnvStore() },
+        { env: loadEnvStore(), pluginEnv: loadPluginEnvDecls() },
         { headers: { "Cache-Control": "no-store" } },
     );
 }

--- a/src/components/workspace/settings-dialog.tsx
+++ b/src/components/workspace/settings-dialog.tsx
@@ -68,7 +68,9 @@ interface EnvCardGroup {
  * Splits declarations into one "shared" group (keys declared by >=2 installed
  * plugins — e.g. MODAL_TOKEN_ID or HF_TOKEN) plus one group per plugin with
  * its remaining own keys. Merge rule for shared keys: required if any
- * declarer says so; description/url/default from the first declarer.
+ * declarer says so; description/default kept only when every declarer agrees
+ * (a plugin-specific hint would mislead on a shared row); url from the first
+ * declarer.
  */
 function buildEnvCardGroups(
     decls: PluginEnvDecl[],
@@ -81,6 +83,12 @@ function buildEnvCardGroups(
             if (seen) {
                 seen.plugins.push(decl.pluginId);
                 if (v.required) seen.v = { ...seen.v, required: true };
+                if (seen.v.description !== v.description) {
+                    seen.v = { ...seen.v, description: undefined };
+                }
+                if (seen.v.default !== v.default) {
+                    seen.v = { ...seen.v, default: undefined };
+                }
             } else {
                 usage.set(v.key, { v: { ...v }, plugins: [decl.pluginId] });
             }

--- a/src/components/workspace/settings-dialog.tsx
+++ b/src/components/workspace/settings-dialog.tsx
@@ -1,9 +1,20 @@
 "use client";
 
-import { Eye, EyeOff, Loader2, Plus, Settings, Trash2 } from "lucide-react";
+import {
+    ChevronDown,
+    ChevronRight,
+    ExternalLink,
+    Eye,
+    EyeOff,
+    Loader2,
+    Plus,
+    Settings,
+    Trash2,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
     Dialog,
@@ -22,12 +33,18 @@ import {
 } from "@/components/ui/tooltip";
 import { apiGet, apiPut } from "@/lib/api/client";
 import { logger } from "@/lib/logger";
+import type {
+    PluginEnvDecl,
+    PluginEnvVar,
+} from "@/lib/plugins/plugin-env-manifest-schema";
+import { pluginDisplayName } from "./nodes/base/node-plugin-id-select";
 
 const navBtnClass =
     "h-10 w-10 rounded-xl bg-white border border-gray-100 hover:bg-gray-50 text-gray-500 hover:text-gray-900 dark:bg-zinc-800 dark:border-zinc-700 dark:text-gray-400 dark:hover:text-white dark:hover:bg-zinc-700 transition-all duration-200";
 
 interface EnvResponse {
     env: Record<string, string>;
+    pluginEnv?: PluginEnvDecl[];
 }
 
 interface Row {
@@ -35,9 +52,223 @@ interface Row {
     value: string;
 }
 
-function toRows(env: Record<string, string>): Row[] {
-    const rows = Object.entries(env).map(([key, value]) => ({ key, value }));
-    return rows.length > 0 ? rows : [{ key: "", value: "" }];
+/** A declared var as rendered inside a card; shared vars carry `usedBy`. */
+interface GroupVar extends PluginEnvVar {
+    /** Display names of the plugins declaring this key (shared card only). */
+    usedBy?: string[];
+}
+
+interface EnvCardGroup {
+    id: string;
+    title: string;
+    vars: GroupVar[];
+}
+
+/**
+ * Splits declarations into one "shared" group (keys declared by >=2 installed
+ * plugins — e.g. MODAL_TOKEN_ID or HF_TOKEN) plus one group per plugin with
+ * its remaining own keys. Merge rule for shared keys: required if any
+ * declarer says so; description/url/default from the first declarer.
+ */
+function buildEnvCardGroups(
+    decls: PluginEnvDecl[],
+    sharedTitle: string,
+): EnvCardGroup[] {
+    const usage = new Map<string, { v: GroupVar; plugins: string[] }>();
+    for (const decl of decls) {
+        for (const v of decl.env) {
+            const seen = usage.get(v.key);
+            if (seen) {
+                seen.plugins.push(decl.pluginId);
+                if (v.required) seen.v = { ...seen.v, required: true };
+            } else {
+                usage.set(v.key, { v: { ...v }, plugins: [decl.pluginId] });
+            }
+        }
+    }
+
+    const sharedKeys = new Set<string>();
+    const sharedVars: GroupVar[] = [];
+    for (const { v, plugins } of usage.values()) {
+        if (plugins.length < 2) continue;
+        sharedKeys.add(v.key);
+        sharedVars.push({ ...v, usedBy: plugins.map(pluginDisplayName) });
+    }
+
+    const groups: EnvCardGroup[] = [];
+    if (sharedVars.length > 0) {
+        groups.push({ id: "shared", title: sharedTitle, vars: sharedVars });
+    }
+    for (const decl of decls) {
+        const vars = decl.env.filter((v) => !sharedKeys.has(v.key));
+        if (vars.length > 0) {
+            groups.push({
+                id: decl.pluginId,
+                title: pluginDisplayName(decl.pluginId),
+                vars,
+            });
+        }
+    }
+    return groups;
+}
+
+function DeclaredVarRow({
+    v,
+    value,
+    revealed,
+    onChange,
+    onToggleReveal,
+}: {
+    v: GroupVar;
+    value: string;
+    revealed: boolean;
+    onChange: (value: string) => void;
+    onToggleReveal: () => void;
+}) {
+    const t = useTranslations("Settings");
+    return (
+        <div className="space-y-1">
+            <div className="flex items-center gap-1.5">
+                <span className="font-mono text-xs text-muted-foreground">
+                    {v.key}
+                    {v.required ? (
+                        <span
+                            className="ml-0.5 text-red-500"
+                            title={t("requiredHint")}
+                        >
+                            *
+                        </span>
+                    ) : null}
+                </span>
+                {v.url ? (
+                    <a
+                        href={v.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        aria-label={t("getKey")}
+                        className="text-muted-foreground hover:text-foreground"
+                    >
+                        <ExternalLink className="h-3 w-3" />
+                    </a>
+                ) : null}
+            </div>
+            <div className="flex items-center gap-2">
+                <Input
+                    value={value}
+                    placeholder={v.default ?? t("valuePlaceholder")}
+                    type={revealed ? "text" : "password"}
+                    spellCheck={false}
+                    autoComplete="off"
+                    className="flex-1 font-mono text-xs"
+                    onChange={(e) => onChange(e.target.value)}
+                />
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9 shrink-0 text-muted-foreground"
+                    aria-label={t("toggleReveal")}
+                    onClick={onToggleReveal}
+                >
+                    {revealed ? (
+                        <EyeOff className="h-4 w-4" />
+                    ) : (
+                        <Eye className="h-4 w-4" />
+                    )}
+                </Button>
+            </div>
+            {v.description ? (
+                <p className="text-xs text-muted-foreground">{v.description}</p>
+            ) : null}
+            {v.usedBy ? (
+                <p className="text-xs text-muted-foreground/70">
+                    {v.usedBy.join(", ")}
+                </p>
+            ) : null}
+        </div>
+    );
+}
+
+function PluginEnvCard({
+    group,
+    values,
+    revealed,
+    onChangeValue,
+    onToggleReveal,
+}: {
+    group: EnvCardGroup;
+    values: Record<string, string>;
+    revealed: Record<string, boolean>;
+    onChangeValue: (key: string, value: string) => void;
+    onToggleReveal: (key: string) => void;
+}) {
+    const t = useTranslations("Settings");
+    const [advancedOpen, setAdvancedOpen] = useState(false);
+
+    const requiredVars = group.vars.filter((v) => v.required);
+    const optionalVars = group.vars.filter((v) => !v.required);
+    const setCount = requiredVars.filter((v) =>
+        (values[v.key] ?? "").trim(),
+    ).length;
+    const allSet = setCount === requiredVars.length;
+
+    return (
+        <div className="space-y-2 rounded-lg border p-3">
+            <div className="flex items-center justify-between">
+                <span className="text-sm font-medium">{group.title}</span>
+                {requiredVars.length > 0 ? (
+                    <Badge variant={allSet ? "secondary" : "outline"}>
+                        {t("setBadge", {
+                            set: setCount,
+                            total: requiredVars.length,
+                        })}
+                    </Badge>
+                ) : null}
+            </div>
+
+            {requiredVars.map((v) => (
+                <DeclaredVarRow
+                    key={v.key}
+                    v={v}
+                    value={values[v.key] ?? ""}
+                    revealed={Boolean(revealed[v.key])}
+                    onChange={(value) => onChangeValue(v.key, value)}
+                    onToggleReveal={() => onToggleReveal(v.key)}
+                />
+            ))}
+
+            {optionalVars.length > 0 ? (
+                <>
+                    <button
+                        type="button"
+                        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                        onClick={() => setAdvancedOpen((open) => !open)}
+                    >
+                        {advancedOpen ? (
+                            <ChevronDown className="h-3.5 w-3.5" />
+                        ) : (
+                            <ChevronRight className="h-3.5 w-3.5" />
+                        )}
+                        {t("advanced", { count: optionalVars.length })}
+                    </button>
+                    {advancedOpen
+                        ? optionalVars.map((v) => (
+                              <DeclaredVarRow
+                                  key={v.key}
+                                  v={v}
+                                  value={values[v.key] ?? ""}
+                                  revealed={Boolean(revealed[v.key])}
+                                  onChange={(value) =>
+                                      onChangeValue(v.key, value)
+                                  }
+                                  onToggleReveal={() => onToggleReveal(v.key)}
+                              />
+                          ))
+                        : null}
+                </>
+            ) : null}
+        </div>
+    );
 }
 
 export function SettingsDialog() {
@@ -45,62 +276,95 @@ export function SettingsDialog() {
     const [open, setOpen] = useState(false);
     const [loading, setLoading] = useState(false);
     const [saving, setSaving] = useState(false);
-    const [rows, setRows] = useState<Row[]>([{ key: "", value: "" }]);
-    const [revealed, setRevealed] = useState<Record<number, boolean>>({});
+    const [decls, setDecls] = useState<PluginEnvDecl[]>([]);
+    // Values of declared keys — one flat map, so a key shared by several
+    // plugins is edited once and stays in sync everywhere.
+    const [values, setValues] = useState<Record<string, string>>({});
+    // Free-form rows for keys no installed plugin declares.
+    const [customRows, setCustomRows] = useState<Row[]>([]);
+    // Keyed by env key for declared rows, `custom:${index}` for custom rows.
+    const [revealed, setRevealed] = useState<Record<string, boolean>>({});
+
+    const groups = useMemo(
+        () => buildEnvCardGroups(decls, t("sharedSectionTitle")),
+        [decls, t],
+    );
+
+    const applyEnv = useCallback(
+        (env: Record<string, string>, nextDecls: PluginEnvDecl[]) => {
+            const claimed = new Set(
+                nextDecls.flatMap((d) => d.env.map((v) => v.key)),
+            );
+            const nextValues: Record<string, string> = {};
+            const nextCustom: Row[] = [];
+            for (const [key, value] of Object.entries(env)) {
+                if (claimed.has(key)) nextValues[key] = value;
+                else nextCustom.push({ key, value });
+            }
+            setDecls(nextDecls);
+            setValues(nextValues);
+            setCustomRows(nextCustom);
+            setRevealed({});
+        },
+        [],
+    );
 
     const fetchEnv = useCallback(async () => {
         setLoading(true);
         try {
             const data = await apiGet<EnvResponse>("/api/settings/env");
-            setRows(toRows(data.env ?? {}));
-            setRevealed({});
+            applyEnv(data.env ?? {}, data.pluginEnv ?? []);
         } catch (error) {
             logger.error("Failed to load settings:", error);
         } finally {
             setLoading(false);
         }
-    }, []);
+    }, [applyEnv]);
 
     useEffect(() => {
         if (open) void fetchEnv();
     }, [open, fetchEnv]);
 
-    const updateRow = (index: number, patch: Partial<Row>) => {
-        setRows((prev) =>
+    const updateCustomRow = (index: number, patch: Partial<Row>) => {
+        setCustomRows((prev) =>
             prev.map((r, i) => (i === index ? { ...r, ...patch } : r)),
         );
     };
 
-    const addRow = () => setRows((prev) => [...prev, { key: "", value: "" }]);
+    const addCustomRow = () =>
+        setCustomRows((prev) => [...prev, { key: "", value: "" }]);
 
-    const removeRow = (index: number) => {
-        setRows((prev) => {
-            const next = prev.filter((_, i) => i !== index);
-            return next.length > 0 ? next : [{ key: "", value: "" }];
-        });
+    const removeCustomRow = (index: number) => {
+        setCustomRows((prev) => prev.filter((_, i) => i !== index));
     };
 
     const save = useCallback(async () => {
-        // Collapse rows into a map; last non-empty key wins, blank keys dropped.
+        // Collapse everything into one flat map; last non-empty key wins,
+        // blank keys dropped. Declared values merge last so cards win over a
+        // duplicate custom row; empty declared values are not persisted (a
+        // stored "" would shadow a shell-exported key via withStoredEnv).
         const env: Record<string, string> = {};
-        for (const { key, value } of rows) {
+        for (const { key, value } of customRows) {
             const k = key.trim();
             if (k) env[k] = value;
+        }
+        for (const [key, value] of Object.entries(values)) {
+            if (value.trim()) env[key] = value;
+            else delete env[key];
         }
         setSaving(true);
         try {
             const data = await apiPut<EnvResponse>("/api/settings/env", {
                 env,
             });
-            setRows(toRows(data.env ?? {}));
-            setRevealed({});
+            applyEnv(data.env ?? {}, decls);
             toast.success(t("saved"));
         } catch (error) {
             logger.error("Failed to save settings:", error);
         } finally {
             setSaving(false);
         }
-    }, [rows, t]);
+    }, [customRows, values, decls, applyEnv, t]);
 
     return (
         <Dialog open={open} onOpenChange={setOpen}>
@@ -121,7 +385,7 @@ export function SettingsDialog() {
                 <TooltipContent side="bottom">{t("title")}</TooltipContent>
             </Tooltip>
 
-            <DialogContent className="max-w-lg">
+            <DialogContent className="sm:max-w-2xl">
                 <DialogHeader>
                     <DialogTitle>{t("title")}</DialogTitle>
                     <DialogDescription>{t("description")}</DialogDescription>
@@ -132,79 +396,117 @@ export function SettingsDialog() {
                         <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
                     </div>
                 ) : (
-                    <div className="max-h-[55vh] space-y-2 overflow-y-auto pr-1">
-                        {rows.map((row, index) => (
-                            <div
-                                key={index}
-                                className="flex items-center gap-2"
-                            >
-                                <Input
-                                    value={row.key}
-                                    placeholder={t("keyPlaceholder")}
-                                    spellCheck={false}
-                                    autoComplete="off"
-                                    className="flex-1 font-mono text-xs"
-                                    onChange={(e) =>
-                                        updateRow(index, {
-                                            key: e.target.value,
-                                        })
-                                    }
-                                />
-                                <Input
-                                    value={row.value}
-                                    placeholder={t("valuePlaceholder")}
-                                    type={revealed[index] ? "text" : "password"}
-                                    spellCheck={false}
-                                    autoComplete="off"
-                                    className="flex-1 font-mono text-xs"
-                                    onChange={(e) =>
-                                        updateRow(index, {
-                                            value: e.target.value,
-                                        })
-                                    }
-                                />
-                                <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="icon"
-                                    className="h-9 w-9 shrink-0 text-muted-foreground"
-                                    aria-label={t("toggleReveal")}
-                                    onClick={() =>
-                                        setRevealed((r) => ({
-                                            ...r,
-                                            [index]: !r[index],
-                                        }))
-                                    }
-                                >
-                                    {revealed[index] ? (
-                                        <EyeOff className="h-4 w-4" />
-                                    ) : (
-                                        <Eye className="h-4 w-4" />
-                                    )}
-                                </Button>
-                                <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="icon"
-                                    className="h-9 w-9 shrink-0 text-muted-foreground hover:text-red-600"
-                                    aria-label={t("removeRow")}
-                                    onClick={() => removeRow(index)}
-                                >
-                                    <Trash2 className="h-4 w-4" />
-                                </Button>
-                            </div>
+                    <div className="max-h-[65vh] space-y-3 overflow-y-auto pr-1">
+                        {groups.map((group) => (
+                            <PluginEnvCard
+                                key={group.id}
+                                group={group}
+                                values={values}
+                                revealed={revealed}
+                                onChangeValue={(key, value) =>
+                                    setValues((prev) => ({
+                                        ...prev,
+                                        [key]: value,
+                                    }))
+                                }
+                                onToggleReveal={(key) =>
+                                    setRevealed((prev) => ({
+                                        ...prev,
+                                        [key]: !prev[key],
+                                    }))
+                                }
+                            />
                         ))}
 
-                        <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            className="w-full"
-                            onClick={addRow}
-                        >
-                            <Plus className="mr-1 h-4 w-4" />
-                            {t("addRow")}
-                        </Button>
+                        <div className="space-y-2">
+                            {groups.length > 0 ? (
+                                <div>
+                                    <h3 className="text-sm font-medium">
+                                        {t("customSectionTitle")}
+                                    </h3>
+                                    <p className="text-xs text-muted-foreground">
+                                        {t("customSectionHint")}
+                                    </p>
+                                </div>
+                            ) : null}
+                            {customRows.map((row, index) => (
+                                <div
+                                    key={index}
+                                    className="flex items-center gap-2"
+                                >
+                                    <Input
+                                        value={row.key}
+                                        placeholder={t("keyPlaceholder")}
+                                        spellCheck={false}
+                                        autoComplete="off"
+                                        className="flex-1 font-mono text-xs"
+                                        onChange={(e) =>
+                                            updateCustomRow(index, {
+                                                key: e.target.value,
+                                            })
+                                        }
+                                    />
+                                    <Input
+                                        value={row.value}
+                                        placeholder={t("valuePlaceholder")}
+                                        type={
+                                            revealed[`custom:${index}`]
+                                                ? "text"
+                                                : "password"
+                                        }
+                                        spellCheck={false}
+                                        autoComplete="off"
+                                        className="flex-1 font-mono text-xs"
+                                        onChange={(e) =>
+                                            updateCustomRow(index, {
+                                                value: e.target.value,
+                                            })
+                                        }
+                                    />
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-9 w-9 shrink-0 text-muted-foreground"
+                                        aria-label={t("toggleReveal")}
+                                        onClick={() =>
+                                            setRevealed((prev) => ({
+                                                ...prev,
+                                                [`custom:${index}`]:
+                                                    !prev[`custom:${index}`],
+                                            }))
+                                        }
+                                    >
+                                        {revealed[`custom:${index}`] ? (
+                                            <EyeOff className="h-4 w-4" />
+                                        ) : (
+                                            <Eye className="h-4 w-4" />
+                                        )}
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-9 w-9 shrink-0 text-muted-foreground hover:text-red-600"
+                                        aria-label={t("removeRow")}
+                                        onClick={() => removeCustomRow(index)}
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                </div>
+                            ))}
+
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="w-full"
+                                onClick={addCustomRow}
+                            >
+                                <Plus className="mr-1 h-4 w-4" />
+                                {t("addRow")}
+                            </Button>
+                        </div>
                     </div>
                 )}
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -24,14 +24,21 @@
     },
     "Settings": {
         "title": "Settings",
-        "description": "Environment variables passed to plugins (e.g. API keys). Each plugin's README documents the keys it needs.",
+        "description": "Environment variables passed to plugins (e.g. API keys). Installed plugins declare their keys below; anything else goes under custom variables.",
         "keyPlaceholder": "KEY",
         "valuePlaceholder": "value",
         "addRow": "Add variable",
         "removeRow": "Remove",
         "toggleReveal": "Show / hide value",
         "save": "Save",
-        "saved": "Settings saved"
+        "saved": "Settings saved",
+        "setBadge": "{set}/{total} set",
+        "advanced": "Advanced ({count})",
+        "sharedSectionTitle": "Shared",
+        "customSectionTitle": "Custom variables",
+        "customSectionHint": "Variables not declared by any installed plugin.",
+        "getKey": "Get key",
+        "requiredHint": "Required"
     },
     "Index": {
         "title": "New Idea"

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -24,14 +24,21 @@
     },
     "Settings": {
         "title": "設定",
-        "description": "プラグインに渡す環境変数（API キーなど）。必要なキーは各プラグインの README を参照してください。",
+        "description": "プラグインに渡す環境変数（API キーなど）。インストール済みプラグインが必要とするキーは下に表示され、それ以外はカスタム変数に入ります。",
         "keyPlaceholder": "KEY",
         "valuePlaceholder": "値",
         "addRow": "変数を追加",
         "removeRow": "削除",
         "toggleReveal": "値の表示 / 非表示",
         "save": "保存",
-        "saved": "設定を保存しました"
+        "saved": "設定を保存しました",
+        "setBadge": "{set}/{total} 設定済み",
+        "advanced": "詳細設定（{count}）",
+        "sharedSectionTitle": "共有",
+        "customSectionTitle": "カスタム変数",
+        "customSectionHint": "どのインストール済みプラグインにも宣言されていない変数。",
+        "getKey": "キーを取得",
+        "requiredHint": "必須"
     },
     "Index": {
         "title": "新しいアイデア"

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -24,14 +24,21 @@
     },
     "Settings": {
         "title": "설정",
-        "description": "플러그인에 전달되는 환경 변수입니다(예: API 키). 각 플러그인의 README에 필요한 키가 문서화되어 있습니다.",
+        "description": "플러그인에 전달되는 환경 변수입니다(예: API 키). 설치된 플러그인이 필요로 하는 키는 아래에 표시되며, 그 외 변수는 사용자 지정 변수에 들어갑니다.",
         "keyPlaceholder": "KEY",
         "valuePlaceholder": "값",
         "addRow": "변수 추가",
         "removeRow": "제거",
         "toggleReveal": "값 표시 / 숨기기",
         "save": "저장",
-        "saved": "설정이 저장되었습니다"
+        "saved": "설정이 저장되었습니다",
+        "setBadge": "{set}/{total} 설정됨",
+        "advanced": "고급 ({count})",
+        "sharedSectionTitle": "공유",
+        "customSectionTitle": "사용자 지정 변수",
+        "customSectionHint": "설치된 어떤 플러그인도 선언하지 않은 변수입니다.",
+        "getKey": "키 발급",
+        "requiredHint": "필수"
     },
     "Index": {
         "title": "새 아이디어"

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -24,14 +24,21 @@
     },
     "Settings": {
         "title": "设置",
-        "description": "传递给插件的环境变量（如 API Key）。各插件的 README 会说明它需要哪些 Key。",
+        "description": "传递给插件的环境变量（如 API Key）。已安装插件所需的 Key 已在下方列出，其余变量放在自定义变量区。",
         "keyPlaceholder": "KEY",
         "valuePlaceholder": "值",
         "addRow": "添加变量",
         "removeRow": "删除",
         "toggleReveal": "显示 / 隐藏值",
         "save": "保存",
-        "saved": "设置已保存"
+        "saved": "设置已保存",
+        "setBadge": "已填 {set}/{total}",
+        "advanced": "高级（{count}）",
+        "sharedSectionTitle": "共享",
+        "customSectionTitle": "自定义变量",
+        "customSectionHint": "未被任何已安装插件声明的变量。",
+        "getKey": "获取 Key",
+        "requiredHint": "必填"
     },
     "Index": {
         "title": "新创意"

--- a/src/lib/plugins/plugin-env-manifest-schema.ts
+++ b/src/lib/plugins/plugin-env-manifest-schema.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+/**
+ * Optional per-plugin env declaration file: `tongflow.plugin.json` at the
+ * plugin repo root. It only feeds the Settings UI (per-plugin env var cards);
+ * plugin/handler registration stays annotation-driven and never reads it.
+ */
+export const PluginEnvVarSchema = z.object({
+    /** Env key, conventional UPPER_SNAKE. */
+    key: z
+        .string()
+        .min(1)
+        .regex(/^[A-Z][A-Z0-9_]*$/),
+    /** Required keys render flat in the card; optional ones go under "Advanced". */
+    required: z.boolean().optional(),
+    /** Short human hint shown under the input. */
+    description: z.string().optional(),
+    /** Default the plugin uses when unset; shown as the input placeholder. */
+    default: z.string().optional(),
+    /** Where to obtain the key (e.g. the provider's API-keys page). */
+    url: z.url().optional(),
+});
+
+export const PluginEnvManifestSchema = z.object({
+    env: z.array(PluginEnvVarSchema).default([]),
+});
+
+export type PluginEnvVar = z.infer<typeof PluginEnvVarSchema>;
+export type PluginEnvManifest = z.infer<typeof PluginEnvManifestSchema>;
+
+/** Loader output: one entry per installed plugin that ships a manifest. */
+export interface PluginEnvDecl {
+    pluginId: string;
+    env: PluginEnvVar[];
+}

--- a/src/lib/plugins/plugin-env-manifests.server.ts
+++ b/src/lib/plugins/plugin-env-manifests.server.ts
@@ -1,0 +1,73 @@
+import "server-only";
+
+import { type Dirent, existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { logger } from "@/lib/logger";
+import {
+    type PluginEnvDecl,
+    PluginEnvManifestSchema,
+} from "@/lib/plugins/plugin-env-manifest-schema";
+import { pluginsDir } from "@/lib/runtime/paths.server";
+
+export const PLUGIN_ENV_MANIFEST_FILE = "tongflow.plugin.json";
+
+/**
+ * Reads `tongflow.plugin.json` from every installed plugin (same `.git`
+ * presence check as isPluginInstalled, so partial clones are skipped).
+ * Reads fresh on every call — files are tiny, the settings dialog is
+ * low-frequency, and newly installed plugins are picked up automatically.
+ * A missing or invalid manifest never fails the call; it just yields no entry.
+ */
+export function loadPluginEnvDecls(): PluginEnvDecl[] {
+    const root = pluginsDir();
+    let entries: Dirent[];
+    try {
+        entries = readdirSync(root, { withFileTypes: true });
+    } catch {
+        return [];
+    }
+
+    const decls: PluginEnvDecl[] = [];
+    for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const pluginId = entry.name;
+        const pluginRoot = join(root, pluginId);
+        const manifestPath = join(pluginRoot, PLUGIN_ENV_MANIFEST_FILE);
+        if (
+            !existsSync(join(pluginRoot, ".git")) ||
+            !existsSync(manifestPath)
+        ) {
+            continue;
+        }
+
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(readFileSync(manifestPath, "utf8"));
+        } catch (error) {
+            logger.warn(
+                `[plugins] unreadable ${PLUGIN_ENV_MANIFEST_FILE} in ${pluginId}:`,
+                error,
+            );
+            continue;
+        }
+        const result = PluginEnvManifestSchema.safeParse(parsed);
+        if (!result.success) {
+            logger.warn(
+                `[plugins] invalid ${PLUGIN_ENV_MANIFEST_FILE} in ${pluginId}: ${result.error.message}`,
+            );
+            continue;
+        }
+
+        // Dedupe keys within one plugin; first declaration wins.
+        const seen = new Set<string>();
+        const env = result.data.env.filter((v) => {
+            if (seen.has(v.key)) return false;
+            seen.add(v.key);
+            return true;
+        });
+        if (env.length > 0) decls.push({ pluginId, env });
+    }
+
+    decls.sort((a, b) => a.pluginId.localeCompare(b.pluginId));
+    return decls;
+}


### PR DESCRIPTION
## Summary

- Plugins can ship an optional `tongflow.plugin.json` at their repo root declaring the env vars they read (`key`, `required`, `description`, `default`, `url`).
- The settings dialog renders one card per installed plugin: required keys flat with a required marker and a get-key link, optional keys collapsed under an Advanced toggle with their defaults as placeholders.
- Keys declared by two or more installed plugins (e.g. `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`, `HF_TOKEN`) are automatically hoisted into a top Shared card that lists every plugin using them; the value is stored once and reaches all of them. Plugin-specific descriptions/defaults are dropped on shared rows when declarers disagree.
- Undeclared keys stay editable under a Custom variables section (previous behavior).
- Persistence unchanged: the flat env map in `settings.json` via the existing PUT; GET now additionally returns `pluginEnv` (declarations of installed plugins).
- Docs: `docs/plugins.md` gains §6.1 describing the manifest format.

## Test plan

- `pnpm lint:check` / `pnpm typecheck` / `pnpm build` pass.
- Manually verified against 27 locally installed plugins with generated manifests: shared card lists all 21 Modal plugins under the Modal tokens and 7 under `HF_TOKEN`; badges track required completion; broken manifest JSON is logged and skipped without breaking the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)