### PR TITLE
fix(ui): cap node prompt textarea height so long input scrolls

### DIFF
--- a/src/components/workspace/nodes/base/node-textarea.tsx
+++ b/src/components/workspace/nodes/base/node-textarea.tsx
@@ -459,7 +459,10 @@ const NodeTextarea = forwardRef<HTMLTextAreaElement, NodeTextareaProps>(
                         onClick={handleSelect}
                         onKeyUp={handleSelect}
                         className={cn(
-                            "resize-none",
+                            // field-sizing-content (ui/textarea) auto-grows with
+                            // input; cap it so long prompts scroll instead of
+                            // stretching the node. Callers may override via className.
+                            "resize-none max-h-40 overflow-y-auto",
                             hasButtons && "pr-12",
                             className,
                         )}


### PR DESCRIPTION
## Summary

Node prompt textareas (shared `NodeTextarea`, used by image/video/audio describe, image edit, and other transfer nodes) grew without bound as text got longer — the base `Textarea` uses `field-sizing-content` auto-sizing and nothing capped it, so the node kept stretching with no scrollbar. (The music node was unaffected only because it hand-rolls its own `max-h` on raw `Textarea`s.)

Cap the inline textarea at `max-h-40` (~8 lines) with `overflow-y-auto`. Callers can still override via `className` (tailwind-merge, caller classes win); the fullscreen editor dialog already had its own bounds.

## Test plan

- [x] `pnpm lint:check` / `pnpm typecheck`
- [ ] Canvas: type/paste a long prompt into a describe or edit node → box stops at ~8 lines and scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)