### PR TITLE
chore(release): 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-07-25
+
+### Added
+
+- **DeepSeek plugin** (`tongflow-api-deepseek`) — DeepSeek V4 as a text
+  provider for `gen-text` / `combine-text` / `split-text`, with a per-node
+  **model dropdown** offering `deepseek-v4-flash` / `deepseek-v4-pro` each
+  with thinking on/off (four choices).
+- **Streaming "thinking" bubble** — when a plugin streams its reasoning
+  (DeepSeek thinking mode), it now appears live in an auto-scrolling bubble
+  anchored beside the node while it runs, separate from the status label and
+  non-occluding. Backed by `progress(..., thinking=True)` in the SDK.
+- **SenseNova-Vision plugin** (`tongflow-modal-sensenova-vision`) — SenseTime's
+  unified vision model: image understanding / visual QA, detection & OCR
+  structured text, full-scene surface normals, salient-object matting, and a
+  human-pose overlay (an alternative implementation of those slots).
+- **Open-vocabulary sound separation** (`separate-sound` node) — describe any
+  sound in words ("dog barking") and split the audio into that sound and
+  everything else.
+
+### Changed
+
+- **Cloud plugin execution path** (Python SDK **tongflow 0.2.7 → 0.2.17**) — a
+  new single-container cloud execution surface so plugins can run in the
+  user's own Modal without a per-call venv + subprocess:
+  - `serve_slot` / `run_and_report` — single-slot execution and a background
+    single-node runner that reports back over an HTTP callback;
+  - `serve_stream` / `serve_stream_from_spec` — single-container streaming
+    slot execution, including a browser-direct stream entry;
+  - self-reported progress (and streamed reasoning) over an HTTP sink, so
+    remote plugins drive the node status and thinking bubble;
+  - an **injectable workflow invoker** that skips the venv + subprocess hop;
+  - **default-slot claims** (`TONGFLOW_DEFAULT_SLOTS`, `@node_slot(default=True)`)
+    so a plugin can declare the default implementation for a slot while still
+    importing under older, already-deployed runtimes.
+
+### Fixed
+
+- SDK `HttpStore` now sends a User-Agent (works around a Cloudflare 403) and
+  emits a stable event id in `serve_stream` (tongflow 0.2.13).
+
 ## [0.2.1] - 2026-07-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "description": "A multi-modal AIGC studio for building generative AI workflows",
     "author": "tong-io",
     "keywords": [


### PR DESCRIPTION
Cut **v0.2.2** — release notes for everything since 0.2.1.

### Added
- **DeepSeek plugin** (`tongflow-api-deepseek`) — DeepSeek V4 text provider (flash/pro) with a per-node model dropdown (× thinking on/off).
- **Streaming thinking bubble** — live, auto-scrolling reasoning beside the node (`progress(thinking=True)`).
- **SenseNova-Vision plugin** (`tongflow-modal-sensenova-vision`) — unified vision (understanding/VQA, detection & OCR, normals, matting, pose).
- **Open-vocabulary sound separation** (`separate-sound`).

### Changed
- **Cloud plugin execution path** (tongflow SDK 0.2.7 → 0.2.17): `serve_slot` / `run_and_report` / `serve_stream` / `serve_stream_from_spec`, HTTP self-reported progress, injectable workflow invoker, default-slot claims.

### Fixed
- SDK `HttpStore` User-Agent (Cloudflare 403) + stable `serve_stream` event id (0.2.13).

Bumps `package.json` to 0.2.2 and adds the CHANGELOG entry. The tag `v0.2.2` (pushed after merge) triggers `desktop-release.yml` to build the DMG/MSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)