### PR TITLE
feat(task): optional direct SSE stream seam + serverless shell gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,10 @@ __pycache__/
 /src/app/(ext)/
 /src/middleware.ts
 /src/instrumentation.ts
+
+# Cloud shell build artifacts for serverless targets (linked in at build
+# time, like src/ext/ above)
+/wrangler.jsonc
+/open-next.config.ts
+/worker-entry.ts
+/.open-next/

--- a/src/app/api/task/wait/route.ts
+++ b/src/app/api/task/wait/route.ts
@@ -4,7 +4,12 @@ import { isTerminalStatus } from "@/constants/task-status";
 import { jsonStringifyForSse } from "@/lib/json-sse";
 import { logger } from "@/lib/logger";
 import { getScope, runWithScope } from "@/lib/runtime/scope.server";
-import { isTaskRunning, onTaskEvent, type TaskEvent } from "@/lib/task/emitter";
+import {
+    directStreamUrl,
+    isTaskRunning,
+    onTaskEvent,
+    type TaskEvent,
+} from "@/lib/task/emitter";
 
 /**
  * GET /api/task/wait?taskId=xxx&reconnect=false
@@ -30,11 +35,24 @@ export async function GET(request: NextRequest) {
         });
     }
 
-    const encoder = new TextEncoder();
-
     // Resolve the tenant scope while the request context is still available;
     // the execution below outlives it, so pin the scope via ALS.
     const scope = await getScope();
+
+    // Direct stream mode (remote executors): kick off execution, then 302
+    // the EventSource to the external SSE endpoint — progress flows from
+    // the executor to the browser without passing through this server.
+    const direct = await directStreamUrl(taskId);
+    if (direct) {
+        if (!reconnect) {
+            runWithScope(scope, () => dispatchTask(taskId)).catch((error) => {
+                logger.error(`[SSE] Failed to start task ${taskId}:`, error);
+            });
+        }
+        return Response.redirect(direct, 302);
+    }
+
+    const encoder = new TextEncoder();
 
     const stream = new ReadableStream({
         start(controller) {

--- a/src/ext-default/task-events.ts
+++ b/src/ext-default/task-events.ts
@@ -71,6 +71,17 @@ export function runningTaskCount(): number {
 }
 
 /**
+ * Optional direct SSE stream for a task. The default backend has none
+ * (events stream in-process through the SSE route); a cloud shell can
+ * return an absolute URL of an external event stream (e.g. a remote
+ * executor's SSE endpoint) and the SSE route will 302 the browser to it —
+ * progress then flows executor -> browser directly.
+ */
+export async function directStreamUrl(_taskId: string): Promise<string | null> {
+    return null;
+}
+
+/**
  * Convenience function for sending task notifications (replaces the Python notifyTask)
  */
 export function notifyTask(

--- a/src/lib/task/emitter.ts
+++ b/src/lib/task/emitter.ts
@@ -20,6 +20,7 @@ export interface TaskEvent {
 
 export {
     abortTask,
+    directStreamUrl,
     emitTaskEvent,
     isTaskRunning,
     notifyTask,


### PR DESCRIPTION
directStreamUrl(taskId) on the @ext/task-events backend (default: null).
When a shell returns a URL (e.g. a remote executor's SSE endpoint), the
task wait route dispatches and then 302s the EventSource to it, so
progress streams executor -> browser directly instead of through the
app server. Also gitignore the serverless shell's linked build files
(wrangler.jsonc, open-next.config.ts, worker-entry.ts, .open-next/).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
