### PR TITLE
fix: allow single-image images-gen-video; re-fit view after loading a workflow

### DIFF
--- a/src/components/workspace/nodes/compose/images-gen-video.tsx
+++ b/src/components/workspace/nodes/compose/images-gen-video.tsx
@@ -94,7 +94,7 @@ const ImagesGenVideoNode = ({
             title={t("titles.imagesGenVideo")}
             icon={<Film className="h-5 w-5" />}
             executeLabel={t("actions.generateVideo")}
-            executeDisabled={!allImages || allImages.length < 2}
+            executeDisabled={!allImages || allImages.length < 1}
         >
             <div className="p-4 space-y-4">
                 <AspectRatioPicker

--- a/src/components/workspace/workflow-dialog.tsx
+++ b/src/components/workspace/workflow-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Edge, Node } from "@xyflow/react";
+import { type Edge, type Node, useReactFlow } from "@xyflow/react";
 import {
     Box,
     Download,
@@ -209,6 +209,7 @@ interface WorkflowDialogProps {
 
 export function WorkflowDialog({ trigger, tooltip }: WorkflowDialogProps) {
     const t = useTranslations("Workspace.dialog");
+    const { fitView } = useReactFlow();
     const [open, setOpen] = useState(false);
     const [workflows, setWorkflows] = useState<Workflow[]>([]);
     const [loading, setLoading] = useState(false);
@@ -285,13 +286,20 @@ export function WorkflowDialog({ trigger, tooltip }: WorkflowDialogProps) {
                 useFlow.getState().setWorkflowId(workflow.id);
                 setOpen(false);
 
+                // `fitView` on <ReactFlow> only runs at mount; switching
+                // workflows swaps nodes without re-fitting, so the freshly
+                // loaded nodes render off-screen. Re-fit once they've mounted.
+                setTimeout(() => {
+                    void fitView({ duration: 400, padding: 0.2 });
+                }, 50);
+
                 toast.success(t("loadSuccess"));
             } catch (error) {
                 logger.error("Failed to load workflow:", error);
                 showErrorToast({ message: t("loadFailed") });
             }
         },
-        [t],
+        [t, fitView],
     );
 
     const renderWorkflowCard = useCallback(


### PR DESCRIPTION
Salvages the two unrelated fixes from the abandoned `feat/free-pro-plan-gates` branch (the plan-gate seam itself is dropped — cloud monetization moved to a single subscription gate implemented entirely in the cloud shell, so upstream stays free of subscription code).

- **images-gen-video**: single-image-to-video models exist; lower the execute gate from 2 images to 1.
- **workflow-dialog**: `fitView` only runs at ReactFlow mount, so loading a workflow left the freshly loaded nodes off-screen; re-fit once they've mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)