### PR TITLE
feat(ui): ExtSlot seam in the root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import ExtSlot from "@ext/ui-slot";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 import { Toaster } from "react-hot-toast";
@@ -64,6 +65,7 @@ export default async function RootLayout({
                     </ErrorBoundary>
                     <Toaster position="top-center" />
                     <TaskFailureToaster />
+                    <ExtSlot />
                 </NextIntlClientProvider>
             </body>
         </html>

--- a/src/ext-default/ui-slot.tsx
+++ b/src/ext-default/ui-slot.tsx
@@ -1,0 +1,8 @@
+/**
+ * Default UI slot: renders nothing. A cloud shell substitutes its own
+ * `src/ext/ui-slot.tsx` (e.g. a floating account menu) — the root layout
+ * mounts it after the page content.
+ */
+export default function ExtSlot() {
+    return null;
+}


### PR DESCRIPTION
A cloud shell can mount UI (e.g. an account menu) after the page content
via src/ext/ui-slot.tsx; the default renders nothing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
