### PR TITLE
refactor(ext): backend seams v2 — db / settings-store / task-dispatch / task-events / asset-token / plugin-registry

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tongflow"
-version = "0.2.2"
+version = "0.2.4"
 description = "Python SDK for TongFlow — author plugins and run multi-modal GenAI workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/tongflow/__init__.py
+++ b/sdk/tongflow/__init__.py
@@ -11,6 +11,6 @@ from .deploy_marker import deploy
 from .engine import run_workflow
 from .progress import progress
 
-__version__ = "0.2.2"
+__version__ = "0.2.4"
 
 __all__ = ["deploy", "progress", "run_workflow"]

--- a/src/app/api/engine-assets/route.ts
+++ b/src/app/api/engine-assets/route.ts
@@ -15,14 +15,14 @@ import { getStorage } from "@/lib/file/storage.server";
 import { runWithScope } from "@/lib/runtime/scope.server";
 import { bindingForEngineAssetToken } from "@/lib/task/engine-asset-tokens.server";
 
-function bindingFrom(request: NextRequest) {
+async function bindingFrom(request: NextRequest) {
     const header = request.headers.get("authorization") ?? "";
     const token = header.startsWith("Bearer ") ? header.slice(7) : "";
-    return token ? bindingForEngineAssetToken(token) : null;
+    return token ? await bindingForEngineAssetToken(token) : null;
 }
 
 export async function GET(request: NextRequest) {
-    const binding = bindingFrom(request);
+    const binding = await bindingFrom(request);
     if (!binding) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -46,7 +46,7 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-    const binding = bindingFrom(request);
+    const binding = await bindingFrom(request);
     if (!binding) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }

--- a/src/app/api/task/wait/route.ts
+++ b/src/app/api/task/wait/route.ts
@@ -1,10 +1,10 @@
+import { dispatchTask } from "@ext/task-dispatch";
 import type { NextRequest } from "next/server";
 import { isTerminalStatus } from "@/constants/task-status";
 import { jsonStringifyForSse } from "@/lib/json-sse";
 import { logger } from "@/lib/logger";
 import { getScope, runWithScope } from "@/lib/runtime/scope.server";
 import { isTaskRunning, onTaskEvent, type TaskEvent } from "@/lib/task/emitter";
-import { dispatchTask } from "@/lib/task/runner";
 
 /**
  * GET /api/task/wait?taskId=xxx&reconnect=false

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,36 +1,6 @@
-import { mkdirSync } from "node:fs";
-import path from "node:path";
-import Database from "better-sqlite3";
-import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
-import { drizzle } from "drizzle-orm/better-sqlite3";
-import { migrate } from "drizzle-orm/better-sqlite3/migrator";
-import { resourcesDir } from "@/lib/runtime/paths.server";
-import { getScope, scopedDataDirFor } from "@/lib/runtime/scope.server";
-import * as schema from "./schema";
-
-// One connection per tenant scope. The open-source build always resolves
-// scope "" and behaves exactly like the previous singleton; a cloud shell
-// gets an isolated, lazily-migrated SQLite db per user.
-const dbs = new Map<string, BetterSQLite3Database<typeof schema>>();
-
-export async function getDb() {
-    const scope = await getScope();
-    let db = dbs.get(scope);
-    if (!db) {
-        const dbDir = scopedDataDirFor(scope);
-        mkdirSync(dbDir, { recursive: true });
-
-        const dbPath = path.join(dbDir, "tongflow.db");
-        const sqlite = new Database(dbPath);
-        sqlite.pragma("journal_mode = WAL");
-        db = drizzle(sqlite, { schema });
-
-        migrate(db, {
-            migrationsFolder: path.join(resourcesDir(), "drizzle"),
-        });
-        dbs.set(scope, db);
-    }
-    return db;
-}
-
+// Database backend seam: the default implementation (src/ext-default/db.ts)
+// opens one local better-sqlite3 file per tenant scope; a cloud shell can
+// substitute another sqlite-dialect drizzle driver via src/ext/db.ts
+// (the schema below is shared by all backends).
+export { getDb } from "@ext/db";
 export * from "./schema";

--- a/src/ext-default/asset-token.ts
+++ b/src/ext-default/asset-token.ts
@@ -1,0 +1,31 @@
+import { randomBytes } from "node:crypto";
+import type { EngineAssetTokenBinding } from "@/lib/task/engine-asset-tokens.server";
+
+/**
+ * Default engine-asset token backend: an in-process map of random bearer
+ * tokens, minted per engine run and revoked when it ends. Correct for the
+ * single-process open-source build; a multi-instance cloud shell
+ * substitutes a stateless scheme (e.g. HMAC-signed tokens) via
+ * `src/ext/asset-token.ts`.
+ */
+
+const tokens = new Map<string, EngineAssetTokenBinding>();
+
+export async function issueEngineAssetToken(
+    scope: string,
+    taskId: string,
+): Promise<string> {
+    const token = randomBytes(24).toString("base64url");
+    tokens.set(token, { scope, taskId });
+    return token;
+}
+
+export async function revokeEngineAssetToken(token: string): Promise<void> {
+    tokens.delete(token);
+}
+
+export async function bindingForEngineAssetToken(
+    token: string,
+): Promise<EngineAssetTokenBinding | null> {
+    return tokens.get(token) ?? null;
+}

--- a/src/ext-default/db.ts
+++ b/src/ext-default/db.ts
@@ -1,0 +1,39 @@
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import Database from "better-sqlite3";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import * as schema from "@/db/schema";
+import { resourcesDir } from "@/lib/runtime/paths.server";
+import { getScope, scopedDataDirFor } from "@/lib/runtime/scope.server";
+
+/**
+ * Default database backend: one local better-sqlite3 file per tenant scope
+ * (scope "" — the open-source build — is exactly the historical single
+ * `data/tongflow.db`). A cloud shell substitutes its own `src/ext/db.ts`
+ * (e.g. a per-user Durable Object SQLite behind drizzle's proxy driver).
+ */
+
+// One connection per tenant scope, lazily opened and migrated.
+const dbs = new Map<string, BetterSQLite3Database<typeof schema>>();
+
+export async function getDb() {
+    const scope = await getScope();
+    let db = dbs.get(scope);
+    if (!db) {
+        const dbDir = scopedDataDirFor(scope);
+        mkdirSync(dbDir, { recursive: true });
+
+        const dbPath = path.join(dbDir, "tongflow.db");
+        const sqlite = new Database(dbPath);
+        sqlite.pragma("journal_mode = WAL");
+        db = drizzle(sqlite, { schema });
+
+        migrate(db, {
+            migrationsFolder: path.join(resourcesDir(), "drizzle"),
+        });
+        dbs.set(scope, db);
+    }
+    return db;
+}

--- a/src/ext-default/plugin-registry.ts
+++ b/src/ext-default/plugin-registry.ts
@@ -1,0 +1,119 @@
+import { join } from "node:path";
+import chokidar, { type FSWatcher } from "chokidar";
+import { logger } from "@/lib/logger";
+import type {
+    PluginConfig,
+    PluginsRegistry,
+} from "@/lib/plugins/plugins-registry-schema";
+import { runPluginsScanner } from "@/lib/plugins/plugins-scanner.server";
+import { pluginsDir, resourcesDir } from "@/lib/runtime/paths.server";
+
+/**
+ * Default plugin registry backend: scan the local plugins dir (with a dev
+ * watcher for live rescans). A cloud shell substitutes e.g. a build-time
+ * baked manifest via `src/ext/plugin-registry.ts`.
+ */
+
+let cached: PluginsRegistry | null = null;
+let watcher: FSWatcher | null = null;
+let rescanTimer: NodeJS.Timeout | null = null;
+
+function emptyRegistry(message?: string): PluginsRegistry {
+    return {
+        version: 1,
+        generatedAt: new Date().toISOString(),
+        nodePluginMap: {},
+        plugins: {},
+        errors: message
+            ? [
+                  {
+                      pluginId: "<scan>",
+                      message,
+                  },
+              ]
+            : undefined,
+    };
+}
+
+function scanAndCache(): PluginsRegistry {
+    ensureDevWatcher();
+    try {
+        cached = runPluginsScanner();
+        return cached;
+    } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        logger.warn("[plugins] Scanner failed, using empty registry:", message);
+        return emptyRegistry(message);
+    }
+}
+
+function scheduleRescan(): void {
+    if (rescanTimer) clearTimeout(rescanTimer);
+    rescanTimer = setTimeout(() => {
+        try {
+            cached = runPluginsScanner();
+            logger.debug("[plugins] Registry refreshed from scanner");
+        } catch (e) {
+            logger.warn(
+                "[plugins] Registry rescan failed; keeping previous cache:",
+                e instanceof Error ? e.message : String(e),
+            );
+        }
+    }, 300);
+}
+
+// The dev watcher starts on the first explicit registry load/refresh, not via
+// feature-registry module initialization, so lifecycle APIs can refresh safely.
+function ensureDevWatcher(): void {
+    if (process.env.NODE_ENV === "production" || watcher) return;
+    watcher = chokidar.watch(
+        [
+            join(pluginsDir(), "**", "*.py"),
+            join(resourcesDir(), "config", "tongflow.abi.json"),
+        ],
+        {
+            ignoreInitial: true,
+            ignored: ["**/__pycache__/**", "**/.venv/**", "**/node_modules/**"],
+        },
+    );
+    watcher.on("all", scheduleRescan);
+    watcher.on("error", (e) => {
+        logger.warn(
+            "[plugins] Registry watcher error:",
+            e instanceof Error ? e.message : String(e),
+        );
+    });
+}
+
+export function loadPluginsRegistry(): PluginsRegistry {
+    if (cached) return cached;
+    return scanAndCache();
+}
+
+export function invalidatePluginsRegistry(): PluginsRegistry {
+    cached = null;
+    if (rescanTimer) {
+        clearTimeout(rescanTimer);
+        rescanTimer = null;
+    }
+    return scanAndCache();
+}
+
+export function getNodePluginIds(nodeSlot: string): string[] {
+    const reg = loadPluginsRegistry();
+    const list = reg.nodePluginMap[nodeSlot] ?? [];
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const id of list) {
+        const x = id.trim();
+        if (!x || seen.has(x)) continue;
+        seen.add(x);
+        out.push(x);
+    }
+    return out;
+}
+
+export function getPluginConfig(pluginId: string): PluginConfig | null {
+    const reg = loadPluginsRegistry();
+    return reg.plugins[pluginId] ?? null;
+}

