### PR TITLE
feat(cloud): extension seams for a cloud shell — tenant scope, storage driver, engine asset sink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,11 @@ __pycache__/
 !/plugins/.gitkeep
 
 .claude/
+
+# Cloud shell extension points: a private shell repo links its own
+# implementations into these paths at build time (see src/ext-default/ for
+# the open-source defaults). They must never be committed here.
+/src/ext/
+/src/app/(ext)/
+/src/middleware.ts
+/src/instrumentation.ts

--- a/sdk/tests/test_http_store.py
+++ b/sdk/tests/test_http_store.py
@@ -1,0 +1,76 @@
+"""HttpStore round-trip against a minimal in-process HTTP sink."""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from tongflow.engine.store import HttpStore
+
+TOKEN = "test-token"
+
+
+class _Sink(BaseHTTPRequestHandler):
+    blobs: dict[str, bytes] = {}
+    counter = 0
+
+    def _authed(self) -> bool:
+        return self.headers.get("Authorization") == f"Bearer {TOKEN}"
+
+    def do_POST(self):  # noqa: N802
+        if not self._authed():
+            self.send_error(401)
+            return
+        qs = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+        ext = (qs.get("ext") or ["bin"])[0]
+        length = int(self.headers.get("Content-Length", "0"))
+        data = self.rfile.read(length)
+        _Sink.counter += 1
+        file_key = f"tasks/t1/{_Sink.counter}.{ext}"
+        _Sink.blobs[file_key] = data
+        body = json.dumps({"file_key": file_key}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):  # noqa: N802
+        if not self._authed():
+            self.send_error(401)
+            return
+        qs = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+        key = (qs.get("file_key") or [""])[0]
+        blob = _Sink.blobs.get(key)
+        if blob is None:
+            self.send_error(404)
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.end_headers()
+        self.wfile.write(blob)
+
+    def log_message(self, *args):  # silence
+        pass
+
+
+def test_http_store_roundtrip():
+    server = HTTPServer(("127.0.0.1", 0), _Sink)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        endpoint = f"http://127.0.0.1:{server.server_address[1]}/assets"
+        store = HttpStore(endpoint, TOKEN)
+
+        ref = store.put(b"hello-bytes", mime="image/png", ext="png")
+        assert ref["file_key"].endswith(".png")
+        assert ref["mime"] == "image/png"
+
+        assert store.get(ref["file_key"]) == b"hello-bytes"
+        assert store.get("tasks/does-not-exist.png") is None
+        # URL-ish refs skip the sink entirely
+        assert store.get("https://example.com/x.png") is None
+        assert store.get("mem://abc") is None
+    finally:
+        server.shutdown()

--- a/sdk/tongflow/engine/__main__.py
+++ b/sdk/tongflow/engine/__main__.py
@@ -9,7 +9,8 @@ Request shape::
     {"workflow": <executable workflow dict>,
      "inputs": {<name>: ...},
      "options": {"plugins_dir", "data_dir", "out_dir", "abi_path",
-                 "file_key_base", "auto_install", "org", "task_id"}}
+                 "file_key_base", "inline_outputs", "asset_endpoint",
+                 "asset_token", "auto_install", "org", "task_id"}}
 
 The TongFlow desktop app uses this to delegate workflow execution to the SDK
 engine (one execution core) while keeping its own DB / SSE / abort shell. The
@@ -59,6 +60,8 @@ def main() -> int:
             abi_path=opts.get("abi_path"),
             file_key_base=opts.get("file_key_base"),
             inline_outputs=bool(opts.get("inline_outputs", True)),
+            asset_endpoint=opts.get("asset_endpoint"),
+            asset_token=opts.get("asset_token"),
             auto_install=bool(opts.get("auto_install", True)),
             org=opts.get("org") or "https://github.com/tong-io",
             plugin_git_urls=opts.get("plugin_git_urls"),

--- a/sdk/tongflow/engine/runner.py
+++ b/sdk/tongflow/engine/runner.py
@@ -37,7 +37,7 @@ from .plugins import (
     prepare_python_env,
     scan_manifest,
 )
-from .store import AssetStore, DiskStore, MemoryStore
+from .store import AssetStore, DiskStore, HttpStore, MemoryStore
 
 EventCb = Callable[[dict[str, Any]], None]
 
