### PR TITLE
fix(css): explicitly @source the gitignored cloud-shell dirs

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,12 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+/* Cloud shell sources: these dirs are gitignored (linked in at build
+   time), so Tailwind's automatic source detection skips them — declare
+   them explicitly or shell-only utility classes are never generated. */
+@source "../ext";
+@source "./(ext)";
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {


### PR DESCRIPTION
Tailwind v4's automatic source detection honors .gitignore, so classes
used only by shell-linked code (src/ext, src/app/(ext)) were never
generated. Explicit @source entries are scanned regardless. No effect
when the dirs are absent.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
