### PR TITLE
feat(settings): one-shot paste for Modal tokens

### DIFF
--- a/src/components/workspace/settings/modal-connect-form.tsx
+++ b/src/components/workspace/settings/modal-connect-form.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { ExternalLink, Loader2 } from "lucide-react";
+import { CheckCircle2, Circle, ExternalLink, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { markModalConnected } from "@/hooks/use-env-setup";
 import { useInChinaTz } from "@/hooks/use-in-china-tz";
 import { apiPatch } from "@/lib/api/client";
@@ -18,6 +18,45 @@ import {
 
 const MODAL_TOKENS_URL = "https://modal.com/settings/tokens";
 const DISCORD_URL = "https://discord.gg/K7V8az94Zf";
+
+// Modal token prefixes; a minimum tail length avoids matching a bare "ak-"
+// the user is still typing.
+const TOKEN_ID_RE = /ak-[A-Za-z0-9_-]{4,}/;
+const TOKEN_SECRET_RE = /as-[A-Za-z0-9_-]{4,}/;
+
+function maskToken(token: string): string {
+    if (token.length <= 10) return token;
+    return `${token.slice(0, 5)}…${token.slice(-4)}`;
+}
+
+function TokenParseStatus({
+    found,
+    foundLabel,
+    missingLabel,
+}: {
+    found: boolean;
+    foundLabel: string;
+    missingLabel: string;
+}) {
+    return (
+        <p
+            className={`flex items-center gap-1.5 text-xs ${
+                found
+                    ? "text-green-600 dark:text-green-500"
+                    : "text-muted-foreground"
+            }`}
+        >
+            {found ? (
+                <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+            ) : (
+                <Circle className="h-3.5 w-3.5 shrink-0" />
+            )}
+            <span className="font-mono">
+                {found ? foundLabel : missingLabel}
+            </span>
+        </p>
+    );
+}
 
 /**
  * Community hand-off for users who get stuck on setup: the WeChat group QR
@@ -71,7 +110,8 @@ function CommunityHelpFooter() {
 
 /**
  * Guided paste flow for connecting the user's Modal account: the "why"
- * story, a jump-off to Modal's token page, and two paste fields. Dialog- and
+ * story, a jump-off to Modal's token page, and one paste-anything box that
+ * extracts the token id/secret from the copied command. Dialog- and
  * wizard-agnostic — the caller wraps it and reacts to `onConnected`.
  */
 export function ModalConnectForm({
@@ -81,15 +121,14 @@ export function ModalConnectForm({
 }) {
     const t = useTranslations("ModalConnect");
     const managed = process.env.NEXT_PUBLIC_MANAGED_PLUGINS === "1";
-    const [tokenId, setTokenId] = useState("");
-    const [tokenSecret, setTokenSecret] = useState("");
+    const [raw, setRaw] = useState("");
     const [saving, setSaving] = useState(false);
 
-    const id = tokenId.trim();
-    const secret = tokenSecret.trim();
-    // Soft format check only — Modal's prefixes could change; never block.
-    const idLooksOff = id.length > 0 && !id.startsWith("ak-");
-    const secretLooksOff = secret.length > 0 && !secret.startsWith("as-");
+    // Modal's token page shows one `modal token set --token-id ak-…
+    // --token-secret as-…` command with a single copy button, so accept any
+    // pasted blob and extract the two values — no field splitting required.
+    const id = raw.match(TOKEN_ID_RE)?.[0] ?? "";
+    const secret = raw.match(TOKEN_SECRET_RE)?.[0] ?? "";
 
     const connect = async () => {
         setSaving(true);
@@ -137,42 +176,29 @@ export function ModalConnectForm({
 
             <div className="space-y-2">
                 <p className="text-sm font-medium">{t("step2Title")}</p>
+                <Textarea
+                    value={raw}
+                    placeholder="modal token set --token-id ak-… --token-secret as-…"
+                    rows={2}
+                    spellCheck={false}
+                    autoComplete="off"
+                    className="resize-none font-mono text-xs"
+                    onChange={(e) => setRaw(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                    {t("pasteHint")}
+                </p>
                 <div className="space-y-1">
-                    <span className="text-xs text-muted-foreground">
-                        {t("tokenIdLabel")}
-                    </span>
-                    <Input
-                        value={tokenId}
-                        placeholder="ak-…"
-                        spellCheck={false}
-                        autoComplete="off"
-                        className="font-mono text-xs"
-                        onChange={(e) => setTokenId(e.target.value)}
+                    <TokenParseStatus
+                        found={Boolean(id)}
+                        foundLabel={t("detectedId", { id: maskToken(id) })}
+                        missingLabel={t("missingId")}
                     />
-                    {idLooksOff ? (
-                        <p className="text-xs text-amber-600 dark:text-amber-500">
-                            {t("prefixWarningId")}
-                        </p>
-                    ) : null}
-                </div>
-                <div className="space-y-1">
-                    <span className="text-xs text-muted-foreground">
-                        {t("tokenSecretLabel")}
-                    </span>
-                    <Input
-                        value={tokenSecret}
-                        placeholder="as-…"
-                        type="password"
-                        spellCheck={false}
-                        autoComplete="off"
-                        className="font-mono text-xs"
-                        onChange={(e) => setTokenSecret(e.target.value)}
+                    <TokenParseStatus
+                        found={Boolean(secret)}
+                        foundLabel={t("detectedSecret")}
+                        missingLabel={t("missingSecret")}
                     />
-                    {secretLooksOff ? (
-                        <p className="text-xs text-amber-600 dark:text-amber-500">
-                            {t("prefixWarningSecret")}
-                        </p>
-                    ) : null}
                 </div>
             </div>
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -70,10 +70,6 @@
         "openTokens": "Open modal.com/settings/tokens",
         "signupHint": "No account yet? Signing up is free.",
         "step2Title": "Step 2 — Paste it here",
-        "tokenIdLabel": "Token ID",
-        "tokenSecretLabel": "Token Secret",
-        "prefixWarningId": "This doesn't look like a token ID (they usually start with ak-).",
-        "prefixWarningSecret": "This doesn't look like a token secret (they usually start with as-).",
         "saveConnect": "Save & connect",
         "connectedToast": "Modal connected",
         "connectFailed": "Couldn't save the token — please try again",
@@ -90,7 +86,12 @@
         "helpWechatPrompt": "Stuck on setup? Scan to join our WeChat group — someone will walk you through it.",
         "helpWechatQrAlt": "WeChat group QR code",
         "helpDiscordPrompt": "Stuck on setup? Hop into our community — happy to help.",
-        "helpDiscordLink": "Join Discord"
+        "helpDiscordLink": "Join Discord",
+        "pasteHint": "Paste the whole command Modal shows you — the Token ID and Secret are picked out automatically.",
+        "detectedId": "Token ID {id}",
+        "detectedSecret": "Token Secret detected",
+        "missingId": "Waiting for the Token ID (starts with ak-)",
+        "missingSecret": "Waiting for the Token Secret (starts with as-)"
     },
     "Onboarding": {
         "welcomeTitle": "Welcome to TongFlow",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -69,11 +69,7 @@
         "step1Title": "ステップ 1：Modal でトークンを取得",
         "openTokens": "modal.com/settings/tokens を開く",
         "signupHint": "アカウントがなければ、まず無料登録を。",
-        "step2Title": "ステップ 2：ここに貼り付け",
-        "tokenIdLabel": "トークン ID",
-        "tokenSecretLabel": "トークンシークレット",
-        "prefixWarningId": "形式が違うようです。トークン ID は通常 ak- で始まります。",
-        "prefixWarningSecret": "形式が違うようです。シークレットは通常 as- で始まります。",
+        "step2Title": "ステップ 2：ここにまるごと貼り付け",
         "saveConnect": "保存して連携",
         "connectedToast": "Modal を連携しました",
         "connectFailed": "保存に失敗しました。もう一度お試しください",
@@ -90,7 +86,12 @@
         "helpWechatPrompt": "設定でつまずいたら、QR コードから WeChat グループへ。誰かが手伝ってくれます。",
         "helpWechatQrAlt": "WeChat グループの QR コード",
         "helpDiscordPrompt": "設定でつまずいたら、コミュニティで気軽に聞いてください。",
-        "helpDiscordLink": "Discord に参加"
+        "helpDiscordLink": "Discord に参加",
+        "pasteHint": "Modal に表示されるコマンドをそのまま貼り付ければ、トークン ID とシークレットを自動で読み取ります。",
+        "detectedId": "トークン ID {id}",
+        "detectedSecret": "トークンシークレットを検出",
+        "missingId": "トークン ID が見つかりません（ak- で始まります）",
+        "missingSecret": "シークレットが見つかりません（as- で始まります）"
     },
     "Onboarding": {
         "welcomeTitle": "TongFlow へようこそ",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -69,11 +69,7 @@
         "step1Title": "1단계 — Modal에서 토큰 발급",
         "openTokens": "modal.com/settings/tokens 열기",
         "signupHint": "계정이 없다면 먼저 무료로 가입하세요.",
-        "step2Title": "2단계 — 여기에 붙여넣기",
-        "tokenIdLabel": "토큰 ID",
-        "tokenSecretLabel": "토큰 시크릿",
-        "prefixWarningId": "형식이 맞지 않는 것 같아요. 토큰 ID는 보통 ak-로 시작합니다.",
-        "prefixWarningSecret": "형식이 맞지 않는 것 같아요. 시크릿은 보통 as-로 시작합니다.",
+        "step2Title": "2단계 — 여기에 통째로 붙여넣기",
         "saveConnect": "저장하고 연결",
         "connectedToast": "Modal이 연결되었습니다",
         "connectFailed": "저장에 실패했어요. 다시 시도해 주세요",
@@ -90,7 +86,12 @@
         "helpWechatPrompt": "설정이 막히면 QR 코드로 WeChat 그룹에 들어오세요. 누군가 도와드릴 거예요.",
         "helpWechatQrAlt": "WeChat 그룹 QR 코드",
         "helpDiscordPrompt": "설정이 막히면 커뮤니티에 편하게 물어보세요.",
-        "helpDiscordLink": "Discord 참여"
+        "helpDiscordLink": "Discord 참여",
+        "pasteHint": "Modal에 표시되는 명령을 그대로 붙여넣으면 토큰 ID와 시크릿을 자동으로 인식합니다.",
+        "detectedId": "토큰 ID {id}",
+        "detectedSecret": "토큰 시크릿 인식됨",
+        "missingId": "토큰 ID를 아직 찾지 못했어요(ak-로 시작)",
+        "missingSecret": "토큰 시크릿을 아직 찾지 못했어요(as-로 시작)"
     },
     "Onboarding": {
         "welcomeTitle": "TongFlow에 오신 것을 환영합니다",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -69,11 +69,7 @@
         "step1Title": "第一步：去 Modal 获取 Token",
         "openTokens": "打开 modal.com/settings/tokens",
         "signupHint": "还没有账号？先免费注册一个。",
-        "step2Title": "第二步：粘贴到这里",
-        "tokenIdLabel": "Token ID",
-        "tokenSecretLabel": "Token Secret",
-        "prefixWarningId": "格式看起来不太对——Token ID 通常以 ak- 开头，请再确认一下。",
-        "prefixWarningSecret": "格式看起来不太对——Token Secret 通常以 as- 开头，请再确认一下。",
+        "step2Title": "第二步：整段粘贴到这里",
         "saveConnect": "保存并连接",
         "connectedToast": "Modal 已连接",
         "connectFailed": "保存失败，请重试",
@@ -90,7 +86,12 @@
         "helpWechatPrompt": "配置遇到问题？扫码进微信群，有人带你跑通。",
         "helpWechatQrAlt": "微信群二维码",
         "helpDiscordPrompt": "配置遇到问题？来社群里问一声，有人帮你搞定。",
-        "helpDiscordLink": "加入 Discord"
+        "helpDiscordLink": "加入 Discord",
+        "pasteHint": "把 Modal 页面上的整行命令直接粘贴进来，会自动识别 Token ID 和 Secret。",
+        "detectedId": "Token ID {id}",
+        "detectedSecret": "已识别 Token Secret",
+        "missingId": "还没识别到 Token ID（ak- 开头）",
+        "missingSecret": "还没识别到 Token Secret（as- 开头）"
     },
     "Onboarding": {
         "welcomeTitle": "欢迎使用 TongFlow",


### PR DESCRIPTION
Modal's token page shows a single `modal token set --token-id ak-… --token-secret as-…` command with one copy button. The connect form now takes any pasted blob in one textarea and extracts both values by prefix (`ak-`/`as-`), showing live parse status (masked token id, secret never displayed). Replaces the two separate paste fields and their soft prefix warnings. i18n updated for en/zh/ja/ko.

Verified: `pnpm lint:check` / `pnpm typecheck` / `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)