### PR TITLE
feat: dynamic-cardinality one-click execution (guard + batch fan-out + channel pass-through)

### DIFF
--- a/sdk/tests/test_engine.py
+++ b/sdk/tests/test_engine.py
@@ -15,7 +15,7 @@ from tongflow.engine.assets import (
     convert_asset_outputs_to_file_refs,
     materialize_asset_inputs,
 )
-from tongflow.engine.bindings import resolve_node_params
+from tongflow.engine.bindings import resolve_node_param_sets, resolve_node_params
 from tongflow.engine.invoker import parse_progress_line
 from tongflow.engine.output_view import compute_output_view
 from tongflow.engine.store import DiskStore, MemoryStore
@@ -91,6 +91,75 @@ def test_resolve_node_params_scalar_with_multiple_values_raises():
     state = {"dn1": {"texts": ["first", "second"]}}
     with pytest.raises(ValueError, match="'My Node' input 'text'.*2 upstream"):
         resolve_node_params(node, {}, state, [{"id": "dn1"}], {})
+
+
+def test_resolve_node_param_sets_batch_fan_out():
+    # The batchField expands into one param set per value; other fields broadcast.
+    node = {
+        "batchField": "text",
+        "bindings": {
+            "text": {
+                "kind": "handle",
+                "consumerShape": "scalar",
+                "sources": [{"fromNodeId": "dn1", "fromField": "texts"}],
+            },
+            "voice": {"kind": "config", "value": "alto"},
+        },
+    }
+    state = {"dn1": {"texts": ["a", "b", "c"]}}
+    sets = resolve_node_param_sets(node, {}, state, [{"id": "dn1"}], {})
+    assert sets == [
+        {"voice": "alto", "text": "a"},
+        {"voice": "alto", "text": "b"},
+        {"voice": "alto", "text": "c"},
+    ]
+    # Single-invocation variant refuses fan-out.
+    with pytest.raises(ValueError, match="fans out"):
+        resolve_node_params(node, {}, state, [{"id": "dn1"}], {})
+
+
+def test_resolve_node_param_sets_batch_single_value_is_one_set():
+    node = {
+        "batchField": "text",
+        "bindings": {
+            "text": {
+                "kind": "handle",
+                "consumerShape": "scalar",
+                "sources": [{"fromNodeId": "dn1", "fromField": "texts"}],
+            }
+        },
+    }
+    state = {"dn1": {"texts": ["solo"]}}
+    assert resolve_node_param_sets(node, {}, state, [{"id": "dn1"}], {}) == [
+        {"text": "solo"}
+    ]
+
+
+def test_resolve_node_param_sets_non_batch_scalar_still_raises():
+    # batchField only exempts its own field; other scalar inputs stay strict.
+    node = {
+        "batchField": "text",
+        "bindings": {
+            "text": {
+                "kind": "handle",
+                "consumerShape": "scalar",
+                "sources": [{"fromNodeId": "dn1", "fromField": "texts"}],
+            },
+            "refAudio": {
+                "kind": "handle",
+                "consumerShape": "scalar",
+                "sources": [{"fromNodeId": "dn2", "fromField": "fileKeys"}],
+            },
+        },
+    }
+    state = {
+        "dn1": {"texts": ["a", "b"]},
+        "dn2": {"fileKeys": ["x.mp3", "y.mp3"]},
+    }
+    with pytest.raises(ValueError, match="input 'refAudio'"):
+        resolve_node_param_sets(
+            node, {}, state, [{"id": "dn1"}, {"id": "dn2"}], {}
+        )
 
 
 def test_resolve_node_params_array_and_config_and_input():
@@ -561,6 +630,55 @@ def test_run_workflow_uses_static_data_when_input_omitted(tmp_path, monkeypatch)
         auto_install=False,
     )
     assert result["outputs"][exec_id]["text"] == "OVERRIDE"
