### PR TITLE
fix(sdk): accept tongflow-router-* plugin id prefix

### DIFF
--- a/sdk/tests/test_scan.py
+++ b/sdk/tests/test_scan.py
@@ -100,3 +100,14 @@ def test_scan_models_duplicate_model_errors(tmp_path):
     )
     payload = _entry(_write_plugin(tmp_path, src), _write_abi(tmp_path))
     assert any("duplicate model" in e["message"] for e in payload["errors"])
+
+
+def test_scan_accepts_router_prefix(tmp_path):
+    # tongflow-router-* (aggregator plugins) are entry.py runners like -api-.
+    root = tmp_path / "plugins"
+    pdir = root / "tongflow-router-fake"
+    pdir.mkdir(parents=True)
+    (pdir / "entry.py").write_text(_HANDLERS, encoding="utf-8")
+    payload = _entry(root, _write_abi(tmp_path))
+    assert payload["errors"] == []
+    assert "tongflow-router-fake" in payload["plugins"]

--- a/sdk/tongflow/scan.py
+++ b/sdk/tongflow/scan.py
@@ -58,7 +58,9 @@ def _detect_runner(plugin_dir: Path) -> tuple[str | None, str | None]:
     # "unknown prefix"; surface a clear rename hint instead.
     lowered = plugin_id.lower()
     if plugin_id != lowered and (
-        lowered.startswith("tongflow-modal-") or lowered.startswith("tongflow-api-")
+        lowered.startswith("tongflow-modal-")
+        or lowered.startswith("tongflow-api-")
+        or lowered.startswith("tongflow-router-")
     ):
         return None, (
             f"{plugin_dir}:1: pluginId must be all lowercase; "
@@ -85,10 +87,14 @@ def _detect_runner(plugin_dir: Path) -> tuple[str | None, str | None]:
         prefix_runner = "modal"
     elif plugin_id.startswith("tongflow-api-"):
         prefix_runner = "api"
+    elif plugin_id.startswith("tongflow-router-"):
+        # Aggregator/router plugins (one key routing to many third-party models)
+        # are entry.py-based local runners — identical execution to "api".
+        prefix_runner = "api"
     else:
         return None, (
             f"{plugin_dir}:1: unknown pluginId prefix; "
-            "fix: use tongflow-modal-<name> or tongflow-api-<name>"
+            "fix: use tongflow-modal-<name>, tongflow-api-<name>, or tongflow-router-<name>"
         )
 
     if not has_deploy and not has_entry:


### PR DESCRIPTION
The plugin scanner (`sdk/tongflow/scan.py` `_detect_runner`) only recognised `tongflow-modal-*` and `tongflow-api-*` prefixes and rejected any `tongflow-router-*` plugin with "unknown pluginId prefix", dropping it from the registry (`plugins` + `nodePluginMap`).

Router / aggregator plugins (OpenRouter, APIMart, Replicate, fal) are entry.py-based local runners — identical execution to `-api-` — so this maps the `tongflow-router-` prefix to the `api` runner. Also extends the lowercase-id hint and the error message, and adds a regression test.

Needed for the `tongflow-router-*` rename to register in the studio bake.

Verified: `cd sdk && pytest` (56 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)