--- a/src/ext-default/settings-store.ts
+++ b/src/ext-default/settings-store.ts
@@ -1,0 +1,30 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { scopedDataDir } from "@/lib/runtime/scope.server";
+
+/**
+ * Default settings persistence: `settings.json` in the scoped data dir.
+ * A cloud shell substitutes its own `src/ext/settings-store.ts` (e.g. a
+ * per-user Durable Object). The blob is the raw (possibly codec-encoded)
+ * file contents; parsing/validation stays in env-store.server.ts.
+ */
+
+async function storeFile(): Promise<string> {
+    return path.join(await scopedDataDir(), "settings.json");
+}
+
+/** Raw settings blob for the current scope, or null when absent. */
+export async function readSettingsBlob(): Promise<string | null> {
+    try {
+        return readFileSync(await storeFile(), "utf8");
+    } catch {
+        return null;
+    }
+}
+
+/** Persist the raw settings blob for the current scope. */
+export async function writeSettingsBlob(blob: string): Promise<void> {
+    const dir = await scopedDataDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "settings.json"), blob, "utf8");
+}

--- a/src/ext-default/task-dispatch.ts
+++ b/src/ext-default/task-dispatch.ts
@@ -1,0 +1,10 @@
+/**
+ * Default task dispatch: run the task in-process (the local runner spawns
+ * Python plugin bridges / the SDK engine). The dynamic import keeps the
+ * node-only dependency chain (child_process etc.) out of bundles for
+ * shells that substitute a remote dispatcher via `src/ext/task-dispatch.ts`.
+ */
+export async function dispatchTask(taskId: string): Promise<void> {
+    const { dispatchTask: dispatchLocally } = await import("@/lib/task/runner");
+    return dispatchLocally(taskId);
+}

