### PR TITLE
fix(sdk): HttpStore UA (CF 403) + serve_stream event id (0.2.13)

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tongflow"
-version = "0.2.12"
+version = "0.2.13"
 description = "Python SDK for TongFlow — author plugins and run multi-modal GenAI workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/tongflow/__init__.py
+++ b/sdk/tongflow/__init__.py
@@ -17,7 +17,7 @@ from .serve import (
     serve_stream_from_spec,
 )
 
-__version__ = "0.2.12"
+__version__ = "0.2.13"
 
 __all__ = [
     "deploy",

--- a/sdk/tongflow/engine/store.py
+++ b/sdk/tongflow/engine/store.py
@@ -126,7 +126,13 @@ class HttpStore:
         self.token = token
 
     def _headers(self) -> dict[str, str]:
-        return {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        # A non-default User-Agent is required: Cloudflare's bot filtering 403s
+        # the stock Python-urllib UA, which breaks asset IO from a plugin
+        # container talking to the Worker sink.
+        headers = {"User-Agent": "tongflow-sdk/1.0"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
 
     def put(
         self,

--- a/sdk/tongflow/serve.py
+++ b/sdk/tongflow/serve.py
@@ -115,7 +115,9 @@ def _sse(event: dict[str, Any]) -> str:
     return f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
 
 
-def serve_stream(payload: dict[str, Any], *, invoke: InvokeFn) -> Iterator[str]:
+def serve_stream(
+    payload: dict[str, Any], *, invoke: InvokeFn, task_id: str = ""
+) -> Iterator[str]:
     """Run one ABI slot in this container and stream progress + result as SSE.
 
     Single-container, direct-stream path: the caller (browser or Worker) holds
@@ -124,6 +126,9 @@ def serve_stream(payload: dict[str, Any], *, invoke: InvokeFn) -> Iterator[str]:
     progress sink), then a terminal ``COMPLETED``/``FAILED`` event carrying the
     output refs. A streaming response starts immediately, so it is not bound by
     the 150s request cap — the slot may take as long as the function timeout.
+
+    Each event carries ``id: task_id`` so the browser can attribute it and
+    persist the terminal state (its /api/task/update-status backup).
 
     The payload must NOT carry `_tongflow` (that installs an HTTP sink); here
     the sink is the in-process queue below.
@@ -153,11 +158,11 @@ def serve_stream(payload: dict[str, Any], *, invoke: InvokeFn) -> Iterator[str]:
         if kind == "end":
             return
         if kind == "progress":
-            yield _sse({"status": "RUNNING", "data": data})
+            yield _sse({"id": task_id, "status": "RUNNING", "data": data})
         elif kind == "done":
-            yield _sse({"status": "COMPLETED", "data": data})
+            yield _sse({"id": task_id, "status": "COMPLETED", "data": data})
         elif kind == "error":
-            yield _sse({"status": "FAILED", "data": {"message": "Task execution failed", "error": data}})
+            yield _sse({"id": task_id, "status": "FAILED", "data": {"message": "Task execution failed", "error": data}})
 
 
 def _resolve_method(deploy_file: str, node_slot: str) -> str:
@@ -214,6 +219,6 @@ def serve_stream_from_spec(
             "assetToken": spec["assetToken"],
         }
     except Exception as e:  # noqa: BLE001
-        yield _sse({"status": "FAILED", "data": {"message": "Spec fetch failed", "error": str(e)}})
+        yield _sse({"id": task_id, "status": "FAILED", "data": {"message": "Spec fetch failed", "error": str(e)}})
         return
-    yield from serve_stream(payload, invoke=invoke)
+    yield from serve_stream(payload, invoke=invoke, task_id=task_id)


### PR DESCRIPTION
First live single-node direct-serve run surfaced two: (1) HttpStore had no User-Agent → Cloudflare 403'd the plugin's asset upload (gen ok, upload failed); now sends a non-default UA. (2) serve_stream events had no `id` → browser's update-status backup POSTed without taskId (400), so the result never persisted; thread task_id + stamp `id`, closing the direct-path DB gap. 38 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)