### PR TITLE
feat(sdk): cloud progress self-report via _tongflow sink (0.2.8)

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tongflow"
-version = "0.2.7"
+version = "0.2.8"
 description = "Python SDK for TongFlow — author plugins and run multi-modal GenAI workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/tongflow/__init__.py
+++ b/sdk/tongflow/__init__.py
@@ -11,6 +11,6 @@ from .deploy_marker import deploy
 from .engine import run_workflow
 from .progress import progress
 
-__version__ = "0.2.7"
+__version__ = "0.2.8"
 
 __all__ = ["deploy", "progress", "run_workflow"]

--- a/sdk/tongflow/engine/invoker.py
+++ b/sdk/tongflow/engine/invoker.py
@@ -74,6 +74,20 @@ def invoke_plugin(
     env_extra: Optional[dict[str, str]] = None,
     on_progress: Optional[ProgressCb] = None,
 ) -> dict[str, Any]:
+    # Cloud mode: the orchestrator exports a progress callback so plugins that
+    # run remotely (their own Modal function, no stderr path back here) can push
+    # progress straight to the Worker. Tuck it into the prompt under the reserved
+    # `_tongflow` key — entry.py forwards the prompt verbatim to the backend and
+    # @node_slot pops it back out. Absent env → unchanged local behaviour.
+    progress_url = os.environ.get("TONGFLOW_PROGRESS_URL")
+    progress_token = os.environ.get("TONGFLOW_PROGRESS_TOKEN")
+    cloud_progress = bool(progress_url and progress_token)
+    prompt_out = (
+        {**prompt, "_tongflow": {"progressUrl": progress_url, "token": progress_token}}
+        if cloud_progress
+        else prompt
+    )
+
     payload = json.dumps(
         {
             "pluginId": plugin_id,
@@ -82,7 +96,7 @@ def invoke_plugin(
             # Optional per-node model choice for router-style plugins; omitted
             # when unset so the envelope stays stable for existing plugins.
             **({"model": model} if model else {}),
-            "prompt": prompt,
+            "prompt": prompt_out,
         }
     )
 
@@ -114,7 +128,9 @@ def invoke_plugin(
             line = line.rstrip("\n")
             prog = parse_progress_line(line)
             if prog is not None:
-                if on_progress is not None:
+                # In cloud mode progress() already POSTed this event straight to
+                # the Worker, so forwarding the stderr copy too would double it.
+                if on_progress is not None and not cloud_progress:
                     on_progress({"type": "plugin_progress", "pluginId": plugin_id, **prog})
                 continue
             stderr_log.append(line)

--- a/sdk/tongflow/progress.py
+++ b/sdk/tongflow/progress.py
@@ -1,23 +1,79 @@
 """Backend-neutral progress reporting for plugins.
 
-A plugin reports progress by calling :func:`progress`. It writes a single
-sentinel-framed line to **stderr** (stdout is reserved for the ABI-JSON result),
-which the platform's generic runner parses and forwards to the task stream.
+A plugin reports progress by calling :func:`progress`. It always writes a
+single sentinel-framed line to **stderr** (stdout is reserved for the ABI-JSON
+result), which the platform's generic runner parses locally.
+
+Cloud mode: when the platform runs a plugin remotely (its own Modal function),
+stderr never reaches the orchestrator, so the same event is ALSO POSTed to a
+progress callback. The callback target is not passed as an argument (the slot
+signature is ABI-locked); the `@node_slot` wrapper pulls it from the reserved
+`_tongflow` key on the incoming dict and installs it here via
+:func:`set_progress_sink`. When no sink is installed (desktop / local runs)
+behaviour is unchanged — pure stderr.
 
 The sentinel must stay byte-for-byte identical to the TypeScript side
 (`src/lib/plugin-executor/progress-protocol.ts`).
-
-Works regardless of where the plugin actually runs: call it from a local
-adapter, from inside a Modal method, or from any other backend — the line ends
-up on the subprocess stderr the platform is reading.
 """
 
 from __future__ import annotations
 
+import contextvars
 import json
 import sys
+import threading
+import urllib.request
 
 PROGRESS_SENTINEL = "@@TF_PROGRESS@@"
+
+# Cloud progress callback for the current request: {"progressUrl", "token"} or
+# None. Installed per call by @node_slot (mirrors _current_model), so it never
+# leaks across requests in a reused container.
+_progress_sink: contextvars.ContextVar[dict[str, str] | None] = (
+    contextvars.ContextVar("tongflow_progress_sink", default=None)
+)
+
+
+def set_progress_sink(sink: dict[str, str] | None) -> None:
+    """Install (or clear) the cloud progress callback for this request."""
+    _progress_sink.set(sink)
+
+
+def _post_progress(sink: dict[str, str], payload: dict[str, object]) -> None:
+    """Fire-and-forget POST of one progress event to the Worker callback.
+
+    Shape matches /api/executor/callback's `type:"event"` contract; the token
+    is the per-run signed token that binds scope+taskId server-side. Never
+    blocks or raises into the plugin — a dropped event is acceptable.
+    """
+    url = sink.get("progressUrl")
+    token = sink.get("token")
+    if not url or not token:
+        return
+    body = json.dumps(
+        {
+            "token": token,
+            "type": "event",
+            "event": {"status": "RUNNING", "data": payload},
+        }
+    ).encode()
+
+    def _send() -> None:
+        try:
+            req = urllib.request.Request(
+                url,
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": "tongflow-plugin/1.0",
+                },
+                method="POST",
+            )
+            urllib.request.urlopen(req, timeout=15)  # noqa: S310
+        except Exception:  # noqa: BLE001 - progress must never break the run
+            pass
+
+    threading.Thread(target=_send, daemon=True).start()
 
 
 def progress(message: str, *, percent: float | None = None) -> None:
@@ -30,3 +86,8 @@ def progress(message: str, *, percent: float | None = None) -> None:
     # with the JSON result on stdout.
     sys.stderr.write(line + "\n")
     sys.stderr.flush()
+    # Cloud: also push straight to the Worker callback (remote plugins have no
+    # stderr path back to the orchestrator).
+    sink = _progress_sink.get()
+    if sink:
+        _post_progress(sink, payload)

--- a/sdk/tongflow/slots.py
+++ b/sdk/tongflow/slots.py
@@ -31,6 +31,8 @@ from typing import Any, TypeVar, cast
 
 from pydantic import BaseModel
 
+from .progress import set_progress_sink
+
 F = TypeVar("F", bound=Callable[..., object])
 
 # Per-request model selection (router-style plugins). The platform's envelope
@@ -38,6 +40,13 @@ F = TypeVar("F", bound=Callable[..., object])
 # it into the prompt dict under this reserved key, and the @node_slot wrapper
 # pops it back out before constructing the typed input.
 MODEL_KEY = "_model"
+
+# Per-request cloud progress callback ({"progressUrl", "token"}). The
+# orchestrator tucks it into the prompt dict under this reserved key when it
+# runs a plugin remotely; the wrapper pops it out and installs it as the
+# progress sink so `progress()` can push events to the Worker. Never an ABI
+# field. Absent on desktop/local runs.
+TONGFLOW_KEY = "_tongflow"
 _current_model: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "tongflow_current_model", default=None
 )
