### PR TITLE
chore: release 0.2.3 (SDK 0.2.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-07-28
+
+### Fixed
+
+- **One-click execution now handles dynamic split counts end-to-end** (#116) —
+  a split's runtime item count drives downstream batch nodes: one plugin call
+  per item (`batchField` fan-out in the engine), outputs collected in batch
+  order. Previously only the first item was processed, silently.
+- **Intermediate data nodes are pure channels in one-click runs** — consumers
+  bind straight to the producer's output, so stale edit-time values of
+  materialized nodes no longer leak into execution. Re-save workflows exported
+  before this version to pick up the new bindings.
+- **Loud failure instead of silent data loss** — a single-value input that
+  receives multiple upstream values now fails the node with a clear message.
+
 ## [0.2.2] - 2026-07-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "A multi-modal AIGC studio for building generative AI workflows",
     "author": "tong-io",
     "keywords": [

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tongflow"
-version = "0.2.17"
+version = "0.2.18"
 description = "Python SDK for TongFlow — author plugins and run multi-modal GenAI workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/tongflow/__init__.py
+++ b/sdk/tongflow/__init__.py
@@ -17,7 +17,7 @@ from .serve import (
     serve_stream_from_spec,
 )
 
-__version__ = "0.2.17"
+__version__ = "0.2.18"
 
 __all__ = [
     "deploy",


### PR DESCRIPTION
Version bumps + CHANGELOG for the dynamic-cardinality one-click execution release (#116).

- SDK 0.2.17 → 0.2.18 (pyproject + __init__, engine batch fan-out + scalar guard)
- App 0.2.2 → 0.2.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)