--- a/src/ext-default/task-events.ts
+++ b/src/ext-default/task-events.ts
@@ -1,0 +1,83 @@
+import { EventEmitter } from "node:events";
+import type { TaskEvent } from "@/lib/task/emitter";
+
+/**
+ * Default task event backend: in-process EventEmitter + AbortController
+ * map. Fits the single-process open-source/desktop build; a cloud shell
+ * substitutes a cross-instance backend (e.g. a Durable Object event log)
+ * via `src/ext/task-events.ts`.
+ */
+
+const emitter = new EventEmitter();
+emitter.setMaxListeners(1000);
+
+// Running task -> AbortController mapping, used to cancel running tasks.
+const runningTasks = new Map<string, AbortController>();
+
+/** Publish task events (called by handlers) */
+export function emitTaskEvent(taskId: string, event: TaskEvent) {
+    emitter.emit(`task:${taskId}`, event);
+}
+
+/**
+ * Subscribe to task events (called by SSE endpoints).
+ * Returns an unsubscribe function.
+ */
+export function onTaskEvent(
+    taskId: string,
+    callback: (event: TaskEvent) => void,
+): () => void {
+    const channel = `task:${taskId}`;
+    emitter.on(channel, callback);
+    return () => {
+        emitter.off(channel, callback);
+    };
+}
+
+/** Register a running task */
+export function registerTask(taskId: string): AbortController {
+    const controller = new AbortController();
+    runningTasks.set(taskId, controller);
+    return controller;
+}
+
+/** Cancel task */
+export function abortTask(taskId: string): boolean {
+    const controller = runningTasks.get(taskId);
+    if (controller) {
+        controller.abort();
+        runningTasks.delete(taskId);
+        return true;
+    }
+    return false;
+}
+
+/** Remove completed tasks */
+export function removeTask(taskId: string) {
+    runningTasks.delete(taskId);
+}
+
+/** Check whether a task is running */
+export function isTaskRunning(taskId: string): boolean {
+    return runningTasks.has(taskId);
+}
+
+/**
+ * Number of currently running tasks (all scopes) — used e.g. by a cloud
+ * shell's idle self-exit guard.
+ */
+export function runningTaskCount(): number {
+    return runningTasks.size;
+}
+
+/**
+ * Convenience function for sending task notifications (replaces the Python notifyTask)
+ */
+export function notifyTask(
+    taskId: string,
+    status: string,
+    data?: Record<string, unknown>,
+    nodeId?: string | null,
+) {
+    emitTaskEvent(taskId, { id: taskId, status, nodeId, data });
+}

