### PR TITLE
feat(sdk): serve_stream single-container streaming slot execution (0.2.11)

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tongflow"
-version = "0.2.10"
+version = "0.2.11"
 description = "Python SDK for TongFlow — author plugins and run multi-modal GenAI workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/tongflow/__init__.py
+++ b/sdk/tongflow/__init__.py
@@ -10,8 +10,15 @@ from __future__ import annotations
 from .deploy_marker import deploy
 from .engine import run_workflow
 from .progress import progress
-from .serve import run_and_report, serve_slot
+from .serve import run_and_report, serve_slot, serve_stream
 
-__version__ = "0.2.10"
+__version__ = "0.2.11"
 
-__all__ = ["deploy", "progress", "run_and_report", "run_workflow", "serve_slot"]
+__all__ = [
+    "deploy",
+    "progress",
+    "run_and_report",
+    "run_workflow",
+    "serve_slot",
+    "serve_stream",
+]

--- a/sdk/tongflow/progress.py
+++ b/sdk/tongflow/progress.py
@@ -23,57 +23,61 @@ import json
 import sys
 import threading
 import urllib.request
+from typing import Callable
 
 PROGRESS_SENTINEL = "@@TF_PROGRESS@@"
 
-# Cloud progress callback for the current request: {"progressUrl", "token"} or
-# None. Installed per call by @node_slot (mirrors _current_model), so it never
-# leaks across requests in a reused container.
-_progress_sink: contextvars.ContextVar[dict[str, str] | None] = (
+# Progress sink for the current request: a callable that receives each event
+# payload ({"message", "percent"?}), or None. It is a plain callback so the
+# same plumbing serves both transports — an HTTP POST to the Worker (remote
+# executor path) and an in-process queue (streaming serve, one container).
+# contextvar-scoped so it never leaks across requests in a reused container.
+ProgressSink = Callable[[dict[str, object]], None]
+_progress_sink: contextvars.ContextVar[ProgressSink | None] = (
     contextvars.ContextVar("tongflow_progress_sink", default=None)
 )
 
 
-def set_progress_sink(sink: dict[str, str] | None) -> None:
-    """Install (or clear) the cloud progress callback for this request."""
+def set_progress_sink(sink: ProgressSink | None) -> None:
+    """Install (or clear) the progress sink for this request/thread."""
     _progress_sink.set(sink)
 
 
-def _post_progress(sink: dict[str, str], payload: dict[str, object]) -> None:
-    """Fire-and-forget POST of one progress event to the Worker callback.
+def http_progress_sink(url: str, token: str) -> ProgressSink:
+    """A sink that fire-and-forget POSTs each event to the Worker callback.
 
     Shape matches /api/executor/callback's `type:"event"` contract; the token
     is the per-run signed token that binds scope+taskId server-side. Never
     blocks or raises into the plugin — a dropped event is acceptable.
     """
-    url = sink.get("progressUrl")
-    token = sink.get("token")
-    if not url or not token:
-        return
-    body = json.dumps(
-        {
-            "token": token,
-            "type": "event",
-            "event": {"status": "RUNNING", "data": payload},
-        }
-    ).encode()
 
-    def _send() -> None:
-        try:
-            req = urllib.request.Request(
-                url,
-                data=body,
-                headers={
-                    "Content-Type": "application/json",
-                    "User-Agent": "tongflow-plugin/1.0",
-                },
-                method="POST",
-            )
-            urllib.request.urlopen(req, timeout=15)  # noqa: S310
-        except Exception:  # noqa: BLE001 - progress must never break the run
-            pass
+    def _sink(payload: dict[str, object]) -> None:
+        body = json.dumps(
+            {
+                "token": token,
+                "type": "event",
+                "event": {"status": "RUNNING", "data": payload},
+            }
+        ).encode()
 
-    threading.Thread(target=_send, daemon=True).start()
+        def _send() -> None:
+            try:
+                req = urllib.request.Request(
+                    url,
+                    data=body,
+                    headers={
+                        "Content-Type": "application/json",
+                        "User-Agent": "tongflow-plugin/1.0",
+                    },
+                    method="POST",
+                )
+                urllib.request.urlopen(req, timeout=15)  # noqa: S310
+            except Exception:  # noqa: BLE001 - progress must never break the run
+                pass
+
+        threading.Thread(target=_send, daemon=True).start()
+
+    return _sink
 
 
 def progress(message: str, *, percent: float | None = None) -> None:
@@ -86,8 +90,11 @@ def progress(message: str, *, percent: float | None = None) -> None:
     # with the JSON result on stdout.
     sys.stderr.write(line + "\n")
     sys.stderr.flush()
-    # Cloud: also push straight to the Worker callback (remote plugins have no
-    # stderr path back to the orchestrator).
+    # Cloud: also hand the event to the installed sink (HTTP callback or the
+    # streaming serve's queue). Remote plugins have no stderr path back.
     sink = _progress_sink.get()
     if sink:
-        _post_progress(sink, payload)
+        try:
+            sink(payload)
+        except Exception:  # noqa: BLE001 - progress must never break the run
+            pass

--- a/sdk/tongflow/serve.py
+++ b/sdk/tongflow/serve.py
@@ -28,8 +28,10 @@ bytes back into refs. The `_tongflow` key rides into the method so
 from __future__ import annotations
 
 import json
+import queue
+import threading
 import urllib.request
-from typing import Any, Callable
+from typing import Any, Callable, Iterator
 
 from .engine.abi_schema import load_abi_schema, resolve_abi_path
 from .engine.assets import (
@@ -37,6 +39,7 @@ from .engine.assets import (
     materialize_asset_inputs,
 )
 from .engine.store import HttpStore
+from .progress import set_progress_sink
 
 # invoke(method_name, input_dict) -> raw ABI dict. The backend endpoint passes
 # a closure that runs the slot locally in this same container.
@@ -106,3 +109,52 @@ def run_and_report(payload: dict[str, Any], *, invoke: InvokeFn) -> None:
     _post(url, {"token": token, "type": "event",
                 "event": {"status": "COMPLETED", "data": result}})
     _post(url, {"token": token, "type": "completed", "result": result})
+
+
+def _sse(event: dict[str, Any]) -> str:
+    return f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+
+
+def serve_stream(payload: dict[str, Any], *, invoke: InvokeFn) -> Iterator[str]:
+    """Run one ABI slot in this container and stream progress + result as SSE.
+
+    Single-container, direct-stream path: the caller (browser or Worker) holds
+    an ``text/event-stream`` response; the slot runs in a worker thread while
+    this generator yields ``RUNNING`` progress events (fed by an in-process
+    progress sink), then a terminal ``COMPLETED``/``FAILED`` event carrying the
+    output refs. A streaming response starts immediately, so it is not bound by
+    the 150s request cap — the slot may take as long as the function timeout.
+
+    The payload must NOT carry `_tongflow` (that installs an HTTP sink); here
+    the sink is the in-process queue below.
+    """
+    q: "queue.Queue[tuple[str, Any]]" = queue.Queue()
+
+    def _run() -> None:
+        # Same thread as the slot call → the contextvar sink is visible to
+        # progress() invoked inside the slot.
+        set_progress_sink(lambda p: q.put(("progress", p)))
+        try:
+            result = serve_slot(payload, invoke=invoke)
+            q.put(("done", result))
+        except Exception as e:  # noqa: BLE001
+            q.put(("error", str(e)))
+        finally:
+            q.put(("end", None))
+
+    threading.Thread(target=_run, daemon=True).start()
+
+    while True:
+        try:
+            kind, data = q.get(timeout=10)
+        except queue.Empty:
+            yield ": ping\n\n"  # keep the connection alive between events
+            continue
+        if kind == "end":
+            return
+        if kind == "progress":
+            yield _sse({"status": "RUNNING", "data": data})
+        elif kind == "done":
+            yield _sse({"status": "COMPLETED", "data": data})
+        elif kind == "error":
+            yield _sse({"status": "FAILED", "data": {"message": "Task execution failed", "error": data}})

--- a/sdk/tongflow/slots.py
+++ b/sdk/tongflow/slots.py
@@ -31,7 +31,7 @@ from typing import Any, TypeVar, cast
 
 from pydantic import BaseModel
 
-from .progress import set_progress_sink
+from .progress import http_progress_sink, set_progress_sink
 
 F = TypeVar("F", bound=Callable[..., object])
 
@@ -175,10 +175,16 @@ def node_slot(*slots: str) -> Callable[[F], F]:
 
         def _marshal(input: Any) -> Any:
             if isinstance(input, dict):
-                # Reserved keys, never ABI fields: reset per call so a previous
-                # request's selection/sink can't leak into this one.
+                # Reserved keys, never ABI fields. `_model` resets per call. A
+                # `_tongflow` callback (executor path) installs an HTTP sink;
+                # when absent we leave the sink untouched so the streaming serve
+                # (which installs an in-process queue sink) isn't clobbered.
                 _current_model.set(input.pop(MODEL_KEY, None))
-                set_progress_sink(input.pop(TONGFLOW_KEY, None))
+                tf = input.pop(TONGFLOW_KEY, None)
+                if isinstance(tf, dict) and tf.get("progressUrl") and tf.get("token"):
+                    set_progress_sink(
+                        http_progress_sink(tf["progressUrl"], tf["token"])
+                    )
                 if input_cls is not None:
                     return _deep_construct(input_cls, input)
             return input


### PR DESCRIPTION
One-container direct-stream path: plugin serves a slot as text/event-stream. serve_stream runs the slot in a thread, yields RUNNING progress (in-process queue sink) then terminal COMPLETED/FAILED with refs. Streaming dodges the 150s cap — no trigger container. Progress sink refactored to a callable (http_progress_sink for the executor path + the streaming queue sink); @node_slot only installs the HTTP sink when _tongflow is present. 38 tests + targeted stream test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)