### PR TITLE
feat(music): optional ref_audio input for gen-music node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Reference audio for music generation** — the music node (`gen-music`)
+  gains an optional `ref_audio` input handle: connect an audio node to
+  condition the song on a reference track. ACE-Step uses it for
+  style-transfer conditioning (`reference_audio`); LeVo uses it as the
+  melody prompt (`melody_wavs`, first 10 s). Requires `tongflow==0.2.1`
+  (published) and redeployed `tongflow-modal-ace-step` /
+  `tongflow-modal-levo` plugins.
+
 ## [0.1.12] - 2026-07-04
 
 ### Added

--- a/config/tongflow.abi.json
+++ b/config/tongflow.abi.json
@@ -844,6 +844,9 @@
                     },
                     "seed": {
                         "type": "integer"
+                    },
+                    "ref_audio": {
+                        "$ref": "#/$defs/Asset"
                     }
                 },
                 "additionalProperties": false

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tongflow"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python SDK for TongFlow — author plugins and run multi-modal GenAI workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/tongflow/__init__.py
+++ b/sdk/tongflow/__init__.py
@@ -11,6 +11,6 @@ from .deploy_marker import deploy
 from .engine import run_workflow
 from .progress import progress
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = ["deploy", "progress", "run_workflow"]

--- a/sdk/tongflow/_data/tongflow.abi.json
+++ b/sdk/tongflow/_data/tongflow.abi.json
@@ -844,6 +844,9 @@
                     },
                     "seed": {
                         "type": "integer"
+                    },
+                    "ref_audio": {
+                        "$ref": "#/$defs/Asset"
                     }
                 },
                 "additionalProperties": false

--- a/sdk/tongflow/models/gen_music.py
+++ b/sdk/tongflow/models/gen_music.py
@@ -13,6 +13,7 @@ class GenMusicInput(BaseModel):
     keyscale: str | None = None
     language: str | None = None
     lyrics: str | None = None
+    ref_audio: Asset | None = None
     seed: int | None = None
     songTitle: str | None = None
     tags: str | None = None

--- a/src/components/workspace/nodes/transfer/text-gen-music.tsx
+++ b/src/components/workspace/nodes/transfer/text-gen-music.tsx
@@ -23,6 +23,7 @@ import { coerceBaseNodeData } from "@/lib/workflow/flow-node-data";
 import type { TongflowPluginNodeProps } from "@/types/tongflow-flow";
 
 import { AbiNodeShell } from "../base/abi-node-shell";