--- a/src/lib/plugins/plugins-registry.server.ts
+++ b/src/lib/plugins/plugins-registry.server.ts
@@ -1,115 +1,14 @@
 import "server-only";
 
-import { join } from "node:path";
-import chokidar, { type FSWatcher } from "chokidar";
-import { logger } from "@/lib/logger";
-import type {
-    PluginConfig,
-    PluginsRegistry,
-} from "@/lib/plugins/plugins-registry-schema";
-import { runPluginsScanner } from "@/lib/plugins/plugins-scanner.server";
-import { pluginsDir, resourcesDir } from "@/lib/runtime/paths.server";
-
-let cached: PluginsRegistry | null = null;
-let watcher: FSWatcher | null = null;
-let rescanTimer: NodeJS.Timeout | null = null;
-
-function emptyRegistry(message?: string): PluginsRegistry {
-    return {
-        version: 1,
-        generatedAt: new Date().toISOString(),
-        nodePluginMap: {},
-        plugins: {},
-        errors: message
-            ? [
-                  {
-                      pluginId: "<scan>",
-                      message,
-                  },
-              ]
-            : undefined,
-    };
-}
-
-function scanAndCache(): PluginsRegistry {
-    ensureDevWatcher();
-    try {
-        cached = runPluginsScanner();
-        return cached;
-    } catch (e) {
-        const message = e instanceof Error ? e.message : String(e);
-        logger.warn("[plugins] Scanner failed, using empty registry:", message);
-        return emptyRegistry(message);
-    }
-}
-
-function scheduleRescan(): void {
-    if (rescanTimer) clearTimeout(rescanTimer);
-    rescanTimer = setTimeout(() => {
-        try {
-            cached = runPluginsScanner();
-            logger.debug("[plugins] Registry refreshed from scanner");
-        } catch (e) {
-            logger.warn(
-                "[plugins] Registry rescan failed; keeping previous cache:",
-                e instanceof Error ? e.message : String(e),
-            );
-        }
-    }, 300);
-}
-
-// The dev watcher starts on the first explicit registry load/refresh, not via
-// feature-registry module initialization, so lifecycle APIs can refresh safely.
-function ensureDevWatcher(): void {
-    if (process.env.NODE_ENV === "production" || watcher) return;
-    watcher = chokidar.watch(
-        [
-            join(pluginsDir(), "**", "*.py"),
-            join(resourcesDir(), "config", "tongflow.abi.json"),
-        ],
-        {
-            ignoreInitial: true,
-            ignored: ["**/__pycache__/**", "**/.venv/**", "**/node_modules/**"],
-        },
-    );
-    watcher.on("all", scheduleRescan);
-    watcher.on("error", (e) => {
-        logger.warn(
-            "[plugins] Registry watcher error:",
-            e instanceof Error ? e.message : String(e),
-        );
-    });
-}
-
-export function loadPluginsRegistry(): PluginsRegistry {
-    if (cached) return cached;
-    return scanAndCache();
-}
-
-export function invalidatePluginsRegistry(): PluginsRegistry {
-    cached = null;
-    if (rescanTimer) {
-        clearTimeout(rescanTimer);
-        rescanTimer = null;
-    }
-    return scanAndCache();
-}
-
-export function getNodePluginIds(nodeSlot: string): string[] {
-    const reg = loadPluginsRegistry();
-    const list = reg.nodePluginMap[nodeSlot] ?? [];
-    const seen = new Set<string>();
-    const out: string[] = [];
-    for (const id of list) {
-        const x = id.trim();
-        if (!x || seen.has(x)) continue;
-        seen.add(x);
-        out.push(x);
-    }
-    return out;
-}
-
-export function getPluginConfig(pluginId: string): PluginConfig | null {
-    const reg = loadPluginsRegistry();
-    return reg.plugins[pluginId] ?? null;
-}
+/**
+ * Plugin registry seam: the default backend (src/ext-default/
+ * plugin-registry.ts) scans the local plugins dir with a dev watcher; a
+ * cloud shell substitutes e.g. a build-time baked manifest via
+ * src/ext/plugin-registry.ts.
+ */
+export {
+    getNodePluginIds,
+    getPluginConfig,
+    invalidatePluginsRegistry,
+    loadPluginsRegistry,
+} from "@ext/plugin-registry";