+
+
+def test_run_workflow_batch_fan_out(tmp_path, monkeypatch):
+    # A batchField with N upstream values → N plugin invocations, outputs
+    # concatenated in batch order into a single flat channel.
+    abi_path = _write_abi(tmp_path)
+    plugins_dir, plugin_id, workflow, exec_id = _stub_plugin_and_workflow(tmp_path)
+    _patch_scan(monkeypatch, plugin_id)
+
+    workflow["dataNodes"][0]["staticData"] = {"texts": ["alpha", "beta", "gamma"]}
+    workflow["executableNodes"][0]["batchField"] = "text"
+
+    events = []
+    result = run_workflow(
+        workflow,
+        plugins_dir=plugins_dir,
+        data_dir=tmp_path / "data",
+        abi_path=abi_path,
+        auto_install=False,
+        on_progress=events.append,
+    )
+
+    assert result["status"] == "success"
+    assert result["outputs"][exec_id]["text"] == ["ALPHA", "BETA", "GAMMA"]
+    assert result["outputs_by_name"]["out_text"] == ["ALPHA", "BETA", "GAMMA"]
+    msgs = [e.get("message") for e in events if e["type"] == "plugin_progress"]
+    assert "batch 1/3" in msgs and "batch 3/3" in msgs
+
+
+def test_run_workflow_scalar_overflow_fails_node(tmp_path, monkeypatch):
+    # Without a batchField, N>1 values into a scalar input fail the node
+    # loudly instead of silently processing only the first value.
+    abi_path = _write_abi(tmp_path)
+    plugins_dir, plugin_id, workflow, exec_id = _stub_plugin_and_workflow(tmp_path)
+    _patch_scan(monkeypatch, plugin_id)
+
+    workflow["dataNodes"][0]["staticData"] = {"texts": ["alpha", "beta"]}
+
+    result = run_workflow(
+        workflow,
+        plugins_dir=plugins_dir,
+        data_dir=tmp_path / "data",
+        abi_path=abi_path,
+        auto_install=False,
+    )
+
+    assert result["status"] == "failed"
+    assert exec_id not in result["outputs"]
+    assert any("expects a single value" in e for e in result["errors"])
 
 
 # --- paths resolution -------------------------------------------------------

--- a/sdk/tests/test_engine.py
+++ b/sdk/tests/test_engine.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from tongflow.engine import run_workflow
 from tongflow.engine import plugins as plugins_mod
 from tongflow.engine import runner as runner_mod
@@ -69,9 +71,26 @@ def test_resolve_node_params_handle_scalar_from_data_node():
             }
         }
     }
-    state = {"dn1": {"texts": ["first", "second"]}}
+    state = {"dn1": {"texts": ["only"]}}
     params = resolve_node_params(node, {}, state, [{"id": "dn1"}], {})
-    assert params["text"] == "first"
+    assert params["text"] == "only"
+
+
+def test_resolve_node_params_scalar_with_multiple_values_raises():
+    # A scalar input receiving N>1 values must error, not silently take [0].
+    node = {
+        "label": "My Node",
+        "bindings": {
+            "text": {
+                "kind": "handle",
+                "consumerShape": "scalar",
+                "sources": [{"fromNodeId": "dn1", "fromField": "texts"}],
+            }
+        },
+    }
+    state = {"dn1": {"texts": ["first", "second"]}}
+    with pytest.raises(ValueError, match="'My Node' input 'text'.*2 upstream"):
+        resolve_node_params(node, {}, state, [{"id": "dn1"}], {})
 
 
 def test_resolve_node_params_array_and_config_and_input():

--- a/sdk/tongflow/engine/bindings.py
+++ b/sdk/tongflow/engine/bindings.py
@@ -4,6 +4,10 @@ Direct translation of ``resolveNodeParams`` in ``src/lib/task/runner.ts``.
 Values are read, in order, from: the upstream executable's projected output
 view, the live data-node state (``texts`` / ``fileKeys``), then the
 workflow-level inputs (for data nodes flagged as inputs).
