### PR TITLE
feat(audio): audio-describe slot, canvas node, and smart-island action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Audio understanding** — new `audio-describe` ABI slot and canvas node:
+  select an audio node and hit **Describe** on the smart island to get a
+  natural-language description of the clip (genre, mood, instruments,
+  vocals, events), with an optional custom prompt. Implemented by three
+  official plugins: **Gemini** (native audio in `generateContent`),
+  **Agnes** (`agnes-2.0-flash`, OpenAI-style `input_audio` part), and
+  **Gemma 4** (GPU, existing multimodal pipeline). Requires
+  `tongflow==0.2.2`.
 - **Reference audio for music generation** — the music node (`gen-music`)
   gains an optional `ref_audio` input handle: connect an audio node to
   condition the song on a reference track. ACE-Step uses it for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Audio understanding** — new `audio-describe` ABI slot and canvas node:
   select an audio node and hit **Describe** on the smart island to get a
   natural-language description of the clip (genre, mood, instruments,
-  vocals, events), with an optional custom prompt. Implemented by three
+  vocals, events), with an optional custom prompt. Implemented by four
   official plugins: **Gemini** (native audio in `generateContent`),
-  **Agnes** (`agnes-2.0-flash`, OpenAI-style `input_audio` part), and
-  **Gemma 4** (GPU, existing multimodal pipeline). Requires
-  `tongflow==0.2.2`.
+  **OpenAI** (`gpt-audio` via `input_audio` part), **Agnes**
+  (`agnes-2.0-flash`, `input_audio` part), and **Gemma 4** (GPU, existing
+  multimodal pipeline). Requires `tongflow==0.2.2`.
 - **Reference audio for music generation** — the music node (`gen-music`)
   gains an optional `ref_audio` input handle: connect an audio node to
   condition the song on a reference track. ACE-Step uses it for

