### PR TITLE
feat(ui): NEXT_PUBLIC_MANAGED_PLUGINS flag hides the plugins entry

### DIFF
--- a/src/components/workspace/workspace-nav.tsx
+++ b/src/components/workspace/workspace-nav.tsx
@@ -237,7 +237,11 @@ export function WorkspaceNav() {
     return (
         <div className="flex items-center gap-2">
             <UpdateButton className={navBtnClass} />
-            <PluginsDialog />
+            {/* Managed platforms (cloud) provision plugins themselves —
+                hide the install entry there. Inlined at build time. */}
+            {process.env.NEXT_PUBLIC_MANAGED_PLUGINS !== "1" && (
+                <PluginsDialog />
+            )}
             <SettingsDialog />
             <ThemeToggleButton />
             <LocaleMenu />


### PR DESCRIPTION
## Summary
- New build-time flag `NEXT_PUBLIC_MANAGED_PLUGINS=1` hides the plugins install entry (PluginsDialog button) in the workspace nav. Managed platforms (the cloud deployment) provision plugin code inside the executor at run time, so the install dialog has no role there — and its filesystem-bound `/api/plugins/official` route can't work on Workers anyway.
- Unset (desktop/self-host): behavior unchanged.

## Test plan
- `pnpm lint:check` / `pnpm typecheck` / `pnpm build` pass.
- Without the env var the plugins button renders as before; with `NEXT_PUBLIC_MANAGED_PLUGINS=1` it is omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)