+
+A scalar-shaped input that collects more than one upstream value is an error:
+one-click execution must never silently drop items produced by an upstream
+split (canvas-side execution fans those out interactively).
 """
 
 from __future__ import annotations
@@ -59,6 +63,19 @@ def resolve_node_params(
             for s in binding.get("sources", []):
                 collected.extend(read_source(s["fromNodeId"], s["fromField"]))
             if binding.get("consumerShape") == "scalar":
+                if len(collected) > 1:
+                    label = (
+                        node.get("label")
+                        or node.get("feature")
+                        or node.get("id")
+                        or "?"
+                    )
+                    raise ValueError(
+                        f"Node '{label}' input '{field}' expects a single value "
+                        f"but received {len(collected)} upstream values. "
+                        f"Refusing to silently drop all but the first — reduce "
+                        f"the upstream to one value."
+                    )
                 if collected:
                     params[field] = collected[0]
             else:

--- a/sdk/tongflow/engine/bindings.py
+++ b/sdk/tongflow/engine/bindings.py
@@ -5,27 +5,40 @@ Values are read, in order, from: the upstream executable's projected output
 view, the live data-node state (``texts`` / ``fileKeys``), then the
 workflow-level inputs (for data nodes flagged as inputs).
 
-A scalar-shaped input that collects more than one upstream value is an error:
+Batch fan-out: when the node's ``batchField`` (a scalar handle promoted via
+``batchOn`` in the canvas sourceSpec) collects N upstream values,
+``resolve_node_param_sets`` returns N param sets — one per value, every other
+field broadcast — mirroring the canvas-side ``buildPrompts`` expansion. Any
+other scalar-shaped input that collects more than one value is an error:
 one-click execution must never silently drop items produced by an upstream
-split (canvas-side execution fans those out interactively).
+split.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 
-def resolve_node_params(
+def resolve_node_param_sets(
     node: dict[str, Any],
     output_views: dict[str, dict[str, Any]],
     data_node_state: dict[str, dict[str, Any]],
     data_nodes: list[dict[str, Any]],
     inputs: dict[str, Any],
-) -> dict[str, Any]:
+) -> list[dict[str, Any]]:
+    """Resolve params, fanning out over the node's batch field.
+
+    Returns one param set per invocation the runner must perform (always at
+    least one). N sets only occur when ``node["batchField"]`` collected N
+    upstream values.
+    """
     params: dict[str, Any] = {}
     bindings = node.get("bindings")
     if not bindings:
-        return params
+        return [params]
+
+    batch_field = node.get("batchField")
+    batch_values: Optional[list[str]] = None
 
     data_node_map = {d["id"]: d for d in data_nodes if isinstance(d, dict) and "id" in d}
 
@@ -64,19 +77,22 @@ def resolve_node_params(
                 collected.extend(read_source(s["fromNodeId"], s["fromField"]))
             if binding.get("consumerShape") == "scalar":
                 if len(collected) > 1:
-                    label = (
-                        node.get("label")
-                        or node.get("feature")
-                        or node.get("id")
-                        or "?"
-                    )
-                    raise ValueError(
-                        f"Node '{label}' input '{field}' expects a single value "
-                        f"but received {len(collected)} upstream values. "
-                        f"Refusing to silently drop all but the first — reduce "
-                        f"the upstream to one value."
-                    )
-                if collected:
+                    if field == batch_field:
+                        batch_values = collected
+                    else:
+                        label = (
+                            node.get("label")
+                            or node.get("feature")
+                            or node.get("id")
+                            or "?"
+                        )
+                        raise ValueError(
+                            f"Node '{label}' input '{field}' expects a single "
+                            f"value but received {len(collected)} upstream "
+                            f"values. Refusing to silently drop all but the "
+                            f"first — reduce the upstream to one value."
+                        )
+                elif collected:
                     params[field] = collected[0]
             else:
                 params[field] = collected
@@ -84,4 +100,25 @@ def resolve_node_params(
             params[field] = binding.get("value")
         elif kind == "input":
             params[field] = inputs.get(binding["inputName"])
-    return params
+
+    if batch_values is None:
+        return [params]
+    return [{**params, batch_field: v} for v in batch_values]
+
+
+def resolve_node_params(
+    node: dict[str, Any],
+    output_views: dict[str, dict[str, Any]],
+    data_node_state: dict[str, dict[str, Any]],
+    data_nodes: list[dict[str, Any]],
+    inputs: dict[str, Any],
+) -> dict[str, Any]:
+    """Single-invocation variant; errors if the node fans out over its batch field."""
+    sets = resolve_node_param_sets(
+        node, output_views, data_node_state, data_nodes, inputs
+    )
+    if len(sets) > 1:
+        raise ValueError(
+            "Node fans out over its batch field; use resolve_node_param_sets."
+        )
+    return sets[0]

--- a/sdk/tongflow/engine/runner.py
+++ b/sdk/tongflow/engine/runner.py
@@ -7,9 +7,11 @@ TongFlow app required. It is a direct translation of ``executeWorkflowTask`` in
 
 1. seed data-node state from ``staticData`` (workflow inputs override on read)
 2. for each tier in ``executionLevels`` (already topologically sorted):
-   resolve params from bindings -> materialize asset inputs -> spawn the plugin
-   -> persist asset outputs -> project into the ABI output view -> refresh the
-   downstream data nodes this node feeds
+   resolve params from bindings (fanning out over the node's ``batchField``
+   when it collected multiple upstream values — one plugin invocation per
+   value, outputs concatenated in batch order) -> materialize asset inputs ->
+   spawn the plugin -> persist asset outputs -> project into the ABI output
+   view -> refresh the downstream data nodes this node feeds
 3. aggregate per-node outputs / errors and return.
 
 The exported JSON is a self-contained execution plan (sorted levels, resolved
@@ -25,7 +27,7 @@ from typing import Any, Callable, Optional, Union
 
 from .abi_schema import load_abi_schema, resolve_abi_path
 from .assets import convert_asset_outputs_to_file_refs, materialize_asset_inputs
-from .bindings import resolve_node_params
+from .bindings import resolve_node_param_sets
 from .invoker import invoke_plugin
 from .output_view import compute_output_view
 from .paths import resolve_data_dir, resolve_plugins_dir
@@ -76,6 +78,28 @@ def _inline_outputs_in_obj(obj: Any, store: MemoryStore) -> Any:
         if data is not None:
             return base64.b64encode(data).decode("ascii")
     return obj
+
+
+def _merge_batch_results(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Merge per-item outputs of a batch fan-out into one payload.
+
+    Each business field becomes the concatenation of the per-item values in
+    batch order (per-item lists are extended, scalars appended), so
+    ``compute_output_view`` sees one flat channel and downstream nodes read
+    all items. ``success`` / ``error`` meta fields are dropped — the runner
+    already raised on any per-item failure.
+    """
+    merged: dict[str, Any] = {"success": True}
+    for r in results:
+        for k, v in r.items():
+            if k in ("success", "error") or v is None:
+                continue
+            bucket = merged.setdefault(k, [])
+            if isinstance(v, list):
+                bucket.extend(v)
+            else:
+                bucket.append(v)
+    return merged
 
 
 def _load_workflow(workflow: Union[str, Path, dict[str, Any]]) -> dict[str, Any]:
