### PR TITLE
fix(task): await remote dispatch before the direct-stream redirect

### DIFF
--- a/src/app/api/task/wait/route.ts
+++ b/src/app/api/task/wait/route.ts
@@ -42,12 +42,16 @@ export async function GET(request: NextRequest) {
     // Direct stream mode (remote executors): kick off execution, then 302
     // the EventSource to the external SSE endpoint — progress flows from
     // the executor to the browser without passing through this server.
+    // Dispatch must complete BEFORE the redirect response: serverless
+    // runtimes cancel work still pending when the response returns.
     const direct = await directStreamUrl(taskId);
     if (direct) {
         if (!reconnect) {
-            runWithScope(scope, () => dispatchTask(taskId)).catch((error) => {
+            try {
+                await runWithScope(scope, () => dispatchTask(taskId));
+            } catch (error) {
                 logger.error(`[SSE] Failed to start task ${taskId}:`, error);
-            });
+            }
         }
         return Response.redirect(direct, 302);
     }


### PR DESCRIPTION
Serverless runtimes cancel pending work once the response returns, so a
fire-and-forget dispatch followed by an immediate 302 never reached the
executor. Local dispatch keeps its fire-and-forget path (it resolves
only when the task finishes and the SSE stream holds the request open).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