+import { MediaThumbnail } from "../base/media-thumbnail";
 
 function buildLanguageOptions(tLang: (key: string) => string) {
     return [
@@ -160,21 +161,36 @@ const TextGenMusicNode = ({ selected, data }: TextGenMusicNodeProps) => {
     const nodeId = useNodeId();
     const edges = useStore((state) => state.edges as Edge[]);
 
-    const { tagsSourceId, lyricsSourceId } = useMemo(() => {
-        if (!nodeId) return { tagsSourceId: null, lyricsSourceId: null };
+    const { tagsSourceId, lyricsSourceId, refAudioSourceId } = useMemo(() => {
+        if (!nodeId) {
+            return {
+                tagsSourceId: null,
+                lyricsSourceId: null,
+                refAudioSourceId: null,
+            };
+        }
         let tagsSrc: string | null = null;
         let lyricsSrc: string | null = null;
+        let refAudioSrc: string | null = null;
         for (const e of edges) {
             if (e.target !== nodeId) continue;
             if (e.targetHandle === "in:tags") tagsSrc = e.source;
             else if (e.targetHandle === "in:lyrics") lyricsSrc = e.source;
+            else if (e.targetHandle === "in:ref_audio") refAudioSrc = e.source;
         }
-        return { tagsSourceId: tagsSrc, lyricsSourceId: lyricsSrc };
+        return {
+            tagsSourceId: tagsSrc,
+            lyricsSourceId: lyricsSrc,
+            refAudioSourceId: refAudioSrc,
+        };
     }, [edges, nodeId]);
 
     const upstreamIds = useMemo(
-        () => [tagsSourceId, lyricsSourceId].filter((v): v is string => !!v),
-        [tagsSourceId, lyricsSourceId],
+        () =>
+            [tagsSourceId, lyricsSourceId, refAudioSourceId].filter(
+                (v): v is string => !!v,
+            ),
+        [tagsSourceId, lyricsSourceId, refAudioSourceId],
     );
     const upstreamNodes = useNodesData(upstreamIds);
 
@@ -191,6 +207,13 @@ const TextGenMusicNode = ({ selected, data }: TextGenMusicNodeProps) => {
         if (!n || n.type !== "textNode") return null;
         return coerceBaseNodeData(n.data).texts?.[0] ?? "";
     }, [lyricsSourceId, upstreamNodes]);
+
+    const refAudioKey = useMemo(() => {
+        if (!refAudioSourceId) return undefined;
+        const n = upstreamNodes.find((u) => u.id === refAudioSourceId);
+        if (!n || n.type !== "audioNode") return undefined;
+        return coerceBaseNodeData(n.data).fileKeys?.[0];
+    }, [refAudioSourceId, upstreamNodes]);
 
     const tagsLocal = (form.state.tags as string | undefined) ?? "";
     const lyricsLocal = (form.state.lyrics as string | undefined) ?? "";
@@ -426,6 +449,19 @@ const TextGenMusicNode = ({ selected, data }: TextGenMusicNodeProps) => {
                         </div>
                     </div>
                 </Card>
+
+                {refAudioKey && (
+                    <Card className="p-3">
+                        <Label className="text-sm font-medium text-muted-foreground mb-2 block">
+                            {t("music.referenceAudio")}
+                        </Label>
+                        <MediaThumbnail
+                            fileKey={refAudioKey}
+                            label={t("music.referenceAudio")}
+                            type="audio"
+                        />
+                    </Card>
+                )}
             </div>
 
             {tagsExpanded && (

--- a/src/generated/abi/index.ts
+++ b/src/generated/abi/index.ts
@@ -1211,6 +1211,23 @@ const _slot_gen_music_inputs = {
         seed: {
             type: "integer",
         },
+        ref_audio: {
+            type: "object",
+            required: ["bytesBase64"],
+            properties: {
+                bytesBase64: {
+                    type: "string",
+                    minLength: 1,
+                },
+                filename: {
+                    type: "string",
+                },
+                mime: {
+                    type: "string",
+                },
+            },
+            additionalProperties: false,
+        },
     },
     additionalProperties: false,
 } as const;
@@ -4262,6 +4279,9 @@ export const ABI_NODES = {
                 },
                 seed: {
                     type: "integer",
+                },
+                ref_audio: {
+                    $ref: "#/$defs/Asset",
                 },
             },
             additionalProperties: false,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -609,6 +609,7 @@
             "music": {
                 "handleStyle": "Style",
                 "handleLyric": "Lyrics",
+                "referenceAudio": "Reference audio",
                 "inputLyrics": "Input Lyrics",
                 "audioDuration": "Audio Duration",
                 "currentDuration": "Current Duration:",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -609,6 +609,7 @@
             "music": {
                 "handleStyle": "スタイル",
                 "handleLyric": "歌詞",
+                "referenceAudio": "参照音声",
                 "inputLyrics": "歌詞を入力",
                 "fromUpstreamReadonly": "上流から（読み取り専用）",
                 "lyricsPlaceholder": "歌詞入力未接続時に入力",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -609,6 +609,7 @@
             "music": {
                 "handleStyle": "스타일",
                 "handleLyric": "가사",
+                "referenceAudio": "참조 오디오",
                 "inputLyrics": "가사 입력",
                 "audioDuration": "오디오 길이",
                 "currentDuration": "현재 길이:",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -609,6 +609,7 @@
             "music": {
                 "handleStyle": "曲风",
                 "handleLyric": "歌词",
+                "referenceAudio": "参考音频",
                 "inputLyrics": "输入歌词",
                 "audioDuration": "音频时长",
                 "currentDuration": "当前时长:",


### PR DESCRIPTION
## Summary

- Add an optional `ref_audio` Asset input to the `gen-music` ABI slot — the music node can now be conditioned on a reference track connected from an audio node.
- The `in:ref_audio` handle, connection validation, workflow export, and server-side asset materialization are all schema-driven; the node UI adds a thumbnail preview when connected (i18n: en/zh/ja/ko).
- SDK **0.2.1** published to PyPI with the regenerated `GenMusicInput` model (`ref_audio: Asset | None`).
- Plugins (deployed to Modal, pins bumped to `tongflow==0.2.1`):
  - **ace-step**: threads the temp-file path into `GenerationParams.reference_audio` (style-transfer conditioning under `text2music`, no task_type change needed) — [tong-io/tongflow-modal-ace-step@98d5b27](https://github.com/tong-io/tongflow-modal-ace-step/commit/98d5b27)
  - **levo**: loads the clip as `melody_wavs` (resampled, clipped to the upstream 10 s prompt convention)

## Test plan

- [x] `pnpm gen:abi` diff limited to gen-music inputs
- [x] `pnpm lint:check` / `pnpm typecheck` / `pnpm build`
- [x] `cd sdk && pytest` (37 passed)
- [x] Both plugins redeployed on Modal against SDK 0.2.1
- [ ] Canvas E2E: audio node → `in:ref_audio` → generate with each plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)