### PR TITLE
fix(desktop): open settings env-var links in the system browser

### DIFF
--- a/src/components/workspace/settings-dialog.tsx
+++ b/src/components/workspace/settings-dialog.tsx
@@ -32,6 +32,7 @@ import {
     TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { apiGet, apiPut } from "@/lib/api/client";
+import { openExternalUrl } from "@/lib/desktop/open-external";
 import { logger } from "@/lib/logger";
 import type {
     PluginEnvDecl,
@@ -149,15 +150,18 @@ function DeclaredVarRow({
                     ) : null}
                 </span>
                 {v.url ? (
-                    <a
-                        href={v.url}
-                        target="_blank"
-                        rel="noreferrer"
+                    // A button, not an anchor: the desktop shell's anchor
+                    // interception would keep console URLs with OAuth-ish
+                    // paths inside the WebView (see lib/desktop).
+                    <button
+                        type="button"
                         aria-label={t("getKey")}
+                        title={v.url}
                         className="text-muted-foreground hover:text-foreground"
+                        onClick={() => v.url && openExternalUrl(v.url)}
                     >
                         <ExternalLink className="h-3 w-3" />
-                    </a>
+                    </button>
                 ) : null}
             </div>
             <div className="flex items-center gap-2">

--- a/src/lib/desktop/open-external.ts
+++ b/src/lib/desktop/open-external.ts
@@ -1,0 +1,44 @@
+/**
+ * Desktop-shell support: open a URL in the user's default browser instead of
+ * navigating the app WebView.
+ *
+ * The desktop app is a Pake (Tauri) shell that exposes `window.__TAURI__`
+ * (withGlobalTauri) with the `shell:allow-open` permission. Pake's own click
+ * interception keeps any URL matching OAuth-ish patterns (/login, /signin,
+ * /auth/, ...) inside the WebView — right for sign-in flows, wrong for
+ * "get your API key" console links, which often carry such paths. Callers
+ * that must always leave the app invoke the shell explicitly instead of
+ * relying on anchor interception.
+ */
+
+interface TauriGlobal {
+    core?: {
+        invoke?: (
+            cmd: string,
+            args?: Record<string, unknown>,
+        ) => Promise<unknown>;
+    };
+}
+
+function tauriInvoke() {
+    if (typeof window === "undefined") return undefined;
+    return (window as Window & { __TAURI__?: TauriGlobal }).__TAURI__?.core
+        ?.invoke;
+}
+
+/**
+ * Open the URL in the system browser (desktop shell) or a new tab (plain
+ * browser).
+ */
+export function openExternalUrl(url: string): void {
+    const invoke = tauriInvoke();
+    if (invoke) {
+        void invoke("plugin:shell|open", { path: url }).catch(() => {
+            // Pake also routes window.open of external URLs to the system
+            // browser, so this fallback stays out of the WebView too.
+            window.open(url, "_blank", "noopener,noreferrer");
+        });
+        return;
+    }
+    window.open(url, "_blank", "noopener,noreferrer");
+}


### PR DESCRIPTION
## Why

Desktop-app users report that clicking the settings dialog's env-var "get key" links navigates **inside the app window** instead of opening the browser.

Root cause: the Pake shell injects a document-capture click handler whose `matchesAuthUrl` treats any URL containing `/login`, `/signin`, `/auth/`, `/authorize` as an OAuth flow and forces `window.location.href` in the WebView. Provider console URLs (and their login redirects) frequently match, so the WebView leaves the app entirely. A React `onClick` can't intercept first — Pake's handler runs at document capture and calls `stopImmediatePropagation`.

## What

- New `src/lib/desktop/open-external.ts`: `openExternalUrl(url)` invokes `plugin:shell|open` via `window.__TAURI__` (Pake builds with `withGlobalTauri` + `shell:allow-open`), falling back to `window.open(_blank)` in a plain browser.
- `settings-dialog.tsx`: the env-var external-link anchor becomes a button calling it — Pake's anchor interception never engages.

Browser UX unchanged (still a new tab). Desktop UX: always the system default browser. Since the shell remote-loads app.tongflow.com, **already-installed desktop apps get the fix on the next cloud deploy** — no desktop re-release.

## Verified

`pnpm lint:check` / `pnpm typecheck` / `pnpm build` all pass. Manual check pending: click a Modal token link in the installed desktop app after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)