--- a/config/tongflow.abi.json
+++ b/config/tongflow.abi.json
@@ -1191,6 +1191,41 @@
             }
         },
         {
+            "nodeSlot": "audio-describe",
+            "inputs": {
+                "type": "object",
+                "required": ["audio"],
+                "properties": {
+                    "text": {
+                        "type": "string"
+                    },
+                    "userPrompt": {
+                        "type": "string"
+                    },
+                    "audio": {
+                        "$ref": "#/$defs/Asset"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "outputs": {
+                "type": "object",
+                "required": ["success"],
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "error": {
+                        "type": "string"
+                    },
+                    "text": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        {
             "nodeSlot": "audio-image-gen-video",
             "inputs": {
                 "type": "object",

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tongflow"
-version = "0.2.1"
+version = "0.2.2"
 description = "Python SDK for TongFlow — author plugins and run multi-modal GenAI workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/tongflow/__init__.py
+++ b/sdk/tongflow/__init__.py
@@ -11,6 +11,6 @@ from .deploy_marker import deploy
 from .engine import run_workflow
 from .progress import progress
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = ["deploy", "progress", "run_workflow"]

--- a/sdk/tongflow/_data/tongflow.abi.json
+++ b/sdk/tongflow/_data/tongflow.abi.json
@@ -1191,6 +1191,41 @@
             }
         },
         {
+            "nodeSlot": "audio-describe",
+            "inputs": {
+                "type": "object",
+                "required": ["audio"],
+                "properties": {
+                    "text": {
+                        "type": "string"
+                    },
+                    "userPrompt": {
+                        "type": "string"
+                    },
+                    "audio": {
+                        "$ref": "#/$defs/Asset"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "outputs": {
+                "type": "object",
+                "required": ["success"],
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "error": {
+                        "type": "string"
+                    },
+                    "text": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        {
             "nodeSlot": "audio-image-gen-video",
             "inputs": {
                 "type": "object",

--- a/sdk/tongflow/models/audio_describe.py
+++ b/sdk/tongflow/models/audio_describe.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from .asset import Asset, AudioRef, FileRef, ImageRef, ModelRef, VideoRef
+
+
+class AudioDescribeInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    audio: Asset
+    text: str | None = None
+    userPrompt: str | None = None
+
+class AudioDescribeOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    success: bool
+    error: str | None = None
+    text: str | None = None
+

--- a/sdk/tongflow/node_slots.py
+++ b/sdk/tongflow/node_slots.py
@@ -46,6 +46,7 @@ class NodeSlots:
     VIDEO_EDIT: Final[str] = 'video-edit'
     IMAGE_DESCRIBE: Final[str] = 'image-describe'
     VIDEO_DESCRIBE: Final[str] = 'video-describe'
+    AUDIO_DESCRIBE: Final[str] = 'audio-describe'
     AUDIO_IMAGE_GEN_VIDEO: Final[str] = 'audio-image-gen-video'
     SPEECH_TEXT_GEN_VIDEO: Final[str] = 'speech-text-gen-video'
     VIDEO_IMAGE_GEN_VIDEO_MIX: Final[str] = 'video-image-gen-video-mix'
@@ -97,6 +98,7 @@ ALL_NODE_SLOTS: Final[tuple[str, ...]] = (
     'video-edit',
     'image-describe',
     'video-describe',
+    'audio-describe',
     'audio-image-gen-video',
     'speech-text-gen-video',
     'video-image-gen-video-mix',

--- a/src/components/workspace/nodes/transfer/audio-describe.tsx
+++ b/src/components/workspace/nodes/transfer/audio-describe.tsx
@@ -1,0 +1,48 @@
+import { Music as AudioIcon, MessageSquare } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { memo } from "react";
+
+import { useAbiForm } from "@/hooks/use-abi-form";
+import { batchOn } from "@/lib/abi/sources";
+import type { TongflowPluginNodeProps } from "@/types/tongflow-flow";
+
+import { AbiNodeShell } from "../base/abi-node-shell";
+import { NodeTextarea } from "../base/node-textarea";
+
+const AudioDescribeNode = ({
+    selected,
+    data,
+}: TongflowPluginNodeProps<"audio-describe", "audioDescribeNode">) => {
+    const t = useTranslations("Workspace.nodes");
+    const form = useAbiForm("audio-describe");
+    const fileKeys = data.fileKeys ?? [];
+
+    return (
+        <AbiNodeShell
+            feature="audio-describe"
+            sourceSpec={{ audio: batchOn() }}
+            form={form}
+            selected={selected}
+            className="min-w-[480px]"
+            data={data}
+            title={t("titles.audioDescribe")}
+            icon={<AudioIcon className="h-5 w-5" />}
+            executeLabel={t("actions.describeAudio")}
+            executeDisabled={!fileKeys?.length}
+        >
+            <div className="p-4 space-y-4">
+                <NodeTextarea
+                    label={t("audioDescribe.promptLabel")}
+                    icon={MessageSquare}
+                    placeholder={t("audioDescribe.promptPlaceholder")}
+                    {...form.bind("text")}
+                    rows={3}
+                />
+            </div>
+        </AbiNodeShell>
+    );
+};
+
+AudioDescribeNode.displayName = "AudioDescribeNode";
+
+export default memo(AudioDescribeNode);

--- a/src/components/workspace/types.tsx
+++ b/src/components/workspace/types.tsx
@@ -49,6 +49,7 @@ import LinkNode from "./nodes/modality/link-node";
 import ModelNode from "./nodes/modality/model-node";
 import TextNode from "./nodes/modality/text-node";
 import VideoNode from "./nodes/modality/video-node";
+import AudioDescribeNode from "./nodes/transfer/audio-describe";
 import AudioGenTextSpeechRecognizeNode from "./nodes/transfer/audio-gen-text-speech-recognize";
 import ConvertVoiceNode from "./nodes/transfer/convert-voice";
 import DenoiseAudioNode from "./nodes/transfer/denoise-audio";
@@ -129,6 +130,7 @@ export const NODE_TYPES: NodeTypes = {
     separateAudioTrackNode: SeparateAudioTrackNode,
     separateSpeakerNode: SeparateSpeakerNode,
     convertVoiceNode: ConvertVoiceNode,
+    audioDescribeNode: AudioDescribeNode,
     imageGenTextNode: ImageGenTextNode,
     videoGenTextNode: VideoGenTextNode,
     videoGenTextSpeechRecognizeNode: VideoGenTextSpeechRecognizeNode,
@@ -220,6 +222,7 @@ export const NODE_CATEGORIES = {
         "separateAudioTrackNode",
         "separateSpeakerNode",
         "convertVoiceNode",
+        "audioDescribeNode",
         "imageGenTextNode",
         "videoGenTextNode",
         "videoGenTextSpeechRecognizeNode",

--- a/src/generated/abi/index.ts
+++ b/src/generated/abi/index.ts
@@ -1780,6 +1780,57 @@ export type VideoDescribeOutput = FromSchema<
     typeof _slot_video_describe_outputs
 >;
 
+const _slot_audio_describe_inputs = {
+    type: "object",
+    required: ["audio"],
+    properties: {
+        text: {
+            type: "string",
+        },
+        userPrompt: {
+            type: "string",
+        },
+        audio: {
+            type: "object",
+            required: ["bytesBase64"],
+            properties: {
+                bytesBase64: {
+                    type: "string",
+                    minLength: 1,
+                },
+                filename: {
+                    type: "string",
+                },
+                mime: {
+                    type: "string",
+                },
+            },
+            additionalProperties: false,
+        },
+    },
+    additionalProperties: false,
+} as const;
+export type AudioDescribeInput = FromSchema<typeof _slot_audio_describe_inputs>;
+const _slot_audio_describe_outputs = {
+    type: "object",
+    required: ["success"],
+    properties: {
+        success: {
+            type: "boolean",
+        },
+        error: {
+            type: "string",
+        },
+        text: {
+            type: "string",
+        },
+    },
+    additionalProperties: false,
+} as const;
+export type AudioDescribeOutput = FromSchema<
+    typeof _slot_audio_describe_outputs
+>;
+
 const _slot_audio_image_gen_video_inputs = {
     type: "object",
     required: ["image", "audio"],
@@ -3320,6 +3371,7 @@ export type NodeSlot =
     | "video-edit"
     | "image-describe"
     | "video-describe"
+    | "audio-describe"
     | "audio-image-gen-video"
     | "speech-text-gen-video"
     | "video-image-gen-video-mix"
@@ -3371,6 +3423,7 @@ export type SlotInputsMap = {
     "video-edit": VideoEditInput;
     "image-describe": ImageDescribeInput;
     "video-describe": VideoDescribeInput;
+    "audio-describe": AudioDescribeInput;
     "audio-image-gen-video": AudioImageGenVideoInput;
     "speech-text-gen-video": SpeechTextGenVideoInput;
     "video-image-gen-video-mix": VideoImageGenVideoMixInput;
@@ -3422,6 +3475,7 @@ export type SlotOutputsMap = {
     "video-edit": VideoEditOutput;
     "image-describe": ImageDescribeOutput;
     "video-describe": VideoDescribeOutput;
+    "audio-describe": AudioDescribeOutput;
     "audio-image-gen-video": AudioImageGenVideoOutput;
     "speech-text-gen-video": SpeechTextGenVideoOutput;
     "video-image-gen-video-mix": VideoImageGenVideoMixOutput;
@@ -4595,6 +4649,40 @@ export const ABI_NODES = {
                     type: "string",
                 },
                 video: {
+                    $ref: "#/$defs/Asset",
+                },
+            },
+            additionalProperties: false,
+        },
+        outputs: {
+            type: "object",
+            required: ["success"],
+            properties: {
+                success: {
+                    type: "boolean",
+                },
+                error: {
+                    type: "string",
+                },
+                text: {
+                    type: "string",
+                },
+            },
+            additionalProperties: false,
+        },
+    },
+    "audio-describe": {
+        inputs: {
+            type: "object",
+            required: ["audio"],
+            properties: {
+                text: {
+                    type: "string",
+                },
+                userPrompt: {
+                    type: "string",
+                },
+                audio: {
                     $ref: "#/$defs/Asset",
                 },
             },

--- a/src/hooks/use-node-actions.tsx
+++ b/src/hooks/use-node-actions.tsx
@@ -656,6 +656,15 @@ export function useNodeActions(args: UseNodeActionsArgs): UseNodeActionsResult {
                     <ActionItem
                         buttons={[
                             {
+                                text: t("describeReverse"),
+                                id: "desc-audio",
+                                nodeType: "audioDescribeNode",
+                                onClick: () =>
+                                    expands(id, [
+                                        { type: "audioDescribeNode", data },
+                                    ]),
+                            },
+                            {
                                 text: t("speechRecognize"),
                                 nodeType: "audioGenTextSpeechRecognizeNode",
                                 onClick: () =>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -357,6 +357,7 @@
                         "video-upscale": "Video upscale",
                         "image-describe": "Image understanding",
                         "video-describe": "Video understanding",
+                        "audio-describe": "Audio understanding",
                         "audio-image-gen-video": "Speech+image to video",
                         "speech-text-gen-video": "Speech+text to video",
                         "video-image-gen-video-mix": "Video+image mix",
@@ -437,6 +438,7 @@
                 "removeWatermark": "Remove Watermark",
                 "separateAudio": "Split Audio & Video",
                 "imageGenText": "Image Description",
+                "audioDescribe": "Audio Description",
                 "imageGenImage": "Image Edit",
                 "videoEdit": "Video Edit",
                 "imageGenModel": "Image to 3D Model",
@@ -492,6 +494,7 @@
                 "compressVideo": "Compress Video",
                 "extractAudio": "Start Split",
                 "describeImage": "Describe Image",
+                "describeAudio": "Describe Audio",
                 "editImage": "Edit Image",
                 "editVideo": "Edit Video",
                 "generate3DModel": "Generate 3D Model",
@@ -740,6 +743,10 @@
             "imageGenText": {
                 "promptLabel": "Custom Prompt",
                 "promptPlaceholder": "Leave empty for default prompt, or enter custom instructions, e.g.: Describe the main subject, style, or on-image text..."
+            },
+            "audioDescribe": {
+                "promptLabel": "Custom Prompt",
+                "promptPlaceholder": "Leave empty for default prompt, or enter custom instructions, e.g.: Describe the genre, mood, instruments, or vocals..."
             },
             "textGenText": {
                 "instructions": "Instructions"

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -357,6 +357,7 @@
                         "video-upscale": "動画アップスケール",
                         "image-describe": "画像理解",
                         "video-describe": "動画理解",
+                        "audio-describe": "音声理解",
                         "audio-image-gen-video": "音声+画像から動画",
                         "speech-text-gen-video": "音声+テキストから動画",
                         "video-image-gen-video-mix": "動画+画像ミックス",
@@ -437,6 +438,7 @@
                 "removeWatermark": "透かし削除",
                 "separateAudio": "映像・音声の分離",
                 "imageGenText": "画像説明",
+                "audioDescribe": "音声理解",
                 "imageGenImage": "画像編集",
                 "videoEdit": "動画編集",
                 "imageGenModel": "画像から3Dモデル",
@@ -492,6 +494,7 @@
                 "compressVideo": "動画を圧縮",
                 "extractAudio": "分離を開始",
                 "describeImage": "画像を説明",
+                "describeAudio": "音声を説明",
                 "editImage": "画像を編集",
                 "editVideo": "動画を編集",
                 "generate3DModel": "3Dモデルを生成",
@@ -654,6 +657,10 @@
             "imageGenText": {
                 "promptLabel": "カスタムプロンプト",
                 "promptPlaceholder": "デフォルトを使う場合は空白のまま。例：被写体・雰囲気・画像内の文字のみを説明..."
+            },
+            "audioDescribe": {
+                "promptLabel": "カスタムプロンプト",
+                "promptPlaceholder": "空欄でデフォルトプロンプトを使用。ジャンル・雰囲気・楽器・ボーカルの説明など、カスタム指示も入力可能…"
             },
             "textGenText": {
                 "instructions": "指示"

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -357,6 +357,7 @@
                         "video-upscale": "비디오 업스케일",
                         "image-describe": "이미지 이해",
                         "video-describe": "비디오 이해",
+                        "audio-describe": "오디오 이해",
                         "audio-image-gen-video": "음성+이미지-비디오",
                         "speech-text-gen-video": "음성+텍스트-비디오",
                         "video-image-gen-video-mix": "비디오+이미지 믹스",
@@ -437,6 +438,7 @@
                 "removeWatermark": "워터마크 제거",
                 "separateAudio": "오디오 & 비디오 분리",
                 "imageGenText": "이미지 설명",
+                "audioDescribe": "오디오 이해",
                 "imageGenImage": "이미지 편집",
                 "videoEdit": "비디오 편집",
                 "imageGenModel": "이미지-3D 모델",
@@ -492,6 +494,7 @@
                 "compressVideo": "비디오 압축",
                 "extractAudio": "분리 시작",
                 "describeImage": "이미지 설명",
+                "describeAudio": "오디오 설명",
                 "editImage": "이미지 편집",
                 "editVideo": "비디오 편집",
                 "generate3DModel": "3D 모델 생성",
@@ -740,6 +743,10 @@
             "imageGenText": {
                 "promptLabel": "사용자 정의 프롬프트",
                 "promptPlaceholder": "기본 프롬프트는 비워 두거나 사용자 정의 지시 사항을 입력하세요. 예: 주요 피사체, 스타일 또는 이미지 내 텍스트 설명..."
+            },
+            "audioDescribe": {
+                "promptLabel": "커스텀 프롬프트",
+                "promptPlaceholder": "비워 두면 기본 프롬프트를 사용합니다. 장르, 분위기, 악기, 보컬 설명 등 커스텀 지시를 입력할 수도 있습니다…"
             },
             "textGenText": {
                 "instructions": "지시 사항"

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -357,6 +357,7 @@
                         "video-upscale": "视频超分",
                         "image-describe": "图像理解",
                         "video-describe": "视频理解",
+                        "audio-describe": "音频理解",
                         "audio-image-gen-video": "语音+图生视频",
                         "speech-text-gen-video": "语音+文生视频",
                         "video-image-gen-video-mix": "视频+图混合",
@@ -437,6 +438,7 @@
                 "removeWatermark": "去除水印",
                 "separateAudio": "音视频分离",
                 "imageGenText": "反推描述",
+                "audioDescribe": "音频理解",
                 "imageGenImage": "图片编辑",
                 "videoEdit": "视频编辑",
                 "imageGenModel": "图片生成3D模型",
@@ -492,6 +494,7 @@
                 "compressVideo": "压缩视频",
                 "extractAudio": "开始分离",
                 "describeImage": "描述图片",
+                "describeAudio": "描述音频",
                 "editImage": "编辑图片",
                 "editVideo": "编辑视频",
                 "generate3DModel": "生成3D模型",
@@ -740,6 +743,10 @@
             "imageGenText": {
                 "promptLabel": "自定义提示词",
                 "promptPlaceholder": "留空使用默认提示词，或输入自定义指令，例如：只描述画面主体、风格、文字内容..."
+            },
+            "audioDescribe": {
+                "promptLabel": "自定义提示词",
+                "promptPlaceholder": "留空使用默认提示词，或输入自定义指令，例如：描述这段音频的曲风、情绪、乐器或人声…"
             },
             "textGenText": {
                 "instructions": "指令"

--- a/src/lib/abi/node-feature-registry.ts
+++ b/src/lib/abi/node-feature-registry.ts
@@ -54,6 +54,7 @@ export const NODE_TYPE_TO_ABI_FEATURE: Readonly<Record<string, NodeSlot>> = {
     separateAudioTrackNode: "separate_audio_track",
     separateSpeakerNode: "separate_speaker",
     convertVoiceNode: "convert_voice",
+    audioDescribeNode: "audio-describe",
     imageGenTextNode: "image-gen-text",
     videoGenTextNode: "video-gen-text",
     videoGenTextSpeechRecognizeNode: "transcribe",


### PR DESCRIPTION
## Summary

> Stacked on #69 (`feat/gen-music-ref-audio`); will auto-retarget to `main` once that merges.

- New **`audio-describe`** ABI slot (`audio` + optional `text`/`userPrompt` → `text`), mirroring `image-describe` / `video-describe` — but with a **dedicated canvas node** (`audioDescribeNode`), which the image/video describe slots never got.
- **Smart island**: audio nodes gain a **Describe** button expanding to the new node. i18n for en/zh/ja/ko (titles, action, prompt field, feature display name).
- **SDK 0.2.2** published to PyPI (`AudioDescribeInput/Output`, `NodeSlots.AUDIO_DESCRIBE`).
- Implemented by four official plugins (each pushed to its own repo):
  - **Gemini** — audio as `inlineData` part in `generateContent`; also fixes the retired `gemini-2.0-flash` default (404 from Google) → `gemini-2.5-flash` ([tong-io/tongflow-api-gemini@6029229](https://github.com/tong-io/tongflow-api-gemini/commit/6029229))
  - **OpenAI** — `gpt-audio` via OpenAI-standard `input_audio` content part, dedicated handler with `OPENAI_AUDIO_MODEL` override ([tong-io/tongflow-api-openai@44c7f9c](https://github.com/tong-io/tongflow-api-openai/commit/44c7f9c))
- **Agnes** — OpenAI-style `input_audio` content part on `agnes-2.0-flash` ([tong-io/tongflow-api-agnes@73fdb07](https://github.com/tong-io/tongflow-api-agnes/commit/73fdb07))
  - **Gemma 4** — existing multimodal audio path, redeployed on Modal with `tongflow==0.2.2` ([tong-io/tongflow-modal-gemma4@abcc3df](https://github.com/tong-io/tongflow-modal-gemma4/commit/abcc3df))

## Test plan

- [x] `pnpm gen:abi` / `gen_models.py` / `gen_node_slots.py` regenerated
- [x] `pnpm lint:check` / `pnpm typecheck` / `pnpm build`
- [x] `cd sdk && pytest` (37 passed)
- [x] **Gemini live test**: synthetic WAV → accurate description ("continuous electronic beeping … ECG-like")
- [x] **OpenAI live test**: synthetic WAV → gpt-audio describes ambient electronic tones
- [x] Gemma 4 redeployed on Modal; remote smoke test
- [ ] Agnes live test (no `AGNES_API_KEY` in local env — statically verified against its own image-describe pattern)
- [ ] Canvas E2E: audio node → smart island **Describe** → run

🤖 Generated with [Claude Code](https://claude.com/claude-code)