@@ -166,9 +175,10 @@ def node_slot(*slots: str) -> Callable[[F], F]:
 
         def _marshal(input: Any) -> Any:
             if isinstance(input, dict):
-                # Reserved routing key, never an ABI field: reset per call so a
-                # previous request's selection can't leak into this one.
+                # Reserved keys, never ABI fields: reset per call so a previous
+                # request's selection/sink can't leak into this one.
                 _current_model.set(input.pop(MODEL_KEY, None))
+                set_progress_sink(input.pop(TONGFLOW_KEY, None))
                 if input_cls is not None:
                     return _deep_construct(input_cls, input)
             return input


### PR DESCRIPTION
## M2 of the executor rework

Remote Modal plugins run in their own container, so `progress()` writes to a stderr the orchestrator never reads — **plugin-internal progress was silently lost in the cloud**. This adds an opt-in push path (backend-neutral, no `modal` import).

### Changes
- **`progress.py`**: contextvar progress sink; when installed, `progress()` also fire-and-forget POSTs the event to a Worker callback (`type:"event"` shape). Unset (desktop/local) → pure stderr, unchanged.
- **`slots.py`**: `@node_slot` pops the reserved `_tongflow` key (`{progressUrl, token}`) and installs it as the sink — mirrors the existing `_model` key, so the slot method still receives a clean ABI model.
- **`engine/invoker.py`**: in cloud mode (`TONGFLOW_PROGRESS_URL/TOKEN` env) inject `_tongflow` into the plugin payload (entry.py forwards it verbatim) and skip the stderr progress copy to avoid double-emitting.
- Version → **0.2.8**.

### Validation
- `cd sdk && pytest` → **38 passed**.
- Targeted test: sink install, clean ABI input (`_tongflow`/`_model` stripped), correct callback body, no POST when key absent.

Backward compatible: old-SDK plugins ignore the extra `_tongflow` key (model_construct drops unknown fields). Requires publish to PyPI + executor pin bump to 0.2.8 to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)