### PR TITLE
feat(task): coded, localized task-failure messages with support links

### DIFF
--- a/src/app/api/task/wait/route.ts
+++ b/src/app/api/task/wait/route.ts
@@ -125,6 +125,7 @@ export async function GET(request: NextRequest) {
                                     status: "FAILED",
                                     data: {
                                         message: "Task failed to start",
+                                        errorCode: "task_failed_to_start",
                                         error: String(error),
                                     },
                                 });

--- a/src/components/ui/error-toast.tsx
+++ b/src/components/ui/error-toast.tsx
@@ -17,6 +17,8 @@ export interface ShowErrorToastOptions {
      * stack (e.g. one per task id). Omit for an auto-generated id.
      */
     id?: string;
+    /** Extra content below the actions (e.g. community-support links). */
+    footer?: React.ReactNode;
 }
 
 function ErrorToastCard({
@@ -24,11 +26,13 @@ function ErrorToastCard({
     title,
     message,
     detail,
+    footer,
 }: {
     toastId: string;
     title?: string;
     message: string;
     detail?: string;
+    footer?: React.ReactNode;
 }) {
     const t = getClientTranslator("Errors");
     const [expanded, setExpanded] = useState(false);
@@ -78,6 +82,7 @@ function ErrorToastCard({
                             {detail}
                         </pre>
                     )}
+                    {footer}
                 </div>
                 <button
                     type="button"
@@ -102,6 +107,7 @@ export function showErrorToast({
     message,
     detail,
     id,
+    footer,
 }: ShowErrorToastOptions): string {
     return toast.custom(
         (tInst) => (
@@ -110,6 +116,7 @@ export function showErrorToast({
                 title={title}
                 message={message}
                 detail={detail}
+                footer={footer}
             />
         ),
         { duration: Number.POSITIVE_INFINITY, id },

--- a/src/components/workspace/community-support-row.tsx
+++ b/src/components/workspace/community-support-row.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { ExternalLink } from "lucide-react";
+import { useState } from "react";
+import { DISCORD_URL, WECHAT_GROUP_QR_SRC } from "@/constants/community";
+import { useInChinaTz } from "@/hooks/use-in-china-tz";
+import { getClientTranslator } from "@/i18n/client";
+import { openExternalUrl } from "@/lib/desktop/open-external";
+
+/**
+ * Compact "need help?" line for error surfaces: Discord invite everywhere,
+ * plus an expandable WeChat-group QR for mainland-China users. Uses
+ * getClientTranslator so it renders fine outside the intl provider tree
+ * (e.g. inside react-hot-toast portals).
+ */
+export function CommunitySupportRow() {
+    const t = getClientTranslator("Errors");
+    const inChina = useInChinaTz();
+    const [qrOpen, setQrOpen] = useState(false);
+
+    return (
+        <div className="mt-2 border-t border-neutral-200 pt-2 dark:border-neutral-700">
+            <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                {t("needHelp")}{" "}
+                {inChina ? (
+                    <>
+                        <button
+                            type="button"
+                            className="text-primary hover:underline"
+                            onClick={() => setQrOpen((open) => !open)}
+                        >
+                            {t("wechatGroup")}
+                        </button>
+                        {" · "}
+                    </>
+                ) : null}
+                <button
+                    type="button"
+                    className="inline-flex items-center gap-0.5 text-primary hover:underline"
+                    onClick={() => openExternalUrl(DISCORD_URL)}
+                >
+                    Discord
+                    <ExternalLink className="h-3 w-3" />
+                </button>
+            </p>
+            {qrOpen ? (
+                <div className="mt-2 flex justify-center">
+                    <img
+                        src={WECHAT_GROUP_QR_SRC}
+                        alt={t("wechatQrAlt")}
+                        className="h-32 w-32 rounded-lg bg-white p-1.5"
+                    />
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/src/components/workspace/settings/token-connect.tsx
+++ b/src/components/workspace/settings/token-connect.tsx
@@ -25,12 +25,11 @@ import {
     DialogTitle,
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
+import { DISCORD_URL, WECHAT_GROUP_QR_SRC } from "@/constants/community";
 import { useInChinaTz } from "@/hooks/use-in-china-tz";
 import { apiPatch } from "@/lib/api/client";
 import { openExternalUrl } from "@/lib/desktop/open-external";
 import { logger } from "@/lib/logger";
-
-const DISCORD_URL = "https://discord.gg/K7V8az94Zf";
 
 /** One credential extracted from the pasted blob. */
 export interface TokenSpec {
@@ -146,7 +145,7 @@ function CommunityHelpFooter() {
                     </p>
                     <div className="flex justify-center">
                         <img
-                            src="/wechat-group-qr.png"
+                            src={WECHAT_GROUP_QR_SRC}
                             alt={t("helpWechatQrAlt")}
                             className="h-32 w-32 rounded-lg bg-white p-1.5"
                         />

--- a/src/components/workspace/task-failure-toaster.tsx
+++ b/src/components/workspace/task-failure-toaster.tsx
@@ -2,10 +2,15 @@
 
 import { useEffect, useRef } from "react";
 import { showErrorToast } from "@/components/ui/error-toast";
+import { CommunitySupportRow } from "@/components/workspace/community-support-row";
 import { TaskStatus, WorkflowStatus } from "@/constants/task-status";
 import { getClientTranslator } from "@/i18n/client";
 import type { SerializedWorkflowFailure } from "@/lib/task/error-envelope";
 import { buildTaskErrorDetail } from "@/lib/task/error-format";
+import {
+    localizeTaskError,
+    shouldOfferSupport,
+} from "@/lib/task/error-localize";
 import { SSE_TASK_MESSAGE_EVENT } from "@/lib/task/sse-events";
 import type { SSEMessage } from "@/types/sse";
 
@@ -21,6 +26,7 @@ export function TaskFailureToaster() {
 
     useEffect(() => {
         const t = getClientTranslator("Workspace.toast");
+        const tErr = getClientTranslator("TaskErrors");
 
         const handle = (event: CustomEvent<SSEMessage>) => {
             const message = event.detail;
@@ -46,7 +52,13 @@ export function TaskFailureToaster() {
             toastedRef.current.add(taskId);
 
             const data = message.data;
-            const errorText = data?.message?.trim() || data?.error?.trim();
+            const rawText = data?.message?.trim() || data?.error?.trim();
+            const coded = {
+                message: rawText,
+                errorCode: data?.errorCode,
+                errorParams: data?.errorParams,
+            };
+            const errorText = localizeTaskError(tErr, coded) || rawText;
             const detail = buildTaskErrorDetail({
                 message: errorText,
                 errors: data?.errors as string[] | undefined,
@@ -62,6 +74,10 @@ export function TaskFailureToaster() {
                 message: errorText || t("taskFailed"),
                 detail,
                 id: `task-failed:${taskId}`,
+                // Server-side faults get community links so users can reach us.
+                footer: shouldOfferSupport(coded) ? (
+                    <CommunitySupportRow />
+                ) : undefined,
             });
         };
 

--- a/src/components/workspace/workspace-left-nav.tsx
+++ b/src/components/workspace/workspace-left-nav.tsx
@@ -24,10 +24,11 @@ import { PortfolioDialog } from "@/components/workspace/portfolio-dialog";
 import { WorkflowDialog } from "@/components/workspace/workflow-dialog";
 import { listTasks, type Task } from "@/lib/api/task";
 import { logger } from "@/lib/logger";
-import { formatStoredTaskErrorForDisplay } from "@/lib/task/error-format";
+import { localizeStoredTaskError } from "@/lib/task/error-localize";
 
 export function WorkspaceLeftNav() {
     const t = useTranslations("Navigation");
+    const tTaskErrors = useTranslations("TaskErrors");
 
     // Task list state
     const [isTaskSheetOpen, setIsTaskSheetOpen] = useState(false);
@@ -217,7 +218,8 @@ export function WorkspaceLeftNav() {
                                             )}
                                         {task.error && (
                                             <div className="text-xs text-red-500 mt-1 line-clamp-2">
-                                                {formatStoredTaskErrorForDisplay(
+                                                {localizeStoredTaskError(
+                                                    tTaskErrors,
                                                     task.error,
                                                 )}
                                             </div>

--- a/src/components/workspace/workspace-nav.tsx
+++ b/src/components/workspace/workspace-nav.tsx
@@ -40,7 +40,7 @@ const LOCALE_OPTIONS = [
 const navBtnClass =
     "h-10 w-10 rounded-xl bg-white border border-gray-100 hover:bg-gray-50 text-gray-500 hover:text-gray-900 dark:bg-zinc-800 dark:border-zinc-700 dark:text-gray-400 dark:hover:text-white dark:hover:bg-zinc-700 transition-all duration-200";
 
-const DISCORD_URL = "https://discord.gg/K7V8az94Zf";
+import { DISCORD_URL } from "@/constants/community";
 
 // Discord SVG Icon
 const DiscordIcon = ({ className }: { className?: string }) => (

--- a/src/constants/community.ts
+++ b/src/constants/community.ts
@@ -1,0 +1,3 @@
+/** Community channels, shared by nav, connect flows and error surfaces. */
+export const DISCORD_URL = "https://discord.gg/K7V8az94Zf";
+export const WECHAT_GROUP_QR_SRC = "/wechat-group-qr.png";

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1184,7 +1184,18 @@
         "details": "Details",
         "copy": "Copy",
         "copied": "Copied",
-        "close": "Close"
+        "close": "Close",
+        "needHelp": "Stuck? Come find us:",
+        "wechatGroup": "WeChat group",
+        "wechatQrAlt": "WeChat group QR code"
+    },
+    "TaskErrors": {
+        "subscription_required": "A TongFlow Cloud subscription is needed to run tasks — open the account menu (top right) to subscribe.",
+        "modal_not_connected": "Modal isn't connected yet, so nothing can run. Open Settings and hit “Connect Modal” — it takes a minute, with $30/month free compute.",
+        "executor_rejected": "Your compute environment rejected the task (HTTP {status}). Try re-running it; if it keeps failing, disconnect and reconnect Modal in Settings.",
+        "task_not_found": "This task no longer exists or has expired — please start it again.",
+        "workflow_invalid": "The workflow has no runnable data — re-save the workflow and try again.",
+        "task_failed_to_start": "The task couldn't start. Please try again in a moment."
     },
     "Api": {
         "unknownError": "Unknown error",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1098,7 +1098,18 @@
         "details": "詳細",
         "copy": "コピー",
         "copied": "コピーしました",
-        "close": "閉じる"
+        "close": "閉じる",
+        "needHelp": "解決しない場合はこちらへ：",
+        "wechatGroup": "WeChat グループ",
+        "wechatQrAlt": "WeChat グループの QR コード"
+    },
+    "TaskErrors": {
+        "subscription_required": "タスクの実行には TongFlow Cloud のサブスクリプションが必要です。右上のアカウントメニューから登録できます。",
+        "modal_not_connected": "Modal が未連携のため実行できません。「設定」で「Modal を連携」を押してください。1 分で完了し、毎月 $30 分の無料枠があります。",
+        "executor_rejected": "実行環境がタスクを拒否しました（HTTP {status}）。まず再実行してみてください。繰り返し失敗する場合は、設定で Modal をいったん解除して再連携してください。",
+        "task_not_found": "タスクが存在しないか期限切れです。もう一度実行してください。",
+        "workflow_invalid": "ワークフローに実行可能なデータがありません。保存し直してからお試しください。",
+        "task_failed_to_start": "タスクを開始できませんでした。少し待ってからもう一度お試しください。"
     },
     "Api": {
         "unknownError": "不明なエラー",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1184,7 +1184,18 @@
         "details": "세부 정보",
         "copy": "복사",
         "copied": "복사됨",
-        "close": "닫기"
+        "close": "닫기",
+        "needHelp": "해결이 안 되면 커뮤니티로 오세요:",
+        "wechatGroup": "WeChat 그룹",
+        "wechatQrAlt": "WeChat 그룹 QR 코드"
+    },
+    "TaskErrors": {
+        "subscription_required": "작업을 실행하려면 TongFlow Cloud 구독이 필요해요. 오른쪽 위 계정 메뉴에서 구독할 수 있습니다.",
+        "modal_not_connected": "Modal이 아직 연결되지 않아 실행할 수 없어요. 설정에서 “Modal 연결”을 눌러 주세요. 1분이면 되고, 매달 $30 무료 컴퓨팅이 제공됩니다.",
+        "executor_rejected": "컴퓨팅 환경이 작업을 거부했어요(HTTP {status}). 먼저 다시 실행해 보시고, 계속 실패하면 설정에서 Modal을 해제 후 다시 연결해 주세요.",
+        "task_not_found": "작업이 존재하지 않거나 만료되었어요. 다시 실행해 주세요.",
+        "workflow_invalid": "워크플로에 실행 가능한 데이터가 없어요. 워크플로를 다시 저장한 뒤 시도해 주세요.",
+        "task_failed_to_start": "작업을 시작하지 못했어요. 잠시 후 다시 시도해 주세요."
     },
     "Api": {
         "unknownError": "알 수 없는 오류",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1184,7 +1184,18 @@
         "details": "详情",
         "copy": "复制",
         "copied": "已复制",
-        "close": "关闭"
+        "close": "关闭",
+        "needHelp": "解决不了？来社群里找我们：",
+        "wechatGroup": "微信群",
+        "wechatQrAlt": "微信群二维码"
+    },
+    "TaskErrors": {
+        "subscription_required": "需要订阅 TongFlow Cloud 才能运行任务——点右上角账号菜单即可开通。",
+        "modal_not_connected": "还没连接 Modal，任务无法运行。打开「设置」点「连接 Modal」，一分钟搞定（每月 $30 免费算力）。",
+        "executor_rejected": "你的算力环境拒绝了这个任务（HTTP {status}）。先重跑一次试试；反复失败的话，去「设置」断开并重新连接 Modal。",
+        "task_not_found": "任务不存在或已过期，请重新发起一次。",
+        "workflow_invalid": "工作流没有可执行的数据，请重新保存工作流后再试。",
+        "task_failed_to_start": "任务启动失败，请稍后重试。"
     },
     "Api": {
         "unknownError": "未知错误",

--- a/src/lib/task/error-envelope.ts
+++ b/src/lib/task/error-envelope.ts
@@ -16,8 +16,13 @@ export type SerializedWorkflowFailure = {
 
 /** Uniform JSON written to `tasks.error`; UI reads `message`. */
 export type SerializedTaskError = {
+    /** English fallback, shown when the client has no translation. */
     message: string;
     failures?: SerializedWorkflowFailure[];
+    /** Stable machine code — the client localizes it (`TaskErrors.<code>`). */
+    errorCode?: string;
+    /** Interpolation values for the localized message (e.g. HTTP status). */
+    errorParams?: Record<string, string | number>;
 };
 
 export function serializeTaskErrorForDb(e: SerializedTaskError): string {

--- a/src/lib/task/error-localize.ts
+++ b/src/lib/task/error-localize.ts
@@ -1,0 +1,67 @@
+import type { SerializedTaskError } from "./error-envelope";
+
+/**
+ * Client-side localization of coded task errors. Servers emit a stable
+ * `errorCode` (+ `errorParams`) alongside the English `message` fallback;
+ * the client renders `TaskErrors.<code>` when it knows the code and falls
+ * back to the raw message otherwise (e.g. uncoded plugin errors).
+ */
+
+const KNOWN_TASK_ERROR_CODES = new Set([
+    "subscription_required",
+    "modal_not_connected",
+    "executor_rejected",
+    "task_not_found",
+    "workflow_invalid",
+    "task_failed_to_start",
+]);
+
+/** Minimal translator shape satisfied by both useTranslations and getClientTranslator. */
+export type TaskErrorTranslator = (
+    key: string,
+    values?: Record<string, string | number>,
+) => string;
+
+export interface CodedTaskError {
+    message?: string | null;
+    errorCode?: string;
+    errorParams?: Record<string, string | number>;
+}
+
+/** Localized headline; falls back to the raw server message. */
+export function localizeTaskError(
+    t: TaskErrorTranslator,
+    e: CodedTaskError,
+): string {
+    if (e.errorCode && KNOWN_TASK_ERROR_CODES.has(e.errorCode)) {
+        return t(e.errorCode, e.errorParams);
+    }
+    return e.message?.trim() ?? "";
+}
+
+/**
+ * Whether the failure points at our side rather than the user's config —
+ * those errors get community-support links so the user can reach us.
+ */
+export function shouldOfferSupport(e: CodedTaskError): boolean {
+    if (e.errorCode === "executor_rejected") {
+        return Number(e.errorParams?.status ?? 0) >= 500;
+    }
+    return e.errorCode === "task_failed_to_start";
+}
+
+/** Localized headline from persisted `tasks.error` JSON; raw string fallback. */
+export function localizeStoredTaskError(
+    t: TaskErrorTranslator,
+    raw: string | null | undefined,
+): string {
+    if (!raw) return "";
+    try {
+        const o = JSON.parse(raw) as Partial<SerializedTaskError>;
+        const localized = localizeTaskError(t, o);
+        if (localized) return localized;
+    } catch {
+        /* Malformed write — best-effort display below. */
+    }
+    return raw;
+}

--- a/src/lib/task/runner.ts
+++ b/src/lib/task/runner.ts
@@ -87,7 +87,10 @@ export async function dispatchTask(taskId: string): Promise<void> {
         notifyTask(
             taskId,
             TaskStatus.FAILED,
-            { message: "Task not found or expired" },
+            {
+                message: "Task not found or expired",
+                errorCode: "task_not_found",
+            },
             null,
         );
         return;
@@ -98,7 +101,10 @@ export async function dispatchTask(taskId: string): Promise<void> {
             notifyTask(
                 taskId,
                 WorkflowStatus.WORKFLOW_FAILED,
-                { message: "Workflow task missing workflowId" },
+                {
+                    message: "Workflow task missing workflowId",
+                    errorCode: "workflow_invalid",
+                },
                 null,
             );
             return;
@@ -110,7 +116,10 @@ export async function dispatchTask(taskId: string): Promise<void> {
             notifyTask(
                 taskId,
                 WorkflowStatus.WORKFLOW_FAILED,
-                { message: "Workflow not found or has no executable data" },
+                {
+                    message: "Workflow not found or has no executable data",
+                    errorCode: "workflow_invalid",
+                },
                 null,
             );
             return;
@@ -137,7 +146,10 @@ export async function executeTask(taskId: string): Promise<void> {
         notifyTask(
             taskId,
             TaskStatus.FAILED,
-            { message: "Task not found or expired" },
+            {
+                message: "Task not found or expired",
+                errorCode: "task_not_found",
+            },
             null,
         );
         return;

--- a/src/types/sse.ts
+++ b/src/types/sse.ts
@@ -54,6 +54,10 @@ export interface SSEMessageData {
     /** True when `message` is streamed reasoning for the node thinking bubble. */
     thinking?: boolean;
     code?: number;
+    /** Stable machine code for a failure — localized via `TaskErrors.<code>`. */
+    errorCode?: string;
+    /** Interpolation values for the localized failure message. */
+    errorParams?: Record<string, string | number>;
     error?: string;
     status?: string;
     file_key?: string;


### PR DESCRIPTION
Task-failure messages like `Executor rejected the task (404). Re-check your Modal setup in Settings.` were hard-coded English strings produced server-side. This PR makes them semantic and localizable:

- **Contract**: `SerializedTaskError` / SSE `data` gain optional `errorCode` + `errorParams`; the English `message` stays as the fallback for old payloads and unknown codes.
- **Producers**: fixed-string failures in the desktop runner and `/api/task/wait` now carry codes (`task_not_found`, `workflow_invalid`, `task_failed_to_start`). The cloud dispatcher (studio repo, companion commit) emits `subscription_required`, `modal_not_connected`, `executor_rejected` (+ HTTP status), etc.
- **Display**: the global failure toast and the left-nav task list localize known codes via a new `TaskErrors` namespace (en/zh/ja/ko, actionable plain-language copy); uncoded plugin errors render as before.
- **Support hand-off**: failures pointing at our side (executor 5xx, task-start crash) append a compact community row to the error toast — WeChat group QR (mainland-China timezone) or Discord link — via the new `CommunitySupportRow` and an `error-toast` footer slot.

Verified: `pnpm lint:check` / `pnpm typecheck` / `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)