@@ -166,6 +166,8 @@ def run_workflow(
     abi_path: Optional[Union[str, Path]] = None,
     file_key_base: Optional[Union[str, Path]] = None,
     inline_outputs: bool = True,
+    asset_endpoint: Optional[str] = None,
+    asset_token: Optional[str] = None,
     auto_install: bool = True,
     org: str = DEFAULT_ORG,
     plugin_git_urls: Optional[dict[str, str]] = None,
@@ -191,6 +193,11 @@ def run_workflow(
             returned as ``{bytesBase64, mime?, filename?}`` — zero files written
             (besides the required plugin clone / venv). When False, outputs are
             written to ``out_dir`` and returned as ``file_key`` paths.
+        asset_endpoint / asset_token: host-managed asset store (loopback HTTP
+            sink, see :class:`~tongflow.engine.store.HttpStore`). When set it
+            overrides ``inline_outputs``: outputs are POSTed to the host and
+            input ``file_key`` refs are fetched from it — the engine touches
+            no asset files on disk.
         auto_install: clone missing plugins and provision a shared venv.
         org / plugin_git_urls: where to clone official / custom plugins from.
         on_progress: optional callback receiving progress event dicts.
@@ -212,9 +219,13 @@ def run_workflow(
     # Output store: in-memory (inline, zero disk) or on-disk (file_key paths,
     # used by the desktop delegation so the canvas reads via /api/uploads).
     out_path = Path(out_dir).resolve() if out_dir else (data_dir / "engine-out")
-    store: AssetStore = (
-        MemoryStore() if inline_outputs else DiskStore(out_path, fk_base)
-    )
+    store: AssetStore
+    if asset_endpoint:
+        store = HttpStore(asset_endpoint, asset_token)
+    elif inline_outputs:
+        store = MemoryStore()
+    else:
+        store = DiskStore(out_path, fk_base)
 
     def emit(event: dict[str, Any]) -> None:
         if on_progress is not None:

--- a/sdk/tongflow/engine/store.py
+++ b/sdk/tongflow/engine/store.py
@@ -7,6 +7,11 @@
   are written to ``out_dir`` and the ``file_key`` is a path (relative to
   ``file_key_base`` when set, else absolute), matching the server's
   ``saveFile`` contract so the canvas can read them via ``/api/uploads``.
+- :class:`HttpStore` (``asset_endpoint`` option): the embedding host owns
+  file storage (e.g. a cloud backend writing to object storage). ``put``
+  POSTs raw bytes over loopback HTTP and gets back the host-assigned
+  ``file_key``; ``get`` fetches bytes for any ``file_key`` the host knows.
+  The engine never sees storage credentials.
 
 ``get`` returns the bytes for a key the store owns, else ``None`` (so the
 filesystem/URL resolver in :mod:`assets` handles plain file_keys / URLs).
@@ -14,7 +19,11 @@ filesystem/URL resolver in :mod:`assets` handles plain file_keys / URLs).
 
 from __future__ import annotations
 
+import json
 import os
+import urllib.error
+import urllib.parse
+import urllib.request
 import uuid
 from pathlib import Path
 from typing import Optional, Protocol
@@ -94,3 +103,76 @@ class DiskStore:
     def get(self, file_key: str) -> Optional[bytes]:
         # Disk file_keys are resolved by the filesystem/URL resolver in assets.
         return None
+
+
+class HttpStore:
+    """Host-managed asset store over (loopback) HTTP.
+
+    The host exposes a single endpoint:
+
+    - ``POST <endpoint>?ext=..&mime=..&filename=..`` with raw bytes as the
+      body -> ``{"file_key": "..."}``
+    - ``GET <endpoint>?file_key=..`` -> raw bytes (404 when unknown)
+
+    Authentication is a Bearer token minted by the host per engine run.
+    """
+
+    # Refs the host sink cannot serve; skip the round trip and let the
+    # URL/data resolver in assets handle them.
+    _SKIP_PREFIXES = ("http://", "https://", "data:", "mem://")
+
+    def __init__(self, endpoint: str, token: Optional[str] = None) -> None:
+        self.endpoint = endpoint
+        self.token = token
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.token}"} if self.token else {}
+
+    def put(
+        self,
+        data: bytes,
+        *,
+        mime: Optional[str] = None,
+        filename: Optional[str] = None,
+        ext: str = "bin",
+    ) -> dict[str, str]:
+        params = {"ext": ext.lstrip(".") or "bin"}
+        if mime:
+            params["mime"] = mime
+        if filename:
+            params["filename"] = filename
+        req = urllib.request.Request(
+            f"{self.endpoint}?{urllib.parse.urlencode(params)}",
+            data=bytes(data),
+            method="POST",
+            headers={
+                "Content-Type": "application/octet-stream",
+                **self._headers(),
+            },
+        )
+        with urllib.request.urlopen(req) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+        file_key = payload.get("file_key")
+        if not isinstance(file_key, str) or not file_key:
+            raise RuntimeError("asset endpoint returned no file_key")
+        out: dict[str, str] = {"file_key": file_key}
+        if mime:
+            out["mime"] = mime
+        if filename:
+            out["filename"] = filename
+        return out
+
+    def get(self, file_key: str) -> Optional[bytes]:
+        if file_key.startswith(self._SKIP_PREFIXES):
+            return None
+        req = urllib.request.Request(
+            f"{self.endpoint}?{urllib.parse.urlencode({'file_key': file_key})}",
+            headers=self._headers(),
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return None
+            raise

--- a/src/app/api/engine-assets/route.ts
+++ b/src/app/api/engine-assets/route.ts
@@ -1,0 +1,66 @@
+/**
+ * Loopback asset sink for the SDK engine (see HttpStore in the Python SDK).
+ *
+ * GET  ?file_key=...                 -> raw bytes (404 when unknown)
+ * POST ?ext=...&mime=...&filename=.. -> {"file_key": "..."}
+ *
+ * Auth: a per-run bearer token minted by the engine delegate, bound to the
+ * run's tenant scope and taskId. Storage goes through the registered
+ * storage driver, so with a remote driver the engine's files never touch
+ * the local disk.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { getStorage } from "@/lib/file/storage.server";
+import { runWithScope } from "@/lib/runtime/scope.server";
+import { bindingForEngineAssetToken } from "@/lib/task/engine-asset-tokens.server";
+
+function bindingFrom(request: NextRequest) {
+    const header = request.headers.get("authorization") ?? "";
+    const token = header.startsWith("Bearer ") ? header.slice(7) : "";
+    return token ? bindingForEngineAssetToken(token) : null;
+}
+
+export async function GET(request: NextRequest) {
+    const binding = bindingFrom(request);
+    if (!binding) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const fileKey = request.nextUrl.searchParams.get("file_key");
+    if (!fileKey) {
+        return NextResponse.json(
+            { error: "file_key is required" },
+            { status: 400 },
+        );
+    }
+    try {
+        const buffer = await runWithScope(binding.scope, () =>
+            getStorage().readFile(fileKey),
+        );
+        return new NextResponse(new Uint8Array(buffer), {
+            headers: { "Content-Type": "application/octet-stream" },
+        });
+    } catch {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+}
+
+export async function POST(request: NextRequest) {
+    const binding = bindingFrom(request);
+    if (!binding) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const ext = request.nextUrl.searchParams.get("ext") ?? "bin";
+    const data = Buffer.from(await request.arrayBuffer());
+    try {
+        const fileKey = await runWithScope(binding.scope, () =>
+            getStorage().saveFile(data, ext, binding.taskId),
+        );
+        return NextResponse.json({ file_key: fileKey });
+    } catch {
+        return NextResponse.json(
+            { error: "Failed to store asset" },
+            { status: 500 },
+        );
+    }
+}

--- a/src/app/api/settings/env/route.ts
+++ b/src/app/api/settings/env/route.ts
@@ -16,7 +16,7 @@ export const runtime = "nodejs";
  */
 export async function GET() {
     return NextResponse.json(
-        { env: loadEnvStore(), pluginEnv: loadPluginEnvDecls() },
+        { env: await loadEnvStore(), pluginEnv: loadPluginEnvDecls() },
         { headers: { "Cache-Control": "no-store" } },
     );
 }
@@ -51,6 +51,6 @@ export async function PUT(request: NextRequest) {
         if (typeof v === "string") env[k] = v;
     }
 
-    saveEnvStore(env);
-    return NextResponse.json({ env: loadEnvStore() });
+    await saveEnvStore(env);
+    return NextResponse.json({ env: await loadEnvStore() });
 }

--- a/src/app/api/task/wait/route.ts
+++ b/src/app/api/task/wait/route.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from "next/server";
 import { isTerminalStatus } from "@/constants/task-status";
 import { jsonStringifyForSse } from "@/lib/json-sse";
 import { logger } from "@/lib/logger";
+import { getScope, runWithScope } from "@/lib/runtime/scope.server";
 import { isTaskRunning, onTaskEvent, type TaskEvent } from "@/lib/task/emitter";
 import { dispatchTask } from "@/lib/task/runner";
 
@@ -30,6 +31,10 @@ export async function GET(request: NextRequest) {
     }
 
     const encoder = new TextEncoder();
+
+    // Resolve the tenant scope while the request context is still available;
+    // the execution below outlives it, so pin the scope via ALS.
+    const scope = await getScope();
 
     const stream = new ReadableStream({
         start(controller) {
@@ -85,30 +90,32 @@ export async function GET(request: NextRequest) {
 
             // Non-reconnect mode: start task execution
             if (!reconnect) {
-                dispatchTask(taskId).catch((error) => {
-                    logger.error(
-                        `[SSE] Failed to start task ${taskId}:`,
-                        error,
-                    );
-                    if (!closed) {
-                        try {
-                            const errEvent = jsonStringifyForSse({
-                                id: taskId,
-                                status: "FAILED",
-                                data: {
-                                    message: "Task failed to start",
-                                    error: String(error),
-                                },
-                            });
-                            controller.enqueue(
-                                encoder.encode(`data: ${errEvent}\n\n`),
-                            );
-                        } catch {
-                            // ignore
+                runWithScope(scope, () => dispatchTask(taskId)).catch(
+                    (error) => {
+                        logger.error(
+                            `[SSE] Failed to start task ${taskId}:`,
+                            error,
+                        );
+                        if (!closed) {
+                            try {
+                                const errEvent = jsonStringifyForSse({
+                                    id: taskId,
+                                    status: "FAILED",
+                                    data: {
+                                        message: "Task failed to start",
+                                        error: String(error),
+                                    },
+                                });
+                                controller.enqueue(
+                                    encoder.encode(`data: ${errEvent}\n\n`),
+                                );
+                            } catch {
+                                // ignore
+                            }
+                            close();
                         }
-                        close();
-                    }
-                });
+                    },
+                );
             }
         },
     });

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,17 +1,13 @@
 /**
  * POST /api/upload
- * Local file upload endpoint.
- * Saves files to data/uploads/ directory.
+ * File upload endpoint. Persists via the storage driver (local disk by
+ * default, under the scoped uploads directory).
  */
 
-import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { nanoid } from "nanoid";
 import { type NextRequest, NextResponse } from "next/server";
+import { getStorage } from "@/lib/file/storage.server";
 import { logger } from "@/lib/logger";
-import { dataDir } from "@/lib/runtime/paths.server";
-
-const UPLOAD_DIR = path.join(dataDir(), "uploads");
 
 export async function POST(request: NextRequest) {
     try {
@@ -25,17 +21,9 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        // Generate unique file key
-        const ext = path.extname(file.name) || "";
-        const fileKey = `${nanoid()}${ext}`;
-
-        // Ensure upload directory exists
-        await mkdir(UPLOAD_DIR, { recursive: true });
-
-        // Write file to disk
-        const filePath = path.join(UPLOAD_DIR, fileKey);
+        const ext = path.extname(file.name).replace(/^\./, "");
         const buffer = Buffer.from(await file.arrayBuffer());
-        await writeFile(filePath, buffer);
+        const fileKey = await getStorage().saveFile(buffer, ext);
 
         const url = `/api/uploads/${fileKey}`;
 

--- a/src/app/api/uploads/[...path]/route.ts
+++ b/src/app/api/uploads/[...path]/route.ts
@@ -1,14 +1,11 @@
 /**
  * GET /api/uploads/[...path]
- * Serve uploaded files from local storage.
+ * Serve uploaded files via the storage driver (local disk by default).
  */
 
-import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { type NextRequest, NextResponse } from "next/server";
-import { dataDir } from "@/lib/runtime/paths.server";
-
-const UPLOAD_DIR = path.join(dataDir(), "uploads");
+import { getStorage } from "@/lib/file/storage.server";
 
 const MIME_TYPES: Record<string, string> = {
     ".jpg": "image/jpeg",
@@ -39,18 +36,10 @@ export async function GET(
 ) {
     try {
         const { path: pathSegments } = await params;
-        const filePath = path.join(UPLOAD_DIR, ...pathSegments);
+        const fileKey = pathSegments.join("/");
 
-        // Prevent directory traversal
-        if (!filePath.startsWith(UPLOAD_DIR)) {
-            return NextResponse.json(
-                { error: "Invalid path" },
-                { status: 400 },
-            );
-        }
-
-        const buffer = await readFile(filePath);
-        const ext = path.extname(filePath).toLowerCase();
+        const buffer = await getStorage().readFile(fileKey);
+        const ext = path.extname(fileKey).toLowerCase();
         const contentType = MIME_TYPES[ext] || "application/octet-stream";
 
         return new NextResponse(new Uint8Array(buffer), {

--- a/src/app/api/uploads/[...path]/route.ts
+++ b/src/app/api/uploads/[...path]/route.ts
@@ -37,8 +37,21 @@ export async function GET(
     try {
         const { path: pathSegments } = await params;
         const fileKey = pathSegments.join("/");
+        const driver = getStorage();
 
-        const buffer = await getStorage().readFile(fileKey);
+        // Remote drivers can hand out a directly-fetchable URL (e.g. a
+        // presigned object-storage URL) so media bytes bypass the app.
+        const directUrl = await driver.publicUrl?.(fileKey);
+        if (directUrl) {
+            return NextResponse.redirect(directUrl, {
+                status: 302,
+                // Shorter than the signed URL's TTL so cached redirects
+                // never point at an expired signature.
+                headers: { "Cache-Control": "private, max-age=3300" },
+            });
+        }
+
+        const buffer = await driver.readFile(fileKey);
         const ext = path.extname(fileKey).toLowerCase();
         const contentType = MIME_TYPES[ext] || "application/octet-stream";
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -4,14 +4,20 @@ import Database from "better-sqlite3";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
-import { dataDir, resourcesDir } from "@/lib/runtime/paths.server";
+import { resourcesDir } from "@/lib/runtime/paths.server";
+import { getScope, scopedDataDirFor } from "@/lib/runtime/scope.server";
 import * as schema from "./schema";
 
-let db: BetterSQLite3Database<typeof schema> | null = null;
+// One connection per tenant scope. The open-source build always resolves
+// scope "" and behaves exactly like the previous singleton; a cloud shell
+// gets an isolated, lazily-migrated SQLite db per user.
+const dbs = new Map<string, BetterSQLite3Database<typeof schema>>();
 
 export async function getDb() {
+    const scope = await getScope();
+    let db = dbs.get(scope);
     if (!db) {
-        const dbDir = dataDir();
+        const dbDir = scopedDataDirFor(scope);
         mkdirSync(dbDir, { recursive: true });
 
         const dbPath = path.join(dbDir, "tongflow.db");
@@ -22,6 +28,7 @@ export async function getDb() {
         migrate(db, {
             migrationsFolder: path.join(resourcesDir(), "drizzle"),
         });
+        dbs.set(scope, db);
     }
     return db;
 }

--- a/src/ext-default/scope.ts
+++ b/src/ext-default/scope.ts
@@ -1,0 +1,9 @@
+/**
+ * Default tenant-scope resolver: single-tenant, one shared data dir.
+ *
+ * A cloud shell substitutes its own `src/ext/scope.ts` (gitignored, linked in
+ * at build time) that maps the request session to a user id.
+ */
+export async function resolveScope(): Promise<string> {
+    return "";
+}

--- a/src/ext-default/settings-codec.ts
+++ b/src/ext-default/settings-codec.ts
@@ -1,0 +1,13 @@
+/**
+ * Default settings codec: settings.json is stored as plain JSON.
+ *
+ * A cloud shell substitutes its own `src/ext/settings-codec.ts` (gitignored,
+ * linked in at build time) to encrypt stored values (e.g. BYOK API keys).
+ */
+export async function encodeEnvStore(plaintext: string): Promise<string> {
+    return plaintext;
+}
+
+export async function decodeEnvStore(stored: string): Promise<string> {
+    return stored;
+}

--- a/src/lib/file/file-utils.ts
+++ b/src/lib/file/file-utils.ts
@@ -1,53 +1,31 @@
 /**
  * File utility functions
  *
- * Replaces R2 by saving files to the local data/uploads/ directory.
+ * Thin wrappers over the storage driver seam (`storage.server.ts`); the
+ * default driver saves files to the scoped local `uploads/` directory.
  */
 
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import path from "node:path";
-import { nanoid } from "nanoid";
-import { dataDir } from "@/lib/runtime/paths.server";
-
-const UPLOADS_DIR = path.join(dataDir(), "uploads");
+import { getStorage } from "@/lib/file/storage.server";
 
 /**
- * Read a file under `data/uploads/` by its fileKey (same as in {@link getFileUrl}).
- * Rejects path traversal.
+ * Read a file under the uploads root by its fileKey (same as in
+ * {@link getFileUrl}). Rejects path traversal.
  */
 export async function readUploadFileByFileKey(
     fileKey: string,
 ): Promise<Buffer> {
-    const normalized = fileKey.replace(/^\/+/, "").replace(/\\/g, "/");
-    const resolved = path.resolve(
-        UPLOADS_DIR,
-        ...normalized.split("/").filter(Boolean),
-    );
-    if (!resolved.startsWith(UPLOADS_DIR)) {
-        throw new Error("Invalid file key");
-    }
-    return readFile(resolved);
+    return getStorage().readFile(fileKey);
 }
 
 /**
- * Save byte data locally and return the fileKey
+ * Save byte data and return the fileKey
  */
 export async function saveFile(
     data: Buffer | Uint8Array,
     ext: string,
     taskId?: string,
 ): Promise<string> {
-    const dir = taskId ? path.join(UPLOADS_DIR, "tasks", taskId) : UPLOADS_DIR;
-
-    await mkdir(dir, { recursive: true });
-
-    const filename = `${nanoid()}.${ext}`;
-    const filePath = path.join(dir, filename);
-
-    await writeFile(filePath, data);
-
-    // Return the path relative to the uploads root directory as the fileKey
-    return path.relative(UPLOADS_DIR, filePath);
+    return getStorage().saveFile(data, ext, taskId);
 }
 
 /**

--- a/src/lib/file/storage.server.ts
+++ b/src/lib/file/storage.server.ts
@@ -72,13 +72,18 @@ const localDriver: StorageDriver = {
     },
 };
 
-let driver: StorageDriver = localDriver;
+// The registry lives on globalThis: instrumentation.ts (where shells
+// register their driver) is compiled as a separate bundle from route
+// handlers, so a module-level variable would not be shared between them.
+const DRIVER_KEY = Symbol.for("tongflow.storage.driver");
+
+type DriverGlobal = { [DRIVER_KEY]?: StorageDriver };
 
 /** Replace the storage backend (cloud shells call this at startup). */
 export function registerStorageDriver(next: StorageDriver): void {
-    driver = next;
+    (globalThis as DriverGlobal)[DRIVER_KEY] = next;
 }
 
 export function getStorage(): StorageDriver {
-    return driver;
+    return (globalThis as DriverGlobal)[DRIVER_KEY] ?? localDriver;
 }

--- a/src/lib/file/storage.server.ts
+++ b/src/lib/file/storage.server.ts
@@ -1,0 +1,72 @@
+import "server-only";
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { nanoid } from "nanoid";
+import { scopedDataDir } from "@/lib/runtime/scope.server";
+
+/**
+ * Storage driver seam.
+ *
+ * The default driver stores files on the local disk under the scoped uploads
+ * directory (`<scopedDataDir>/uploads/`) — the historical behavior. A cloud
+ * shell can register an alternative driver (e.g. R2 via the S3 API) from its
+ * instrumentation hook so media bytes never transit the app server.
+ */
+
+export interface StorageDriver {
+    /**
+     * Persist bytes and return the fileKey (path relative to the uploads
+     * root, e.g. `tasks/<taskId>/<id>.png`).
+     */
+    saveFile(
+        data: Buffer | Uint8Array,
+        ext: string,
+        taskId?: string,
+    ): Promise<string>;
+    /** Read bytes by fileKey. Throws on missing files and invalid keys. */
+    readFile(fileKey: string): Promise<Buffer>;
+}
+
+async function uploadsRoot(): Promise<string> {
+    return path.join(await scopedDataDir(), "uploads");
+}
+
+const localDriver: StorageDriver = {
+    async saveFile(data, ext, taskId) {
+        const root = await uploadsRoot();
+        const dir = taskId ? path.join(root, "tasks", taskId) : root;
+        await mkdir(dir, { recursive: true });
+
+        const filename = ext ? `${nanoid()}.${ext}` : nanoid();
+        const filePath = path.join(dir, filename);
+        await writeFile(filePath, data);
+
+        // The fileKey is the path relative to the uploads root.
+        return path.relative(root, filePath);
+    },
+
+    async readFile(fileKey) {
+        const root = await uploadsRoot();
+        const normalized = fileKey.replace(/^\/+/, "").replace(/\\/g, "/");
+        const resolved = path.resolve(
+            root,
+            ...normalized.split("/").filter(Boolean),
+        );
+        if (!resolved.startsWith(root)) {
+            throw new Error("Invalid file key");
+        }
+        return readFile(resolved);
+    },
+};
+
+let driver: StorageDriver = localDriver;
+
+/** Replace the storage backend (cloud shells call this at startup). */
+export function registerStorageDriver(next: StorageDriver): void {
+    driver = next;
+}
+
+export function getStorage(): StorageDriver {
+    return driver;
+}

--- a/src/lib/file/storage.server.ts
+++ b/src/lib/file/storage.server.ts
@@ -26,6 +26,18 @@ export interface StorageDriver {
     ): Promise<string>;
     /** Read bytes by fileKey. Throws on missing files and invalid keys. */
     readFile(fileKey: string): Promise<Buffer>;
+    /**
+     * True when files do not live on the local uploads dir. The engine
+     * delegate then routes the SDK engine's asset IO through the
+     * `/api/engine-assets` loopback sink instead of a local out_dir.
+     */
+    remote?: boolean;
+    /**
+     * Optional directly-fetchable URL for a fileKey (e.g. a presigned
+     * object-storage URL). The uploads route 302s to it when present;
+     * return null to stream bytes via the app instead.
+     */
+    publicUrl?(fileKey: string): Promise<string | null>;
 }
 
 async function uploadsRoot(): Promise<string> {

--- a/src/lib/plugin-executor/runners/generic.ts
+++ b/src/lib/plugin-executor/runners/generic.ts
@@ -8,6 +8,7 @@ import { ensurePluginPython } from "@/lib/plugins/plugin-python-env.server";
 import { getPluginConfig } from "@/lib/plugins/plugins-registry.server";
 import { PYTHON_UTF8_ENV } from "@/lib/plugins/python-lite";
 import { pluginsDir, resourcesDir } from "@/lib/runtime/paths.server";
+import { getScope, scopedDataDirFor } from "@/lib/runtime/scope.server";
 import { withStoredEnv } from "@/lib/settings/env-store.server";
 import { notifyTask } from "@/lib/task/emitter";
 import { parseProgressLine } from "../progress-protocol";
@@ -55,9 +56,20 @@ export async function execPlugin<S extends NodeSlot>(
         tongflowSdkDir,
         process.env.PYTHONPATH?.trim(),
     ].filter((x): x is string => Boolean(x));
-    const pythonEnv = withStoredEnv({
+    // In a scoped (cloud) run, point the Modal deploy cache into the user's
+    // data dir so needsDeploy plugins deploy into that user's own account.
+    const scope = await getScope();
+    const pythonEnv = await withStoredEnv({
         ...PYTHON_UTF8_ENV,
         PYTHONPATH: pythonPathParts.join(delimiter),
+        ...(scope
+            ? {
+                  TONGFLOW_MODAL_CACHE_DIR: join(
+                      scopedDataDirFor(scope),
+                      "modal-cache",
+                  ),
+              }
+            : {}),
     });
 
     const payload = {

--- a/src/lib/runtime/scope.server.ts
+++ b/src/lib/runtime/scope.server.ts
@@ -1,0 +1,47 @@
+import "server-only";
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import path from "node:path";
+import { resolveScope } from "@ext/scope";
+import { dataDir } from "./paths.server";
+
+/**
+ * Tenant scoping seam.
+ *
+ * The open-source build is single-tenant: `resolveScope()` (from `@ext/scope`,
+ * defaulting to `src/ext-default/scope.ts`) returns "" and `scopedDataDir()`
+ * is exactly `dataDir()`. A cloud shell links in its own `src/ext/scope.ts`
+ * that maps the request session to a user id, which gives every user an
+ * isolated data directory (`<dataDir>/users/<id>/`) — per-user SQLite,
+ * uploads and settings — with no schema or route changes.
+ */
+
+const scopeStorage = new AsyncLocalStorage<string>();
+
+/**
+ * Current tenant scope. Work pinned via `runWithScope` wins; otherwise the
+ * `@ext/scope` resolver runs (request context).
+ */
+export async function getScope(): Promise<string> {
+    const pinned = scopeStorage.getStore();
+    if (pinned !== undefined) return pinned;
+    return resolveScope();
+}
+
+/**
+ * Pin a scope for work that outlives the request context, e.g. background
+ * task execution kicked off from a route handler.
+ */
+export function runWithScope<T>(scope: string, fn: () => T): T {
+    return scopeStorage.run(scope, fn);
+}
+
+/** Data root for a known scope; `dataDir()` itself when scope is "". */
+export function scopedDataDirFor(scope: string): string {
+    return scope ? path.join(dataDir(), "users", scope) : dataDir();
+}
+
+/** Data root for the current scope. */
+export async function scopedDataDir(): Promise<string> {
+    return scopedDataDirFor(await getScope());
+}

--- a/src/lib/settings/env-store.server.ts
+++ b/src/lib/settings/env-store.server.ts
@@ -2,7 +2,8 @@ import "server-only";
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { dataDir } from "@/lib/runtime/paths.server";
+import { decodeEnvStore, encodeEnvStore } from "@ext/settings-codec";
+import { scopedDataDir } from "@/lib/runtime/scope.server";
 
 /**
  * Generic, platform-agnostic environment store.
@@ -12,19 +13,23 @@ import { dataDir } from "@/lib/runtime/paths.server";
  * keys it needs in its own README. The stored values are merged into the
  * environment of spawned plugin processes at execution time, so edits take
  * effect without restarting the server.
+ *
+ * The file lives in the scoped data dir (per-user in a cloud shell) and its
+ * raw contents pass through the `@ext/settings-codec` hooks — identity by
+ * default, encryption in a cloud shell.
  */
 
 export type EnvStore = Record<string, string>;
 
-function storeFile(): string {
-    return path.join(dataDir(), "settings.json");
+async function storeFile(): Promise<string> {
+    return path.join(await scopedDataDir(), "settings.json");
 }
 
 /** Read the stored env map. Returns `{}` when absent or unreadable. */
-export function loadEnvStore(): EnvStore {
+export async function loadEnvStore(): Promise<EnvStore> {
     try {
-        const raw = readFileSync(storeFile(), "utf8");
-        const parsed = JSON.parse(raw) as unknown;
+        const raw = readFileSync(await storeFile(), "utf8");
+        const parsed = JSON.parse(await decodeEnvStore(raw)) as unknown;
         if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
             return {};
         }
@@ -43,27 +48,28 @@ export function loadEnvStore(): EnvStore {
 }
 
 /** Persist the env map, overwriting the previous contents. */
-export function saveEnvStore(env: EnvStore): void {
-    const dir = dataDir();
+export async function saveEnvStore(env: EnvStore): Promise<void> {
+    const dir = await scopedDataDir();
     mkdirSync(dir, { recursive: true });
     const clean: EnvStore = {};
     for (const [k, v] of Object.entries(env)) {
         const key = k.trim();
         if (key && typeof v === "string") clean[key] = v;
     }
-    writeFileSync(storeFile(), JSON.stringify(clean, null, 2), "utf8");
+    const encoded = await encodeEnvStore(JSON.stringify(clean, null, 2));
+    writeFileSync(path.join(dir, "settings.json"), encoded, "utf8");
 }
 
 /**
  * Build a spawn environment: the stored values override the process env so the
  * UI is the source of truth, while still inheriting PATH and other essentials.
  */
-export function withStoredEnv(
+export async function withStoredEnv(
     extra?: Record<string, string | undefined>,
-): NodeJS.ProcessEnv {
+): Promise<NodeJS.ProcessEnv> {
     return {
         ...process.env,
-        ...loadEnvStore(),
+        ...(await loadEnvStore()),
         ...extra,
     };
 }

--- a/src/lib/task/emitter.ts
+++ b/src/lib/task/emitter.ts
@@ -89,6 +89,14 @@ export function isTaskRunning(taskId: string): boolean {
 }
 
 /**
+ * Number of currently running tasks (all scopes) — used e.g. by a cloud
+ * shell's idle self-exit guard.
+ */
+export function runningTaskCount(): number {
+    return runningTasks.size;
+}
+
+/**
  * Convenience function for sending task notifications (replaces the Python notifyTask)
  */
 export function notifyTask(

--- a/src/lib/task/engine-asset-tokens.server.ts
+++ b/src/lib/task/engine-asset-tokens.server.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import { randomBytes } from "node:crypto";
+
+/**
+ * Per-run bearer tokens for the `/api/engine-assets` loopback sink. The
+ * engine delegate mints one per spawned engine process (binding the tenant
+ * scope and taskId) and revokes it when the run ends, so the engine child
+ * can read/write assets through the storage driver without ever holding
+ * storage credentials or a user session.
+ */
+
+interface TokenBinding {
+    scope: string;
+    taskId: string;
+}
+
+const tokens = new Map<string, TokenBinding>();
+
+export function issueEngineAssetToken(scope: string, taskId: string): string {
+    const token = randomBytes(24).toString("base64url");
+    tokens.set(token, { scope, taskId });
+    return token;
+}
+
+export function revokeEngineAssetToken(token: string): void {
+    tokens.delete(token);
+}
+
+export function bindingForEngineAssetToken(token: string): TokenBinding | null {
+    return tokens.get(token) ?? null;
+}

--- a/src/lib/task/engine-delegate.server.ts
+++ b/src/lib/task/engine-delegate.server.ts
@@ -12,7 +12,8 @@ import { getDb, tasks } from "@/db";
 import { logger } from "@/lib/logger";
 import { resolveBasePython } from "@/lib/plugins/plugin-python-env.server";
 import { PYTHON_UTF8_ENV, resolvePythonLite } from "@/lib/plugins/python-lite";
-import { dataDir, pluginsDir, resourcesDir } from "@/lib/runtime/paths.server";
+import { pluginsDir, resourcesDir } from "@/lib/runtime/paths.server";
+import { getScope, scopedDataDirFor } from "@/lib/runtime/scope.server";
 import { withStoredEnv } from "@/lib/settings/env-store.server";
 import {
     type SerializedWorkflowFailure,
@@ -125,7 +126,9 @@ export async function executeWorkflowViaEngine(
 
         const python = resolveBasePython() ?? (await resolvePythonLite());
         const sdkDir = join(resourcesDir(), "sdk");
-        const uploadsBase = join(dataDir(), "uploads");
+        const scope = await getScope();
+        const dataRoot = scopedDataDirFor(scope);
+        const uploadsBase = join(dataRoot, "uploads");
         const outDir = join(uploadsBase, "tasks", taskId);
 
         const request = {
@@ -135,7 +138,7 @@ export async function executeWorkflowViaEngine(
                 // abi_path omitted on purpose: the engine falls back to the ABI
                 // bundled in the SDK, which always exists in the resources dir.
                 plugins_dir: pluginsDir(),
-                data_dir: dataDir(),
+                data_dir: dataRoot,
                 out_dir: outDir,
                 file_key_base: uploadsBase,
                 // Disk outputs: the canvas reads results via /api/uploads/<file_key>.
@@ -145,11 +148,19 @@ export async function executeWorkflowViaEngine(
             },
         };
 
-        const env = withStoredEnv({
+        // In a scoped (cloud) run, point the Modal deploy cache into the
+        // user's data dir so needsDeploy plugins deploy into that user's own
+        // account.
+        const env = await withStoredEnv({
             ...PYTHON_UTF8_ENV,
             PYTHONPATH: [sdkDir, process.env.PYTHONPATH?.trim()]
                 .filter((x): x is string => Boolean(x))
                 .join(delimiter),
+            ...(scope
+                ? {
+                      TONGFLOW_MODAL_CACHE_DIR: join(dataRoot, "modal-cache"),
+                  }
+                : {}),
         });
 
         await new Promise<void>((resolve, reject) => {

--- a/src/lib/task/engine-delegate.server.ts
+++ b/src/lib/task/engine-delegate.server.ts
@@ -9,6 +9,7 @@ import {
     WorkflowStatus,
 } from "@/constants/task-status";
 import { getDb, tasks } from "@/db";
+import { getStorage } from "@/lib/file/storage.server";
 import { logger } from "@/lib/logger";
 import { resolveBasePython } from "@/lib/plugins/plugin-python-env.server";
 import { PYTHON_UTF8_ENV, resolvePythonLite } from "@/lib/plugins/python-lite";
@@ -21,6 +22,10 @@ import {
     workflowTaskFailureEnvelope,
 } from "@/lib/task/error-envelope";
 import { notifyTask, registerTask, removeTask } from "./emitter";
+import {
+    issueEngineAssetToken,
+    revokeEngineAssetToken,
+} from "./engine-asset-tokens.server";
 
 /**
  * Delegate workflow execution to the SDK engine (`python -m tongflow.engine`),
@@ -116,6 +121,7 @@ export async function executeWorkflowViaEngine(
     inputs: Record<string, unknown>,
 ): Promise<void> {
     const controller = registerTask(taskId);
+    let assetToken: string | null = null;
 
     try {
         const db = await getDb();
@@ -131,6 +137,26 @@ export async function executeWorkflowViaEngine(
         const uploadsBase = join(dataRoot, "uploads");
         const outDir = join(uploadsBase, "tasks", taskId);
 
+        // Remote storage driver (cloud): route the engine's asset IO through
+        // the /api/engine-assets loopback sink so files go straight to the
+        // driver's backend and never touch the local disk. Local driver
+        // (desktop / open-source default): unchanged disk contract.
+        const remoteStorage = Boolean(getStorage().remote);
+        assetToken = remoteStorage
+            ? issueEngineAssetToken(scope, taskId)
+            : null;
+        const assetOptions = assetToken
+            ? {
+                  asset_endpoint: `http://127.0.0.1:${process.env.PORT || "3000"}/api/engine-assets`,
+                  asset_token: assetToken,
+              }
+            : {
+                  out_dir: outDir,
+                  file_key_base: uploadsBase,
+                  // Disk outputs: the canvas reads results via /api/uploads/<file_key>.
+                  inline_outputs: false,
+              };
+
         const request = {
             workflow: JSON.parse(workflowJson),
             inputs,
@@ -139,10 +165,7 @@ export async function executeWorkflowViaEngine(
                 // bundled in the SDK, which always exists in the resources dir.
                 plugins_dir: pluginsDir(),
                 data_dir: dataRoot,
-                out_dir: outDir,
-                file_key_base: uploadsBase,
-                // Disk outputs: the canvas reads results via /api/uploads/<file_key>.
-                inline_outputs: false,
+                ...assetOptions,
                 auto_install: true,
                 task_id: taskId,
             },
@@ -345,6 +368,7 @@ export async function executeWorkflowViaEngine(
             })
             .where(eq(tasks.id, taskId));
     } finally {
+        if (assetToken) revokeEngineAssetToken(assetToken);
         removeTask(taskId);
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
             }
         ],
         "paths": {
-            "@/*": ["./src/*"]
+            "@/*": ["./src/*"],
+            "@ext/*": ["./src/ext/*", "./src/ext-default/*"]
         }
     },
     "include": [


### PR DESCRIPTION
## Summary

Adapter seams that let a private cloud shell run TongFlow multi-tenant with remote (object) storage, while the open-source/desktop build keeps byte-identical behavior:

- **Tenant scope seam**: `getScope()` / `runWithScope()` / `scopedDataDir()` (`src/lib/runtime/scope.server.ts`). Default scope is `""` via `src/ext-default/scope.ts` → all paths identical to today. A shell links its own resolver into gitignored `src/ext/`; per-user data dirs (`<dataDir>/users/<id>/`) give isolation with zero schema changes. DB handle becomes one lazily-migrated connection per scope.
- **Storage driver seam**: `src/lib/file/storage.server.ts` (registry on `globalThis` — instrumentation is a separate bundle). Optional `remote` flag + `publicUrl()`; the uploads route 302s to presigned URLs when available.
- **Engine asset sink**: SDK `HttpStore` (loopback HTTP AssetStore, per-run bearer token) + `/api/engine-assets` route + engine-delegate wiring, so a remote-storage shell runs the SDK engine without asset files touching local disk. Engine subprocesses never hold storage credentials. Local driver keeps the exact `out_dir`/`file_key_base` disk contract.
- **Settings codec seam**: env-store is async, contents pass through `@ext/settings-codec` (identity by default; a shell can encrypt BYOK keys).
- `runningTaskCount()` on the task emitter; `TONGFLOW_MODAL_CACHE_DIR` per scope in spawned runs; `@ext/*` tsconfig alias with `src/ext-default/` fallbacks; gitignored shell link points (`src/ext/`, `src/app/(ext)/`, `src/middleware.ts`, `src/instrumentation.ts`).

## Testing

- `pnpm lint:check` / `pnpm typecheck` / `pnpm build` pass; `cd sdk && pytest` (38 passed, incl. new `test_http_store.py`).
- Desktop regression: dev-server smoke — settings roundtrip and upload/read land in the historical `data/` paths (scope `""`), uploads GET streams bytes (no redirect), `/api/engine-assets` 401s without a token.
- Cloud-shell E2E (external repo): two users get isolated `users/<id>/` SQLite/uploads; with an R2 driver registered, uploads go straight to R2 (`users/<scope>/...`) and media serves via 302 presigned URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)