### PR TITLE
feat(api): cancelable tf:unauthorized event so shells can take over 401 UX

### DIFF
--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -164,7 +164,20 @@ export async function apiClient<T = unknown>(
                     response.status === 401
                         ? t("unauthorized")
                         : t("accessDenied");
-                if (shouldShowErrorToast) {
+                // Cancelable seam for embedding shells: preventDefault means
+                // the shell surfaced the 401 itself (e.g. a sign-in dialog),
+                // so the default toast is suppressed.
+                const handledByShell =
+                    response.status === 401 &&
+                    typeof window !== "undefined" &&
+                    !window.dispatchEvent(
+                        new CustomEvent("tf:unauthorized", {
+                            cancelable: true,
+                        }),
+                    );
+                if (handledByShell) {
+                    errorToastShown = true;
+                } else if (shouldShowErrorToast) {
                     showErrorToast({ message: authErrorMsg });
                     errorToastShown = true;
                 }


### PR DESCRIPTION
## Why

In the cloud build, a signed-out user hitting any API gets a bare "Unauthorized" toast — unfriendly for first-time users. The cloud shell wants to open a sign-in dialog instead, but the api client had no seam to suppress its own toast.

## What

On 401, `apiClient` dispatches a cancelable `tf:unauthorized` CustomEvent before showing the toast. If a listener calls `preventDefault()` (the cloud shell's fetch guard does, opening its sign-in dialog), the toast is suppressed and the error still propagates to the caller as before. With no listener (OSS/self-host), behavior is byte-for-byte unchanged.

403 keeps the existing toast — signing in wouldn't help there.

Companion change in the cloud shell repo wires this to a login dialog.

## Verified

- `pnpm lint:check`, `pnpm typecheck`, `pnpm build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)