### PR TITLE
refactor(plugins): plugin-env seam for the settings dialog declarations

### DIFF
--- a/src/ext-default/plugin-env.ts
+++ b/src/ext-default/plugin-env.ts
@@ -1,0 +1,73 @@
+import { type Dirent, existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { logger } from "@/lib/logger";
+import {
+    type PluginEnvDecl,
+    PluginEnvManifestSchema,
+} from "@/lib/plugins/plugin-env-manifest-schema";
+import { pluginsDir } from "@/lib/runtime/paths.server";
+
+export const PLUGIN_ENV_MANIFEST_FILE = "tongflow.plugin.json";
+
+/**
+ * Default plugin-env backend: reads `tongflow.plugin.json` from every
+ * installed plugin (same `.git` presence check as isPluginInstalled, so
+ * partial clones are skipped). Reads fresh on every call — files are tiny,
+ * the settings dialog is low-frequency, and newly installed plugins are
+ * picked up automatically. A missing or invalid manifest never fails the
+ * call; it just yields no entry. A cloud shell substitutes a build-time
+ * baked declaration list via `src/ext/plugin-env.ts`.
+ */
+export function loadPluginEnvDecls(): PluginEnvDecl[] {
+    const root = pluginsDir();
+    let entries: Dirent[];
+    try {
+        entries = readdirSync(root, { withFileTypes: true });
+    } catch {
+        return [];
+    }
+
+    const decls: PluginEnvDecl[] = [];
+    for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const pluginId = entry.name;
+        const pluginRoot = join(root, pluginId);
+        const manifestPath = join(pluginRoot, PLUGIN_ENV_MANIFEST_FILE);
+        if (
+            !existsSync(join(pluginRoot, ".git")) ||
+            !existsSync(manifestPath)
+        ) {
+            continue;
+        }
+
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(readFileSync(manifestPath, "utf8"));
+        } catch (error) {
+            logger.warn(
+                `[plugins] unreadable ${PLUGIN_ENV_MANIFEST_FILE} in ${pluginId}:`,
+                error,
+            );
+            continue;
+        }
+        const result = PluginEnvManifestSchema.safeParse(parsed);
+        if (!result.success) {
+            logger.warn(
+                `[plugins] invalid ${PLUGIN_ENV_MANIFEST_FILE} in ${pluginId}: ${result.error.message}`,
+            );
+            continue;
+        }
+
+        // Dedupe keys within one plugin; first declaration wins.
+        const seen = new Set<string>();
+        const env = result.data.env.filter((v) => {
+            if (seen.has(v.key)) return false;
+            seen.add(v.key);
+            return true;
+        });
+        if (env.length > 0) decls.push({ pluginId, env });
+    }
+
+    decls.sort((a, b) => a.pluginId.localeCompare(b.pluginId));
+    return decls;
+}

--- a/src/lib/plugins/plugin-env-manifests.server.ts
+++ b/src/lib/plugins/plugin-env-manifests.server.ts
@@ -1,73 +1,9 @@
 import "server-only";
 
-import { type Dirent, existsSync, readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-import { logger } from "@/lib/logger";
-import {
-    type PluginEnvDecl,
-    PluginEnvManifestSchema,
-} from "@/lib/plugins/plugin-env-manifest-schema";
-import { pluginsDir } from "@/lib/runtime/paths.server";
-
-export const PLUGIN_ENV_MANIFEST_FILE = "tongflow.plugin.json";
-
 /**
- * Reads `tongflow.plugin.json` from every installed plugin (same `.git`
- * presence check as isPluginInstalled, so partial clones are skipped).
- * Reads fresh on every call — files are tiny, the settings dialog is
- * low-frequency, and newly installed plugins are picked up automatically.
- * A missing or invalid manifest never fails the call; it just yields no entry.
+ * Plugin-env seam: the default backend (src/ext-default/plugin-env.ts)
+ * reads `tongflow.plugin.json` from every installed plugin; a cloud shell
+ * substitutes a build-time baked declaration list via
+ * src/ext/plugin-env.ts.
  */
-export function loadPluginEnvDecls(): PluginEnvDecl[] {
-    const root = pluginsDir();
-    let entries: Dirent[];
-    try {
-        entries = readdirSync(root, { withFileTypes: true });
-    } catch {
-        return [];
-    }
-
-    const decls: PluginEnvDecl[] = [];
-    for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-        const pluginId = entry.name;
-        const pluginRoot = join(root, pluginId);
-        const manifestPath = join(pluginRoot, PLUGIN_ENV_MANIFEST_FILE);
-        if (
-            !existsSync(join(pluginRoot, ".git")) ||
-            !existsSync(manifestPath)
-        ) {
-            continue;
-        }
-
-        let parsed: unknown;
-        try {
-            parsed = JSON.parse(readFileSync(manifestPath, "utf8"));
-        } catch (error) {
-            logger.warn(
-                `[plugins] unreadable ${PLUGIN_ENV_MANIFEST_FILE} in ${pluginId}:`,
-                error,
-            );
-            continue;
-        }
-        const result = PluginEnvManifestSchema.safeParse(parsed);
-        if (!result.success) {
-            logger.warn(
-                `[plugins] invalid ${PLUGIN_ENV_MANIFEST_FILE} in ${pluginId}: ${result.error.message}`,
-            );
-            continue;
-        }
-
-        // Dedupe keys within one plugin; first declaration wins.
-        const seen = new Set<string>();
-        const env = result.data.env.filter((v) => {
-            if (seen.has(v.key)) return false;
-            seen.add(v.key);
-            return true;
-        });
-        if (env.length > 0) decls.push({ pluginId, env });
-    }
-
-    decls.sort((a, b) => a.pluginId.localeCompare(b.pluginId));
-    return decls;
-}
+export { loadPluginEnvDecls, PLUGIN_ENV_MANIFEST_FILE } from "@ext/plugin-env";


### PR DESCRIPTION
## Summary
- Move `loadPluginEnvDecls` (the `tongflow.plugin.json` reader feeding the Settings dialog's per-plugin env cards) behind an `@ext/plugin-env` seam, following the exact `plugin-registry` seam pattern.
- Default backend `src/ext-default/plugin-env.ts` keeps the current filesystem scan verbatim — no behavior change for desktop/self-host.
- Motivation: on the managed cloud deployment there is no plugins directory on the server (plugin code is provisioned inside the executor at run time), so the fs scan returns `[]` and the Settings dialog shows no plugin env vars. The cloud shell will substitute a build-time baked declaration list via `src/ext/plugin-env.ts`.

## Test plan
- `pnpm lint:check` / `pnpm typecheck` / `pnpm build` pass.
- Desktop: settings dialog renders per-plugin env cards exactly as before (same code, moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)