### PR TITLE
feat(plugins): register official Agnes AI plugin; release v0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12] - 2026-07-04
+
+### Added
+
+- **Agnes AI official plugin** (`tongflow-api-agnes`) — one API key covers
+  **12 slots** via the OpenAI-compatible [Agnes AI](https://agnes-ai.com)
+  gateway: text generation / splitting / combining and image understanding
+  (`agnes-2.0-flash`, 512K context), image generation / editing
+  (`agnes-image-2.1-flash` / `2.0-flash`, per-node model picker), multi-image
+  fusion (`agnes-image-2.0-flash`), and async text / image / multi-image /
+  first-last-frame → video (`agnes-video-v2.0`, up to ~18 s per clip).
+
 ## [0.1.11] - 2026-07-03
 
 ### Fixed
@@ -182,7 +194,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 First public open-source release of TongFlow.
 
-[Unreleased]: https://github.com/tong-io/tongflow/compare/v0.1.10...HEAD
+[Unreleased]: https://github.com/tong-io/tongflow/compare/v0.1.12...HEAD
+[0.1.12]: https://github.com/tong-io/tongflow/compare/v0.1.11...v0.1.12
+[0.1.11]: https://github.com/tong-io/tongflow/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/tong-io/tongflow/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/tong-io/tongflow/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/tong-io/tongflow/compare/v0.1.7...v0.1.8

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Run the preloaded example node by node, or switch to Execute Mode and hit the ru
 - [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — OpenAI for `gen_text` and image generation / editing / fusion (`gpt-image-2`)
 - [tongflow-api-bytedance](https://github.com/tong-io/tongflow-api-bytedance) — Volcengine Ark (Doubao Seedance 2.0) for text/image/audio → video
 - [tongflow-api-apimart](https://github.com/tong-io/tongflow-api-apimart) — APIMart gateway with a per-node **model picker**: image gen/edit (Z-Image, Seedream, Nano Banana, GPT-Image), text/image → video (Kling, VEO3, Sora2, Seedance), `gen_text` (GPT-5, Claude, Gemini), Whisper transcription and TTS
+- [tongflow-api-agnes](https://github.com/tong-io/tongflow-api-agnes) — Agnes AI gateway: `gen_text` / text tools / image understanding (`agnes-2.0-flash`), image generation / editing / fusion (`agnes-image-2.x-flash`), and text / image / first-last-frame → video (`agnes-video-v2.0`)
 
 ### GPU/CPU plugins
 

--- a/config/official-plugins.json
+++ b/config/official-plugins.json
@@ -6,6 +6,7 @@
         "tongflow-api-openai",
         "tongflow-api-bytedance",
         "tongflow-api-apimart",
+        "tongflow-api-agnes",
         "tongflow-modal-ffmpeg",
         "tongflow-modal-pyscenedetect",
         "tongflow-modal-z-image",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow-desktop",
-    "version": "0.1.11",
+    "version": "0.1.12",
     "description": "TongFlow desktop app (Electron shell around the Next.js standalone server + portable Python).",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -177,6 +177,7 @@ TongFlowで生成AIを活用し、創造力を解き放とう！
 - [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — OpenAI ベースの `gen_text` および画像生成 / 編集 / 融合（`gpt-image-2`）
 - [tongflow-api-bytedance](https://github.com/tong-io/tongflow-api-bytedance) — Volcengine Ark（Doubao Seedance 2.0）ベースのテキスト / 画像 / 音声 → 動画
 - [tongflow-api-apimart](https://github.com/tong-io/tongflow-api-apimart) — APIMart ゲートウェイ。ノード上で**モデルを選択**可能：画像生成 / 編集（Z-Image、Seedream、Nano Banana、GPT-Image）、テキスト / 画像 → 動画（Kling、VEO3、Sora2、Seedance）、`gen_text`（GPT-5、Claude、Gemini）、Whisper 文字起こしと TTS
+- [tongflow-api-agnes](https://github.com/tong-io/tongflow-api-agnes) — Agnes AI ゲートウェイ：`gen_text` / テキストツール / 画像理解（`agnes-2.0-flash`）、画像生成 / 編集 / 融合（`agnes-image-2.x-flash`）、テキスト / 画像 / 最初・最後フレーム → 動画（`agnes-video-v2.0`）
 
 ### GPU/CPU プラグイン
 

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -177,6 +177,7 @@ app 默认不预装任何插件。打开**插件管理器**（右上角的方块
 - [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — 基于 OpenAI 的 `gen_text` 及图像生成 / 编辑 / 融合（`gpt-image-2`）
 - [tongflow-api-bytedance](https://github.com/tong-io/tongflow-api-bytedance) — 基于火山方舟（豆包 Seedance 2.0）的 文 / 图 / 音 → 视频
 - [tongflow-api-apimart](https://github.com/tong-io/tongflow-api-apimart) — APIMart 聚合网关，支持节点上**按模型选择**：图像生成 / 编辑（Z-Image、Seedream、Nano Banana、GPT-Image）、文 / 图 → 视频（可灵、VEO3、Sora2、Seedance）、`gen_text`（GPT-5、Claude、Gemini）、Whisper 转录与 TTS
+- [tongflow-api-agnes](https://github.com/tong-io/tongflow-api-agnes) — Agnes AI 网关：`gen_text` / 文本工具 / 图像理解（`agnes-2.0-flash`）、图像生成 / 编辑 / 融合（`agnes-image-2.x-flash`）、文 / 图 / 首尾帧 → 视频（`agnes-video-v2.0`）
 
 ### GPU/CPU 插件
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow",
-    "version": "0.1.11",
+    "version": "0.1.12",
     "description": "A multi-modal AIGC studio for building generative AI workflows",
     "author": "tong-io",
     "keywords": [


### PR DESCRIPTION
## Summary

- Register **tongflow-api-agnes** ([repo](https://github.com/tong-io/tongflow-api-agnes)) in `config/official-plugins.json` — 12 ABI slots via the OpenAI-compatible [Agnes AI](https://agnes-ai.com) gateway:
  - text: `gen-text` / `split-text` / `combine-text` (`agnes-2.0-flash`, 512K context)
  - vision: `image-describe` / `image-gen-text`
  - image: `image-gen` / `image-edit` (2.1/2.0 model picker), `image-fusion` (2.0 only)
  - video (async): `text-gen-video` / `image-gen-video` / `images-gen-video` / `image-image-gen-video` (`agnes-video-v2.0`, ~18 s max)
- Add the plugin to the **API plugins** list in all three READMEs (EN/ZH/JA); capability matrix unchanged (no first-time slots)
- Cut **v0.1.12**: CHANGELOG entry (+ backfill missing 0.1.11 compare link), version bump in `package.json` / `desktop/package.json`

## Checks

- `pnpm lint:check` / `pnpm typecheck` / `pnpm build` / `pnpm verify:plugins` all pass
- Plugin itself: pyright 0 errors, dispatcher smoke-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)