--- a/src/lib/settings/env-store.server.ts
+++ b/src/lib/settings/env-store.server.ts
@@ -1,9 +1,7 @@
 import "server-only";
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import path from "node:path";
 import { decodeEnvStore, encodeEnvStore } from "@ext/settings-codec";
-import { scopedDataDir } from "@/lib/runtime/scope.server";
+import { readSettingsBlob, writeSettingsBlob } from "@ext/settings-store";
 
 /**
  * Generic, platform-agnostic environment store.
@@ -14,21 +12,18 @@ import { scopedDataDir } from "@/lib/runtime/scope.server";
  * environment of spawned plugin processes at execution time, so edits take
  * effect without restarting the server.
  *
- * The file lives in the scoped data dir (per-user in a cloud shell) and its
- * raw contents pass through the `@ext/settings-codec` hooks — identity by
- * default, encryption in a cloud shell.
+ * Two seams compose here: `@ext/settings-store` persists the raw blob
+ * (default: settings.json in the scoped data dir) and `@ext/settings-codec`
+ * encodes/decodes it (default: identity; a cloud shell encrypts BYOK keys).
  */
 
 export type EnvStore = Record<string, string>;
 
-async function storeFile(): Promise<string> {
-    return path.join(await scopedDataDir(), "settings.json");
-}
-
 /** Read the stored env map. Returns `{}` when absent or unreadable. */
 export async function loadEnvStore(): Promise<EnvStore> {
     try {
-        const raw = readFileSync(await storeFile(), "utf8");
+        const raw = await readSettingsBlob();
+        if (raw == null) return {};
         const parsed = JSON.parse(await decodeEnvStore(raw)) as unknown;
         if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
             return {};
@@ -49,15 +44,13 @@ export async function loadEnvStore(): Promise<EnvStore> {
 
 /** Persist the env map, overwriting the previous contents. */
 export async function saveEnvStore(env: EnvStore): Promise<void> {
-    const dir = await scopedDataDir();
-    mkdirSync(dir, { recursive: true });
     const clean: EnvStore = {};
     for (const [k, v] of Object.entries(env)) {
         const key = k.trim();
         if (key && typeof v === "string") clean[key] = v;
     }
     const encoded = await encodeEnvStore(JSON.stringify(clean, null, 2));
-    writeFileSync(path.join(dir, "settings.json"), encoded, "utf8");
+    await writeSettingsBlob(encoded);
 }
 
 /**

--- a/src/lib/task/emitter.ts
+++ b/src/lib/task/emitter.ts
@@ -1,14 +1,15 @@
 /**
- * Global task event system
+ * Global task event system.
  *
- * Replaces Redis pub/sub with in-process EventEmitter realtime notifications.
- * SSE endpoints listen for events, and handlers publish events.
+ * Backend seam: the default (src/ext-default/task-events.ts) is an
+ * in-process EventEmitter — it replaces Redis pub/sub for the single-
+ * process open-source/desktop build. A cloud shell substitutes a
+ * cross-instance backend (e.g. a Durable Object event log) via
+ * src/ext/task-events.ts. SSE endpoints listen for events, and handlers
+ * publish events.
  */
 
-import { EventEmitter } from "node:events";
 import type { SSEStatusType } from "@/constants/task-status";
-
-// ==================== Types ====================
 
 export interface TaskEvent {
     id: string;
@@ -17,93 +18,13 @@ export interface TaskEvent {
     data?: Record<string, unknown>;
 }
 
-// ==================== Global singleton ====================
-
-const emitter = new EventEmitter();
-emitter.setMaxListeners(1000);
-
-/**
- * Running task -> AbortController mapping
- * Used to cancel running tasks
- */
-const runningTasks = new Map<string, AbortController>();
-
-// ==================== Public API ====================
-
-/**
- * Publish task events (called by handlers)
- */
-export function emitTaskEvent(taskId: string, event: TaskEvent) {
-    emitter.emit(`task:${taskId}`, event);
-}
-
-/**
- * Subscribe to task events (called by SSE endpoints)
- * Return an unsubscribe function
- */
-export function onTaskEvent(
-    taskId: string,
-    callback: (event: TaskEvent) => void,
-): () => void {
-    const channel = `task:${taskId}`;
-    emitter.on(channel, callback);
-    return () => {
-        emitter.off(channel, callback);
-    };
-}
-
-/**
- * Register a running task
- */
-export function registerTask(taskId: string): AbortController {
-    const controller = new AbortController();
-    runningTasks.set(taskId, controller);
-    return controller;
-}
-
-/**
- * Cancel task
- */
-export function abortTask(taskId: string): boolean {
-    const controller = runningTasks.get(taskId);
-    if (controller) {
-        controller.abort();
-        runningTasks.delete(taskId);
-        return true;
-    }
-    return false;
-}
-
-/**
- * Remove completed tasks
- */
-export function removeTask(taskId: string) {
-    runningTasks.delete(taskId);
-}
-
-/**
- * Check whether a task is running
- */
-export function isTaskRunning(taskId: string): boolean {
-    return runningTasks.has(taskId);
-}
-
-/**
- * Number of currently running tasks (all scopes) — used e.g. by a cloud
- * shell's idle self-exit guard.
- */
-export function runningTaskCount(): number {
-    return runningTasks.size;
-}
-
-/**
- * Convenience function for sending task notifications (replaces the Python notifyTask)
- */
-export function notifyTask(
-    taskId: string,
-    status: string,
-    data?: Record<string, unknown>,
-    nodeId?: string | null,
-) {
-    emitTaskEvent(taskId, { id: taskId, status, nodeId, data });
-}
+export {
+    abortTask,
+    emitTaskEvent,
+    isTaskRunning,
+    notifyTask,
+    onTaskEvent,
+    registerTask,
+    removeTask,
+    runningTaskCount,
+} from "@ext/task-events";

--- a/src/lib/task/engine-asset-tokens.server.ts
+++ b/src/lib/task/engine-asset-tokens.server.ts
@@ -1,32 +1,24 @@
 import "server-only";
 
-import { randomBytes } from "node:crypto";
-
 /**
  * Per-run bearer tokens for the `/api/engine-assets` loopback sink. The
  * engine delegate mints one per spawned engine process (binding the tenant
  * scope and taskId) and revokes it when the run ends, so the engine child
  * can read/write assets through the storage driver without ever holding
  * storage credentials or a user session.
+ *
+ * Backend seam: the default (src/ext-default/asset-token.ts) is an
+ * in-process map; a cloud shell substitutes a stateless scheme via
+ * src/ext/asset-token.ts.
  */
 
-interface TokenBinding {
+export interface EngineAssetTokenBinding {
     scope: string;
     taskId: string;
 }
 
-const tokens = new Map<string, TokenBinding>();
-
-export function issueEngineAssetToken(scope: string, taskId: string): string {
-    const token = randomBytes(24).toString("base64url");
-    tokens.set(token, { scope, taskId });
-    return token;
-}
-
-export function revokeEngineAssetToken(token: string): void {
-    tokens.delete(token);
-}
-
-export function bindingForEngineAssetToken(token: string): TokenBinding | null {
-    return tokens.get(token) ?? null;
-}
+export {
+    bindingForEngineAssetToken,
+    issueEngineAssetToken,
+    revokeEngineAssetToken,
+} from "@ext/asset-token";

--- a/src/lib/task/engine-delegate.server.ts
+++ b/src/lib/task/engine-delegate.server.ts
@@ -143,7 +143,7 @@ export async function executeWorkflowViaEngine(
         // (desktop / open-source default): unchanged disk contract.
         const remoteStorage = Boolean(getStorage().remote);
         assetToken = remoteStorage
-            ? issueEngineAssetToken(scope, taskId)
+            ? await issueEngineAssetToken(scope, taskId)
             : null;
         const assetOptions = assetToken
             ? {
@@ -368,7 +368,7 @@ export async function executeWorkflowViaEngine(
             })
             .where(eq(tasks.id, taskId));
     } finally {
-        if (assetToken) revokeEngineAssetToken(assetToken);
+        if (assetToken) await revokeEngineAssetToken(assetToken);
         removeTask(taskId);
     }
 }


### PR DESCRIPTION
## Summary

Second batch of cloud-shell seams: six mechanical impl-moves into `src/ext-default/` behind the existing `@ext/*` alias fallback. Each seam's default is the current implementation verbatim; a shell substitutes serverless backends (per-user Durable Object SQLite, KV settings, remote task dispatch, cross-instance event log, HMAC asset tokens, baked plugin manifest) by linking `src/ext/*`.

Open-source/desktop behavior is unchanged by construction — the default modules are the same code, re-exported.

## Testing

- `pnpm lint:check`, `pnpm typecheck`, `pnpm build` pass.
- Dev-server smoke over every seam: settings roundtrip preserves existing values, workspace list reads existing data (db seam), upload + serve via local storage driver, `/api/engine-assets` still 401s without a token, plugin registry scans and serves the same manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)