@@ -324,35 +348,62 @@ def run_workflow(
                         f"Plugin {plugin_id} not found in scanned manifest."
                     )
 
-                params = resolve_node_params(
+                param_sets = resolve_node_param_sets(
                     node, output_views, data_node_state, data_nodes, inputs
                 )
-                business_input = materialize_asset_inputs(
-                    slot, params, abi, search_dirs, store
-                )
                 plugin_dir = plugins_dir / cfg["localSubdir"]
-                if invoker is not None:
-                    raw = invoker(plugin_id, slot, business_input, plugin_dir, model)
-                else:
-                    raw = invoke_plugin(
-                        python=python,
-                        plugin_dir=plugin_dir,
-                        entry_file=cfg.get("entryFile", "entry.py"),
-                        plugin_id=plugin_id,
-                        node_slot=slot,
-                        prompt=business_input,
-                        sdk_root=SDK_ROOT,
-                        task_id=task_id,
-                        model=model,
-                        on_progress=on_progress,
+                total = len(param_sets)
+                item_results: list[dict[str, Any]] = []
+                for item_idx, params in enumerate(param_sets):
+                    if total > 1:
+                        emit(
+                            {
+                                "type": "plugin_progress",
+                                "nodeId": node_id,
+                                "message": f"batch {item_idx + 1}/{total}",
+                            }
+                        )
+                    business_input = materialize_asset_inputs(
+                        slot, params, abi, search_dirs, store
                     )
-                result = convert_asset_outputs_to_file_refs(slot, raw, abi, store)
-
-                if result.get("success") is False:
-                    raise RuntimeError(
-                        str(result.get("error") or "Plugin returned success=false")
+                    if invoker is not None:
+                        raw = invoker(
+                            plugin_id, slot, business_input, plugin_dir, model
+                        )
+                    else:
+                        raw = invoke_plugin(
+                            python=python,
+                            plugin_dir=plugin_dir,
+                            entry_file=cfg.get("entryFile", "entry.py"),
+                            plugin_id=plugin_id,
+                            node_slot=slot,
+                            prompt=business_input,
+                            sdk_root=SDK_ROOT,
+                            task_id=task_id,
+                            model=model,
+                            on_progress=on_progress,
+                        )
+                    item = convert_asset_outputs_to_file_refs(
+                        slot, raw, abi, store
                     )
 
+                    if item.get("success") is False:
+                        suffix = (
+                            f" (batch item {item_idx + 1}/{total})"
+                            if total > 1
+                            else ""
+                        )
+                        raise RuntimeError(
+                            str(item.get("error") or "Plugin returned success=false")
+                            + suffix
+                        )
+                    item_results.append(item)
+
+                result = (
+                    item_results[0]
+                    if total == 1
+                    else _merge_batch_results(item_results)
+                )
                 node_outputs[node_id] = result
 
                 routes = node.get("outputs") or []

--- a/src/lib/workflow/executable-workflow.ts
+++ b/src/lib/workflow/executable-workflow.ts
@@ -22,7 +22,10 @@ import type { Edge, Node } from "@xyflow/react";
  *    `AbiOutputView`.
  *  - upstream is a data node → canvas-side data field (`texts` / `fileKeys`).
  *    The runner reads from `dataNodeState` (initialized from `staticData` and
- *    refreshed after each executable completes).
+ *    refreshed after each executable completes). Only standalone data nodes
+ *    (uploads / manual input) bind this way — a data node fed by an
+ *    executable is a pure channel and the exporter binds the consumer
+ *    straight to the producer's output field instead.
  *
  * `consumerShape` reflects the ABI shape of the destination input:
  *  - `"scalar"` → runner takes the first value across collected sources.

--- a/src/lib/workflow/exporter.test.ts
+++ b/src/lib/workflow/exporter.test.ts
@@ -1,0 +1,126 @@
+import type { Edge, Node } from "@xyflow/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { registerAbiNode, unregisterAbiNode } from "@/lib/abi/node-registry";
+import { batchOn, collectAll, handle } from "@/lib/abi/sources";
+
+import { WorkflowExporter } from "./exporter";
+
+/**
+ * Channel pass-through: a data node fed by an executable is a pure channel —
+ * consumers bind straight to the producer's output field, and sibling data
+ * nodes materialized from the same channel collapse to a single source.
+ */
+
+const pos = { x: 0, y: 0 };
+
+function textNode(id: string, texts: string[]): Node {
+    return { id, type: "textNode", position: pos, data: { texts } };
+}
+
+afterEach(() => {
+    for (const id of ["split", "combine", "gen"]) unregisterAbiNode(id);
+});
+
+function buildSplitFanIn(consumerFeature: "combine-text" | "gen-text") {
+    // src(text) → split-text → tn1/tn2 (materialized at edit time, stale
+    // staticData) → consumer.
+    registerAbiNode({
+        nodeId: "split",
+        feature: "split-text",
+        sourceSpec: {
+            text: handle({ nodeType: "textNode", path: "texts[0]" }),
+        },
+    });
+    const consumerId = consumerFeature === "combine-text" ? "combine" : "gen";
+    registerAbiNode({
+        nodeId: consumerId,
+        feature: consumerFeature,
+        sourceSpec:
+            consumerFeature === "combine-text"
+                ? { texts: collectAll() }
+                : { text: batchOn({ nodeType: "textNode", path: "texts" }) },
+    });
+
+    const consumerHandle =
+        consumerFeature === "combine-text" ? "in:texts" : "in:text";
+    const nodes: Node[] = [
+        textNode("src", ["long input"]),
+        { id: "split", type: "splitTextNode", position: pos, data: {} },
+        textNode("tn1", ["stale-1"]),
+        textNode("tn2", ["stale-2"]),
+        { id: consumerId, type: "consumerNode", position: pos, data: {} },
+    ];
+    const edges: Edge[] = [
+        { id: "e1", source: "src", target: "split", targetHandle: "in:text" },
+        {
+            id: "e2",
+            source: "split",
+            target: "tn1",
+            sourceHandle: "out:texts",
+        },
+        {
+            id: "e3",
+            source: "split",
+            target: "tn2",
+            sourceHandle: "out:texts",
+        },
+        {
+            id: "e4",
+            source: "tn1",
+            target: consumerId,
+            targetHandle: consumerHandle,
+        },
+        {
+            id: "e5",
+            source: "tn2",
+            target: consumerId,
+            targetHandle: consumerHandle,
+        },
+    ];
+    return {
+        workflow: new WorkflowExporter(nodes, edges).export(),
+        consumerId,
+    };
+}
+
+describe("WorkflowExporter channel pass-through", () => {
+    it("binds an array consumer to the producer channel, deduped", () => {
+        const { workflow, consumerId } = buildSplitFanIn("combine-text");
+        const consumer = workflow.executableNodes.find(
+            (n) => n.id === consumerId,
+        );
+        expect(consumer).toBeDefined();
+        const binding = consumer?.bindings.texts;
+        if (binding?.kind !== "handle") throw new Error("expected handle");
+        expect(binding.consumerShape).toBe("array");
+        // Two sibling text nodes collapse into one producer-channel source.
+        expect(binding.sources).toEqual([
+            { fromNodeId: "split", fromField: "texts" },
+        ]);
+    });
+
+    it("binds a batch consumer to the producer channel with batchField kept", () => {
+        const { workflow, consumerId } = buildSplitFanIn("gen-text");
+        const consumer = workflow.executableNodes.find(
+            (n) => n.id === consumerId,
+        );
+        expect(consumer?.batchField).toBe("text");
+        const binding = consumer?.bindings.text;
+        if (binding?.kind !== "handle") throw new Error("expected handle");
+        expect(binding.consumerShape).toBe("scalar");
+        expect(binding.sources).toEqual([
+            { fromNodeId: "split", fromField: "texts" },
+        ]);
+    });
+
+    it("keeps a standalone data node (no executable producer) as the source", () => {
+        const { workflow } = buildSplitFanIn("combine-text");
+        const split = workflow.executableNodes.find((n) => n.id === "split");
+        const binding = split?.bindings.text;
+        if (binding?.kind !== "handle") throw new Error("expected handle");
+        expect(binding.sources).toEqual([
+            { fromNodeId: "src", fromField: "texts" },
+        ]);
+    });
+});

--- a/src/lib/workflow/exporter.ts
+++ b/src/lib/workflow/exporter.ts
@@ -703,15 +703,27 @@ export class WorkflowExporter {
                     //    (the runner handles fan-out separately).
                     const consumerShape: "scalar" | "array" =
                         fSpec.array || fSpec.collect ? "array" : "scalar";
-                    out[field] = {
-                        kind: "handle",
-                        sources: matches.map((u) =>
+                    // Sibling data nodes materialized from the same producer
+                    // channel pass through to identical sources — keep one,
+                    // or the consumer would read the channel once per sibling.
+                    const seen = new Set<string>();
+                    const sources = matches
+                        .map((u) =>
                             this.resolveBindingSource(
                                 u.node,
                                 u.edgeSourceHandle,
                                 fSpec.nodeType,
                             ),
-                        ),
+                        )
+                        .filter((s) => {
+                            const key = `${s.fromNodeId} ${s.fromField}`;
+                            if (seen.has(key)) return false;
+                            seen.add(key);
+                            return true;
+                        });
+                    out[field] = {
+                        kind: "handle",
+                        sources,
                         targetHandle: handleId,
                         consumerShape,
                     };
@@ -743,7 +755,11 @@ export class WorkflowExporter {
 
     /**
      * Pick the right `fromField` for a binding source:
-     *  - upstream is a data node → dataField (`texts` / `fileKeys`) from DATA_NODE_TYPES.
+     *  - upstream is a data node fed by an executable → pass through to the
+     *    producer's ABI sourceField (the data node is a pure channel; see
+     *    `findExecutableProducer`).
+     *  - upstream is a standalone data node → dataField (`texts` / `fileKeys`)
+     *    from DATA_NODE_TYPES.
      *  - upstream is an executable / Add executable → ABI sourceField via the
      *    upstream's output routes; prefer the route whose nodeType matches the
      *    consumer's expected nodeType (so multi-channel sources route correctly).
@@ -758,6 +774,21 @@ export class WorkflowExporter {
         const upstreamType = upstream.type ?? "";
 
         if (isDataNode(upstreamType)) {
+            // Channel pass-through: a data node fed by an executable is a pure
+            // channel in one-click execution — bind the consumer straight to
+            // the producer's runtime output. The materialized node's edit-time
+            // staticData must never leak into execution, and the producer's
+            // runtime cardinality (e.g. a split's item count) must win over
+            // the frozen canvas topology.
+            const producer = this.findExecutableProducer(upstream.id);
+            if (producer) {
+                return this.pickExecutableSourceField(
+                    producer.nodeId,
+                    producer.feature,
+                    producer.edgeSourceHandle,
+                    consumerNodeType,
+                );
+            }
             const info = DATA_NODE_TYPES[upstreamType];
             return { fromNodeId: upstream.id, fromField: info.outputField };
         }
@@ -798,6 +829,29 @@ export class WorkflowExporter {
             fromNodeId: upstream.id,
             fromField: info?.outputField ?? "texts",
         };
+    }
+
+    /**
+     * The ABI executable feeding a data node, if any. A data node has at most
+     * one producer (data → data edges are rejected by connection rules).
+     */
+    private findExecutableProducer(dataNodeId: string): {
+        nodeId: string;
+        feature: string;
+        edgeSourceHandle: string | undefined;
+    } | null {
+        for (const edge of this.edges) {
+            if (edge.target !== dataNodeId) continue;
+            const reg = getAbiNodeRegistration(edge.source);
+            if (reg) {
+                return {
+                    nodeId: edge.source,
+                    feature: reg.feature,
+                    edgeSourceHandle: edge.sourceHandle ?? undefined,
+                };
+            }
+        }
+        return null;
     }
 
     private pickExecutableSourceField(


### PR DESCRIPTION
## Problem

Canvas editing materializes split results interactively, but the exported one-click plan froze topology at export time:

- a scalar consumer downstream of a split silently processed only `collected[0]` (silent data loss);
- `ExecutableNode.batchField` was exported but the Python engine never read it — no fan-out;
- split outputs were poured wholesale into only the **first** materialized sibling data node, while the other siblings kept stale edit-time `staticData`, so fan-in downstream read duplicated/stale mixtures.

`text → split-text → N text nodes → group → gen-image` was broken in one-click execution regardless of N.

## Changes (3 commits, in order)

1. **Guard** (`sdk/tongflow/engine/bindings.py`): a scalar input that collects N>1 upstream values now fails the node with a clear message instead of silently dropping items.
2. **Batch fan-out** (`sdk/tongflow/engine/`): the engine honors `batchField` — N collected values → N plugin invocations (other fields broadcast, matching canvas `buildPrompts`), per-item `batch i/N` progress events, outputs concatenated in batch order into one flat channel.
3. **Channel pass-through** (`src/lib/workflow/exporter.ts`): a data node fed by an executable is a pure channel — consumers bind straight to the producer's ABI output field, sibling data nodes dedupe into a single source, edit-time `staticData` no longer leaks into execution. Runtime cardinality always wins over frozen canvas topology.

## Semantics decided (with @tong-io)

- One-click mental model = dataflow pipeline; materialized intermediate data nodes are visualization anchors only.
- Known tradeoff: positional subset selection (wiring only sibling #2/#4 to a consumer) is not expressible in one-click runs — use content-based selection nodes instead. Interactive mode unaffected.
- Old saved workflow JSONs need a re-export to pick up pass-through bindings.
- Cloud executor picks these engine changes up at the next PyPI SDK release; desktop uses the repo `sdk/` directly.

## Tests

- SDK: 62 passed (new: scalar-overflow guard, param-set fan-out units, batch e2e, failure e2e)
- vitest: 37 passed (new: exporter pass-through ×3)
- `pnpm typecheck` / `lint:check` / `build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)