### PR TITLE
feat(workspace): app mode — workflow as an input/output form

### DIFF
--- a/src/components/workspace/app-view/app-file-input.tsx
+++ b/src/components/workspace/app-view/app-file-input.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { FileIcon, Loader2, UploadCloud, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useFileAsyncLoader, useFileUrl } from "@/hooks/use-file-async-loader";
+import { useDropzone, useMultipleUpload } from "@/hooks/use-upload";
+import { cn } from "@/lib/utils";
+import type { DataNode } from "@/lib/workflow/executable-workflow";
+import { MODEL_FILE_ACCEPT } from "./model-file-accept";
+
+const MAX_FILES = 9;
+
+/** Mime-pattern accepts feed useDropzone's validation; extension-based
+ * accepts (3D model formats) only filter the native picker. */
+const MIME_ACCEPT: Partial<Record<DataNode["dataType"], string>> = {
+    image: "image/*",
+    video: "video/*",
+    audio: "audio/*",
+};
+
+function FilePreview({
+    fileKey,
+    dataType,
+    onRemove,
+}: {
+    fileKey: string;
+    dataType: DataNode["dataType"];
+    onRemove: () => void;
+}) {
+    const { url } = useFileAsyncLoader(fileKey);
+    const directUrl = useFileUrl(fileKey);
+
+    return (
+        <div className="relative group rounded-lg border border-border/60 overflow-hidden bg-muted/30">
+            {dataType === "image" ? (
+                url ? (
+                    <img
+                        src={url}
+                        alt={fileKey}
+                        className="h-24 w-full object-cover"
+                    />
+                ) : (
+                    <div className="h-24 w-full flex items-center justify-center">
+                        <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                    </div>
+                )
+            ) : dataType === "video" ? (
+                <video
+                    src={directUrl}
+                    className="h-24 w-full object-cover"
+                    muted
+                />
+            ) : dataType === "audio" ? (
+                <div className="h-24 w-full flex items-center justify-center p-2">
+                    <audio src={directUrl} controls className="w-full" />
+                </div>
+            ) : (
+                <div className="h-24 w-full flex flex-col items-center justify-center gap-1 p-2">
+                    <FileIcon className="size-6 text-muted-foreground" />
+                    <span className="text-[10px] text-muted-foreground truncate max-w-full">
+                        {fileKey.split("/").pop()}
+                    </span>
+                </div>
+            )}
+            <button
+                type="button"
+                onClick={onRemove}
+                className="absolute top-1 right-1 rounded-full bg-black/60 text-white p-0.5 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+            >
+                <X className="size-3" />
+            </button>
+        </div>
+    );
+}
+
+export function AppFileInput({
+    dataType,
+    fileKeys,
+    onChange,
+    disabled,
+}: {
+    dataType: DataNode["dataType"];
+    fileKeys: string[];
+    onChange: (fileKeys: string[]) => void;
+    disabled?: boolean;
+}) {
+    const t = useTranslations("Workspace.appView");
+
+    const { upload, isUploading, progress } = useMultipleUpload({
+        onSuccess: (responses) => {
+            onChange(responses.map((r) => r.key));
+        },
+    });
+
+    const mimeAccept = MIME_ACCEPT[dataType];
+    const dropzone = useDropzone({
+        accept: mimeAccept,
+        maxFiles: MAX_FILES,
+        onDrop: (files) => {
+            void upload(files);
+        },
+    });
+
+    const inputProps = dropzone.getInputProps();
+    // 3D model formats are extension-based; the picker filters, the
+    // dropzone validation stays open.
+    const inputAccept =
+        mimeAccept ?? (dataType === "model" ? MODEL_FILE_ACCEPT : undefined);
+
+    return (
+        <div className="space-y-2">
+            {fileKeys.length > 0 && (
+                <div className="grid grid-cols-3 gap-2">
+                    {fileKeys.map((key) => (
+                        <FilePreview
+                            key={key}
+                            fileKey={key}
+                            dataType={dataType}
+                            onRemove={() =>
+                                onChange(fileKeys.filter((k) => k !== key))
+                            }
+                        />
+                    ))}
+                </div>
+            )}
+            <label
+                className={cn(
+                    "flex flex-col items-center justify-center gap-1.5 rounded-lg border border-dashed p-6 text-center transition-colors",
+                    dropzone.isDragActive
+                        ? "border-primary bg-primary/5"
+                        : "border-border/70 hover:border-border",
+                    disabled || isUploading
+                        ? "opacity-60 pointer-events-none"
+                        : "cursor-pointer",
+                )}
+                {...dropzone.getRootProps()}
+            >
+                <input
+                    {...inputProps}
+                    accept={inputAccept}
+                    className="hidden"
+                    disabled={disabled || isUploading}
+                />
+                {isUploading ? (
+                    <>
+                        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+                        <span className="text-xs text-muted-foreground">
+                            {progress}%
+                        </span>
+                    </>
+                ) : (
+                    <>
+                        <UploadCloud className="size-5 text-muted-foreground" />
+                        <span className="text-xs text-muted-foreground">
+                            {t("dropFilesHere")}
+                        </span>
+                    </>
+                )}
+            </label>
+            {dropzone.error && (
+                <p className="text-xs text-red-500">{dropzone.error}</p>
+            )}
+        </div>
+    );
+}

--- a/src/components/workspace/app-view/app-input-field.tsx
+++ b/src/components/workspace/app-view/app-input-field.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { AppFileInput } from "./app-file-input";
+import {
+    type AppFieldValue,
+    type AppFormField,
+    fieldHasValue,
+} from "./use-app-form-model";
+
+export function AppInputField({
+    field,
+    onChange,
+    disabled,
+}: {
+    field: AppFormField;
+    onChange: (patch: AppFieldValue) => void;
+    disabled?: boolean;
+}) {
+    const t = useTranslations("Workspace.appView");
+
+    const label = field.label?.trim() || t(`fieldType.${field.dataType}`);
+    const missing = field.required && !fieldHasValue(field);
+
+    return (
+        <div className="space-y-1.5">
+            <Label className="text-sm">
+                {label}
+                {missing && <span className="text-red-500 ml-0.5">*</span>}
+            </Label>
+            {field.dataType === "text" ? (
+                <Textarea
+                    value={field.value.texts?.[0] ?? ""}
+                    onChange={(e) => onChange({ texts: [e.target.value] })}
+                    placeholder={t("textPlaceholder")}
+                    rows={3}
+                    disabled={disabled}
+                    className="resize-y"
+                />
+            ) : (
+                <AppFileInput
+                    dataType={field.dataType}
+                    fileKeys={field.value.fileKeys ?? []}
+                    onChange={(fileKeys) => onChange({ fileKeys })}
+                    disabled={disabled}
+                />
+            )}
+        </div>
+    );
+}

--- a/src/components/workspace/app-view/app-outputs.tsx
+++ b/src/components/workspace/app-view/app-outputs.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Check, Copy, Download, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useFileAsyncLoader, useFileUrl } from "@/hooks/use-file-async-loader";
+import type { AppOutputItem } from "./use-app-form-model";
+
+function CopyTextButton({ text }: { text: string }) {
+    const t = useTranslations("Workspace.appView");
+    const [copied, setCopied] = useState(false);
+    return (
+        <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs"
+            onClick={() => {
+                void navigator.clipboard.writeText(text);
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1500);
+            }}
+        >
+            {copied ? (
+                <Check className="size-3.5 text-emerald-500" />
+            ) : (
+                <Copy className="size-3.5" />
+            )}
+            {t("copyText")}
+        </Button>
+    );
+}
+
+function ImageResult({ fileKey }: { fileKey: string }) {
+    const { url, isLoading } = useFileAsyncLoader(fileKey);
+    if (isLoading || !url) {
+        return (
+            <div className="aspect-square rounded-lg bg-muted/40 flex items-center justify-center">
+                <Loader2 className="size-4 animate-spin text-muted-foreground" />
+            </div>
+        );
+    }
+    return (
+        <a href={url} target="_blank" rel="noopener noreferrer">
+            <img
+                src={url}
+                alt={fileKey}
+                className="rounded-lg w-full object-cover"
+            />
+        </a>
+    );
+}
+
+function FileResult({ fileKey }: { fileKey: string }) {
+    const t = useTranslations("Workspace.appView");
+    const url = useFileUrl(fileKey);
+    return (
+        <a
+            href={url}
+            download
+            className="flex items-center gap-2 rounded-lg border border-border/60 px-3 py-2 text-sm hover:bg-muted/40 transition-colors"
+        >
+            <Download className="size-4 text-muted-foreground shrink-0" />
+            <span className="truncate">{fileKey.split("/").pop()}</span>
+            <span className="ml-auto text-xs text-muted-foreground shrink-0">
+                {t("download")}
+            </span>
+        </a>
+    );
+}
+
+function VideoResult({ fileKey }: { fileKey: string }) {
+    const url = useFileUrl(fileKey);
+    return <video src={url} controls className="w-full rounded-lg" />;
+}
+
+function AudioResult({ fileKey }: { fileKey: string }) {
+    const url = useFileUrl(fileKey);
+    return <audio src={url} controls className="w-full" />;
+}
+
+function OutputBlock({ output }: { output: AppOutputItem }) {
+    if (!output.isFileValues) {
+        return (
+            <div className="space-y-2">
+                {output.values.map((text, i) => (
+                    <div
+                        key={i}
+                        className="rounded-lg border border-border/60 bg-muted/20 p-3"
+                    >
+                        <p className="text-sm whitespace-pre-wrap wrap-break-word">
+                            {text}
+                        </p>
+                        <div className="mt-1 flex justify-end">
+                            <CopyTextButton text={text} />
+                        </div>
+                    </div>
+                ))}
+            </div>
+        );
+    }
+
+    if (output.type === "image") {
+        return (
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                {output.values.map((key) => (
+                    <ImageResult key={key} fileKey={key} />
+                ))}
+            </div>
+        );
+    }
+
+    if (output.type === "video") {
+        return (
+            <div className="space-y-2">
+                {output.values.map((key) => (
+                    <VideoResult key={key} fileKey={key} />
+                ))}
+            </div>
+        );
+    }
+
+    if (output.type === "audio") {
+        return (
+            <div className="space-y-2">
+                {output.values.map((key) => (
+                    <AudioResult key={key} fileKey={key} />
+                ))}
+            </div>
+        );
+    }
+
+    // model / file / anything else: download links
+    return (
+        <div className="space-y-2">
+            {output.values.map((key) => (
+                <FileResult key={key} fileKey={key} />
+            ))}
+        </div>
+    );
+}
+
+export function AppOutputs({ outputs }: { outputs: AppOutputItem[] }) {
+    const t = useTranslations("Workspace.appView");
+
+    const withValues = outputs.filter((o) => o.values.length > 0);
+    if (withValues.length === 0) {
+        return (
+            <p className="text-sm text-muted-foreground text-center py-6">
+                {t("noOutputsYet")}
+            </p>
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            {withValues.map((output) => (
+                <OutputBlock key={output.nodeId} output={output} />
+            ))}
+        </div>
+    );
+}

--- a/src/components/workspace/app-view/app-run-progress.tsx
+++ b/src/components/workspace/app-view/app-run-progress.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Progress } from "@/components/ui/progress";
+import { useTaskStore } from "@/hooks/use-task";
+
+/**
+ * Step progress for an app-mode run: progress bar + "step n/m · node label".
+ * Reads the store maps that use-workflow-execution keeps updated from SSE,
+ * so it stays correct across mode switches mid-run.
+ */
+export function AppRunProgress({
+    totalSteps,
+    stepLabels,
+}: {
+    totalSteps: number;
+    stepLabels: Map<string, string>;
+}) {
+    const t = useTranslations("Workspace.appView");
+    const workflowExecutionStatus = useTaskStore(
+        (state) => state.workflowExecutionStatus,
+    );
+    const nodeExecutionStatusMap = useTaskStore(
+        (state) => state.nodeExecutionStatusMap,
+    );
+
+    if (workflowExecutionStatus === "idle") return null;
+
+    if (workflowExecutionStatus === "completed") {
+        return (
+            <div className="text-sm text-emerald-500 text-center">
+                {t("completed")}
+            </div>
+        );
+    }
+
+    if (workflowExecutionStatus === "failed") {
+        return (
+            <div className="text-sm text-red-500 text-center">
+                {t("failed")}
+            </div>
+        );
+    }
+
+    // running / paused
+    let completed = 0;
+    let runningLabel: string | null = null;
+    for (const [nodeId, label] of stepLabels) {
+        const status = nodeExecutionStatusMap.get(nodeId);
+        if (status === "completed") completed++;
+        else if (status === "running" && runningLabel === null) {
+            runningLabel = label;
+        }
+    }
+    const current = Math.min(completed + 1, totalSteps);
+    const percent = totalSteps > 0 ? (completed / totalSteps) * 100 : 0;
+
+    return (
+        <div className="space-y-1.5">
+            <Progress value={percent} />
+            <div className="text-xs text-muted-foreground text-center">
+                {t("stepProgress", { current, total: totalSteps })}
+                {runningLabel ? ` · ${runningLabel}` : ""}
+            </div>
+        </div>
+    );
+}

--- a/src/components/workspace/app-view/app-view.tsx
+++ b/src/components/workspace/app-view/app-view.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { Loader2, Play, Square } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { SaveExecuteDialog } from "@/components/workspace/save-execute-dialog";
+import type { FlowState } from "@/hooks/use-flow";
+import { useFlow } from "@/hooks/use-flow";
+import { useTaskStore } from "@/hooks/use-task";
+import { useWorkflowExecution } from "@/hooks/use-workflow-execution";
+import { AppInputField } from "./app-input-field";
+import { AppOutputs } from "./app-outputs";
+import { AppRunProgress } from "./app-run-progress";
+import {
+    type AppFieldValue,
+    type AppFormField,
+    fieldHasValue,
+    findAddNodeValueTarget,
+    useAppFormModel,
+} from "./use-app-form-model";
+
+const selector = (state: FlowState) => ({
+    nodes: state.nodes,
+    edges: state.edges,
+    workflowId: state.workflowId,
+    workflowName: state.workflowName,
+    workflowDescription: state.workflowDescription,
+    setWorkflowName: state.setWorkflowName,
+    setWorkflowId: state.setWorkflowId,
+    setWorkflowDescription: state.setWorkflowDescription,
+});
+
+/**
+ * App mode: the workflow rendered as a simple form — inputs on top, run
+ * button with step progress, final outputs below. The canvas stays mounted
+ * (hidden) underneath, so ABI registrations, SSE output application and
+ * recovery keep working unchanged.
+ */
+export function AppView() {
+    const {
+        nodes,
+        edges,
+        workflowId,
+        workflowName,
+        workflowDescription,
+        setWorkflowName,
+        setWorkflowId,
+        setWorkflowDescription,
+    } = useFlow(useShallow(selector));
+
+    const t = useTranslations("Workspace.appView");
+    const tIsland = useTranslations("Workspace.smartIsland");
+    const tIndex = useTranslations("Index");
+
+    const setWorkspaceMode = useTaskStore((state) => state.setWorkspaceMode);
+    const workflowExecutionStatus = useTaskStore(
+        (state) => state.workflowExecutionStatus,
+    );
+    const isRunning = workflowExecutionStatus === "running";
+
+    const model = useAppFormModel(nodes, edges);
+
+    const {
+        showSaveDialog,
+        setShowSaveDialog,
+        tempName,
+        setTempName,
+        tempDescription,
+        setTempDescription,
+        isSaving,
+        handleExecuteClick,
+        handleSaveAndExecute,
+        handleStop,
+    } = useWorkflowExecution({
+        nodes,
+        edges,
+        workflowId,
+        workflowName,
+        workflowDescription,
+        setWorkflowId,
+        setWorkflowName,
+        setWorkflowDescription,
+        defaultWorkflowName: tIndex("title"),
+        t: tIsland,
+    });
+
+    // Mirrors the canvas Add-node behavior: values land on the downstream
+    // data node (spawning one via `expands` when absent), never on the Add
+    // node itself; plain data-node fields are written in place.
+    const handleFieldChange = useCallback(
+        (field: AppFormField, patch: AppFieldValue) => {
+            const store = useFlow.getState();
+            if (!field.isAddNode) {
+                const node = store.nodes.find((n) => n.id === field.nodeId);
+                store.updates(field.nodeId, {
+                    ...(node?.data as Record<string, unknown>),
+                    ...patch,
+                });
+                return;
+            }
+            const downstreamId = findAddNodeValueTarget(
+                field.nodeId,
+                field.expandType,
+                store.nodes,
+                store.edges,
+            );
+            if (downstreamId) {
+                const downstream = store.nodes.find(
+                    (n) => n.id === downstreamId,
+                );
+                store.updates(downstreamId, {
+                    ...(downstream?.data as Record<string, unknown>),
+                    ...patch,
+                });
+            } else {
+                store.expands(field.nodeId, [
+                    { type: field.expandType, data: { ...patch } },
+                ]);
+            }
+            // Keep addTextNode's own manual value in sync (the exporter's
+            // manual-mode path and the canvas textarea both read it).
+            if (patch.texts && field.expandType === "textNode") {
+                const current = useFlow.getState();
+                const addNode = current.nodes.find(
+                    (n) => n.id === field.nodeId,
+                );
+                current.updates(field.nodeId, {
+                    ...(addNode?.data as Record<string, unknown>),
+                    manualValue: patch.texts[0] ?? "",
+                });
+            }
+        },
+        [],
+    );
+
+    const missingRequired = model.fields.some(
+        (f) => f.required && !fieldHasValue(f),
+    );
+
+    if (model.error) {
+        return (
+            <div className="h-full flex flex-col items-center justify-center gap-3 px-4">
+                <p className="text-sm text-muted-foreground text-center">
+                    {t(
+                        model.error === "empty"
+                            ? "emptyWorkflow"
+                            : model.error === "invalid"
+                              ? "invalidWorkflow"
+                              : "nothingToRun",
+                    )}
+                </p>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setWorkspaceMode("create")}
+                >
+                    {t("goToCreateMode")}
+                </Button>
+            </div>
+        );
+    }
+
+    return (
+        <>
+            <SaveExecuteDialog
+                open={showSaveDialog}
+                onOpenChange={setShowSaveDialog}
+                isNewWorkflow={!workflowId}
+                tempName={tempName}
+                tempDescription={tempDescription}
+                onNameChange={setTempName}
+                onDescriptionChange={setTempDescription}
+                onConfirm={handleSaveAndExecute}
+                isSaving={isSaving}
+            />
+            <div className="max-w-2xl mx-auto px-4 pt-20 pb-24 space-y-5">
+                <div className="space-y-1">
+                    <h1 className="text-xl font-semibold">{workflowName}</h1>
+                    {workflowDescription && (
+                        <p className="text-sm text-muted-foreground">
+                            {workflowDescription}
+                        </p>
+                    )}
+                </div>
+
+                {model.fields.length > 0 && (
+                    <Card>
+                        <CardHeader className="pb-3">
+                            <CardTitle className="text-base">
+                                {t("inputsTitle")}
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            {model.fields.map((field) => (
+                                <AppInputField
+                                    key={field.nodeId}
+                                    field={field}
+                                    onChange={(patch) =>
+                                        handleFieldChange(field, patch)
+                                    }
+                                    disabled={isRunning}
+                                />
+                            ))}
+                        </CardContent>
+                    </Card>
+                )}
+
+                <div className="space-y-3">
+                    {isRunning ? (
+                        <Button
+                            variant="destructive"
+                            className="w-full"
+                            onClick={() => void handleStop()}
+                        >
+                            <Square className="size-4" />
+                            {t("cancel")}
+                        </Button>
+                    ) : (
+                        <Button
+                            className="w-full"
+                            disabled={missingRequired || isSaving}
+                            onClick={handleExecuteClick}
+                        >
+                            {isSaving ? (
+                                <Loader2 className="size-4 animate-spin" />
+                            ) : (
+                                <Play className="size-4" />
+                            )}
+                            {t("run")}
+                        </Button>
+                    )}
+                    <AppRunProgress
+                        totalSteps={model.totalSteps}
+                        stepLabels={model.stepLabels}
+                    />
+                </div>
+
+                <Card>
+                    <CardHeader className="pb-3">
+                        <CardTitle className="text-base">
+                            {t("outputsTitle")}
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <AppOutputs outputs={model.outputs} />
+                    </CardContent>
+                </Card>
+            </div>
+        </>
+    );
+}

--- a/src/components/workspace/app-view/model-file-accept.ts
+++ b/src/components/workspace/app-view/model-file-accept.ts
@@ -1,0 +1,14 @@
+/**
+ * Accept string for 3D model uploads, flattened from the canonical format
+ * catalog maintained next to the model node.
+ */
+
+import { FORMAT_CATEGORIES } from "@/components/workspace/nodes/modality/model-node.formats";
+
+export const MODEL_FILE_ACCEPT = Array.from(
+    new Set(
+        Object.values(FORMAT_CATEGORIES).flatMap(
+            (category) => category.formats,
+        ),
+    ),
+).join(",");

--- a/src/components/workspace/app-view/use-app-form-model.ts
+++ b/src/components/workspace/app-view/use-app-form-model.ts
@@ -1,0 +1,249 @@
+"use client";
+
+/**
+ * Derives the app-mode form model from the live canvas graph.
+ *
+ * Reuses the workflow exporter: level-0 data / Add nodes become form fields,
+ * `outputs` (leaf data nodes) become the results section. Values are read
+ * live from the canvas nodes so the form and the canvas stay in sync in both
+ * directions, and SSE-applied outputs show up as soon as `expands` merges
+ * them into the downstream data nodes.
+ *
+ * The exporter resolves executable nodes through the ABI mount registry,
+ * which is populated by the (hidden but mounted) canvas node components in
+ * their mount effects — i.e. *after* the render in which a nodes change is
+ * first seen. The `tick` effect below re-derives once per nodes/edges change
+ * so the memo always settles on a fully-registered graph.
+ */
+
+import type { Edge, Node } from "@xyflow/react";
+import { useEffect, useMemo, useState } from "react";
+import type {
+    DataNode,
+    WorkflowOutput,
+} from "@/lib/workflow/executable-workflow";
+import { DATA_NODE_TYPES } from "@/lib/workflow/executable-workflow";
+import { exportWorkflow } from "@/lib/workflow/exporter";
+import { WorkflowParser } from "@/lib/workflow/parser";
+
+export type AppFormErrorState = "empty" | "invalid" | "nothingToRun" | null;
+
+export interface AppFieldValue {
+    texts?: string[];
+    fileKeys?: string[];
+}
+
+export interface AppFormField {
+    /** Level-0 canvas node backing this field (data node or Add node). */
+    nodeId: string;
+    /** True when the backing node is an Add node (value lives downstream). */
+    isAddNode: boolean;
+    /** Data node type an Add-node field spawns/merges via `expands`. */
+    expandType: string;
+    dataType: DataNode["dataType"];
+    label?: string;
+    /** Field must have a value before the workflow can run. */
+    required: boolean;
+    /** Current value, read live from the canvas. */
+    value: AppFieldValue;
+}
+
+export interface AppOutputItem {
+    nodeId: string;
+    type: WorkflowOutput["type"];
+    /** Current values (fileKeys or texts), read live from the canvas. */
+    values: string[];
+    /** True when the values are file keys (vs raw text). */
+    isFileValues: boolean;
+}
+
+export interface AppFormModel {
+    error: AppFormErrorState;
+    fields: AppFormField[];
+    outputs: AppOutputItem[];
+    totalSteps: number;
+    /** Executable node id -> display label, for progress rendering. */
+    stepLabels: Map<string, string>;
+}
+
+/** addImageNode -> imageNode, addLinkNode -> linkNode, ... */
+function addNodeToDataNodeType(addType: string): string {
+    const stripped = addType.replace(/^add/, "");
+    return stripped.charAt(0).toLowerCase() + stripped.slice(1);
+}
+
+function nodeData(
+    nodes: Node[],
+    nodeId: string,
+): Record<string, unknown> | undefined {
+    const node = nodes.find((n) => n.id === nodeId);
+    return node?.data as Record<string, unknown> | undefined;
+}
+
+/**
+ * The canvas node whose `data` holds an Add-node field's current value: the
+ * first downstream data node of the expected type, if one exists.
+ */
+export function findAddNodeValueTarget(
+    addNodeId: string,
+    expandType: string,
+    nodes: Node[],
+    edges: Edge[],
+): string | undefined {
+    const edge = edges.find((e) => {
+        if (e.source !== addNodeId) return false;
+        const target = nodes.find((n) => n.id === e.target);
+        return target?.type === expandType;
+    });
+    return edge?.target;
+}
+
+function readFieldValue(
+    dataNode: DataNode,
+    expandType: string,
+    nodes: Node[],
+    edges: Edge[],
+): AppFieldValue {
+    const isAdd = !DATA_NODE_TYPES[dataNode.type];
+    if (!isAdd) {
+        const data = nodeData(nodes, dataNode.id);
+        return {
+            texts: data?.texts as string[] | undefined,
+            fileKeys: data?.fileKeys as string[] | undefined,
+        };
+    }
+    // Add node: prefer the downstream data node (where uploads land), then
+    // the Add node's own data (manualValue covers addTextNode manual input).
+    const downstreamId = findAddNodeValueTarget(
+        dataNode.id,
+        expandType,
+        nodes,
+        edges,
+    );
+    if (downstreamId) {
+        const data = nodeData(nodes, downstreamId);
+        const texts = data?.texts as string[] | undefined;
+        const fileKeys = data?.fileKeys as string[] | undefined;
+        if ((texts && texts.length > 0) || (fileKeys && fileKeys.length > 0)) {
+            return { texts, fileKeys };
+        }
+    }
+    const own = nodeData(nodes, dataNode.id);
+    const ownTexts = own?.texts as string[] | undefined;
+    const manualValue = own?.manualValue as string | undefined;
+    return {
+        texts:
+            ownTexts && ownTexts.length > 0
+                ? ownTexts
+                : manualValue
+                  ? [manualValue]
+                  : undefined,
+        fileKeys: own?.fileKeys as string[] | undefined,
+    };
+}
+
+function hasValue(value: AppFieldValue): boolean {
+    return (
+        (value.texts?.some((t) => t.trim().length > 0) ?? false) ||
+        (value.fileKeys?.length ?? 0) > 0
+    );
+}
+
+export function fieldHasValue(field: AppFormField): boolean {
+    return hasValue(field.value);
+}
+
+export function useAppFormModel(nodes: Node[], edges: Edge[]): AppFormModel {
+    // Canvas node components register their ABI specs in mount effects, which
+    // run after the render where a nodes change first appears. Bumping a tick
+    // afterwards re-runs the memo against the fully-populated registry.
+    const [tick, setTick] = useState(0);
+    useEffect(() => {
+        setTick((t) => t + 1);
+    }, [nodes, edges]);
+
+    return useMemo<AppFormModel>(() => {
+        void tick;
+        if (nodes.length === 0) {
+            return {
+                error: "empty",
+                fields: [],
+                outputs: [],
+                totalSteps: 0,
+                stepLabels: new Map(),
+            };
+        }
+
+        // A cycle keeps nodes out of every execution level and the exporter
+        // silently drops them — reject the graph up front instead.
+        if (!new WorkflowParser({ nodes, edges }).isValid()) {
+            return {
+                error: "invalid",
+                fields: [],
+                outputs: [],
+                totalSteps: 0,
+                stepLabels: new Map(),
+            };
+        }
+
+        const executable = exportWorkflow(nodes, edges, {
+            includeOriginalFlow: false,
+        });
+
+        const fields: AppFormField[] = executable.dataNodes
+            .filter((d) => d.level === 0)
+            .map((d) => {
+                const isAddNode = !DATA_NODE_TYPES[d.type];
+                const expandType = isAddNode
+                    ? addNodeToDataNodeType(d.type)
+                    : d.type;
+                const value = readFieldValue(d, expandType, nodes, edges);
+                return {
+                    nodeId: d.id,
+                    isAddNode,
+                    expandType,
+                    dataType: d.dataType,
+                    label: d.label,
+                    required: true,
+                    value,
+                };
+            });
+
+        if (executable.executableNodes.length === 0) {
+            return {
+                error: "nothingToRun",
+                fields,
+                outputs: [],
+                totalSteps: 0,
+                stepLabels: new Map(),
+            };
+        }
+
+        const fieldNodeIds = new Set(fields.map((f) => f.nodeId));
+        const outputs: AppOutputItem[] = executable.outputs
+            // A dangling level-0 node is both a field and a leaf; showing it
+            // in the results section would just mirror the input.
+            .filter((o) => !fieldNodeIds.has(o.nodeId))
+            .map((o) => {
+                const data = nodeData(nodes, o.nodeId);
+                const isFileValues = o.field === "fileKeys";
+                const values =
+                    (data?.[o.field] as string[] | undefined)?.filter(
+                        (v) => v && v.length > 0,
+                    ) ?? [];
+                return { nodeId: o.nodeId, type: o.type, values, isFileValues };
+            });
+
+        const stepLabels = new Map<string, string>(
+            executable.executableNodes.map((n) => [n.id, n.label ?? n.type]),
+        );
+
+        return {
+            error: null,
+            fields,
+            outputs,
+            totalSteps: executable.executableNodes.length,
+            stepLabels,
+        };
+    }, [nodes, edges, tick]);
+}

--- a/src/components/workspace/mode-switch.tsx
+++ b/src/components/workspace/mode-switch.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { Play, Sparkles } from "lucide-react";
+import { AppWindow, Play, Sparkles } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
-import { Switch } from "@/components/ui/switch";
 import {
     Tooltip,
     TooltipContent,
@@ -14,20 +13,49 @@ import {
     WORKSPACE_MODE_KEY,
     type WorkspaceMode,
 } from "@/hooks/use-task";
+import { cn } from "@/lib/utils";
 
 interface ModeSwitchProps {
     onChange?: (mode: WorkspaceMode) => void;
 }
 
+const MODES: {
+    mode: WorkspaceMode;
+    icon: React.ComponentType<{ className?: string }>;
+    labelKey: string;
+    activeClass: string;
+}[] = [
+    {
+        mode: "create",
+        icon: Sparkles,
+        labelKey: "createMode",
+        activeClass: "bg-violet-500 text-white",
+    },
+    {
+        mode: "execute",
+        icon: Play,
+        labelKey: "executeMode",
+        activeClass: "bg-emerald-500 text-white",
+    },
+    {
+        mode: "app",
+        icon: AppWindow,
+        labelKey: "appMode",
+        activeClass: "bg-sky-500 text-white",
+    },
+];
+
+const VALID_MODES: WorkspaceMode[] = ["create", "execute", "app"];
+
 /**
- * Switch between create and execute modes
+ * Segmented control switching between create / execute / app modes
  */
 export function ModeSwitch({ onChange }: ModeSwitchProps) {
     const t = useTranslations("Workspace.modeSwitch");
     const workspaceMode = useTaskStore((state) => state.workspaceMode);
     const setWorkspaceMode = useTaskStore((state) => state.setWorkspaceMode);
     const [mounted, setMounted] = useState(false);
-    // Control the tooltip via hover/focus so toggling the switch (a pointer-down
+    // Control the tooltip via hover/focus so clicking a segment (a pointer-down
     // on the trigger) doesn't dismiss it the way Radix's default behavior does.
     const [tooltipOpen, setTooltipOpen] = useState(false);
 
@@ -36,63 +64,56 @@ export function ModeSwitch({ onChange }: ModeSwitchProps) {
         const savedMode = localStorage.getItem(
             WORKSPACE_MODE_KEY,
         ) as WorkspaceMode | null;
-        if (savedMode && (savedMode === "create" || savedMode === "execute")) {
+        if (savedMode && VALID_MODES.includes(savedMode)) {
             setWorkspaceMode(savedMode);
         }
     }, [setWorkspaceMode]);
 
-    const handleModeChange = (checked: boolean) => {
-        const newMode: WorkspaceMode = checked ? "execute" : "create";
-        setWorkspaceMode(newMode);
-        onChange?.(newMode);
+    const handleModeChange = (mode: WorkspaceMode) => {
+        setWorkspaceMode(mode);
+        onChange?.(mode);
     };
 
     if (!mounted) {
         return (
             <div className="flex items-center gap-1.5 p-2 rounded-xl bg-background/80 backdrop-blur-md border border-border/50 dark:border-gray-500/60">
-                <div className="w-16 h-6" />
+                <div className="w-24 h-6" />
             </div>
         );
     }
 
-    const isExecuteMode = workspaceMode === "execute";
+    const activeLabelKey =
+        MODES.find((m) => m.mode === workspaceMode)?.labelKey ?? "createMode";
 
     return (
         <Tooltip open={tooltipOpen}>
             <TooltipTrigger asChild>
                 <div
-                    className="flex items-center gap-1.5 p-2 rounded-xl bg-background/80 backdrop-blur-md border border-border/50 dark:border-gray-500/60 transition-all duration-300 hover:border-border dark:hover:border-gray-400/70 cursor-pointer"
+                    className="flex items-center gap-1 p-1.5 rounded-xl bg-background/80 backdrop-blur-md border border-border/50 dark:border-gray-500/60 transition-all duration-300 hover:border-border dark:hover:border-gray-400/70"
                     onPointerEnter={() => setTooltipOpen(true)}
                     onPointerLeave={() => setTooltipOpen(false)}
                     onFocus={() => setTooltipOpen(true)}
                     onBlur={() => setTooltipOpen(false)}
                 >
-                    <Sparkles
-                        className={`size-4 transition-all duration-200 ${
-                            !isExecuteMode
-                                ? "text-violet-500 scale-110"
-                                : "text-muted-foreground scale-100"
-                        }`}
-                    />
-
-                    <Switch
-                        checked={isExecuteMode}
-                        onCheckedChange={handleModeChange}
-                        className="data-[state=checked]:bg-emerald-500 data-[state=unchecked]:bg-violet-500 dark:data-[state=unchecked]:bg-violet-500 data-[state=checked]:dark:bg-emerald-500"
-                    />
-
-                    <Play
-                        className={`size-4 transition-all duration-200 ${
-                            isExecuteMode
-                                ? "text-emerald-500 scale-110"
-                                : "text-muted-foreground scale-100"
-                        }`}
-                    />
+                    {MODES.map(({ mode, icon: Icon, activeClass }) => (
+                        <button
+                            key={mode}
+                            type="button"
+                            aria-pressed={workspaceMode === mode}
+                            onClick={() => handleModeChange(mode)}
+                            className={cn(
+                                "flex items-center justify-center size-7 rounded-lg cursor-pointer transition-all duration-200",
+                                workspaceMode === mode
+                                    ? activeClass
+                                    : "text-muted-foreground hover:bg-gray-100 dark:hover:bg-gray-700/50",
+                            )}
+                        >
+                            <Icon className="size-4" />
+                        </button>
+                    ))}
                 </div>
             </TooltipTrigger>
-            <TooltipContent side="top">
-                {isExecuteMode ? t("executeMode") : t("createMode")}
-            </TooltipContent>
+            <TooltipContent side="top">{t(activeLabelKey)}</TooltipContent>
         </Tooltip>
     );
 }

--- a/src/components/workspace/workspace.tsx
+++ b/src/components/workspace/workspace.tsx
@@ -39,10 +39,13 @@ import {
 import { usePreloadFeatures } from "@/hooks/use-features";
 import type { FlowState } from "@/hooks/use-flow";
 import { useFlow } from "@/hooks/use-flow";
+import { useTaskStore } from "@/hooks/use-task";
 import { useWorkflowRecovery } from "@/hooks/use-workflow-recovery";
 import { logger } from "@/lib/logger";
+import { cn } from "@/lib/utils";
 import { isValidFlowConnection } from "@/lib/workflow/connection-rules";
 import { parseWorkflowImportJson } from "@/lib/workflow/exporter";
+import { AppView } from "./app-view/app-view";
 import { ModeSwitch } from "./mode-switch";
 import { OnboardingGate } from "./onboarding/onboarding-gate";
 import SmartIsland from "./smart-island";
@@ -72,6 +75,12 @@ function WorkspaceInner({
 
     // Separate data and functions to avoid re-renders caused by function reference changes
     const { nodes, edges } = useFlow(useShallow(selector));
+
+    // App mode replaces the canvas with a form view. The ReactFlow tree stays
+    // mounted (visibility-hidden) so ABI node registrations, SSE output
+    // application and workflow recovery keep working while it's covered.
+    const workspaceMode = useTaskStore((state) => state.workspaceMode);
+    const isAppMode = workspaceMode === "app";
 
     // Get functions directly from the store (function references never change)
     const onNodesChange = useFlow.getState().onNodesChange;
@@ -350,51 +359,65 @@ function WorkspaceInner({
 
     return (
         <div className="relative w-full h-full overflow-hidden [&_.react-flow]:!bg-[#f6f7f9] dark:[&_.react-flow]:!bg-background">
-            <ReactFlow
-                nodes={nodes}
-                onNodesChange={onNodesChange}
-                edges={edges}
-                onEdgesChange={onEdgesChange}
-                onConnect={onConnect}
-                isValidConnection={isValidConnection}
-                // Manual new connections are disabled at the handle level
-                // (isConnectableStart={false}); users may only reconnect an
-                // existing edge's endpoint, validated by isValidConnection.
-                onReconnect={onReconnect}
-                onReconnectStart={onReconnectStart}
-                onReconnectEnd={onReconnectEnd}
-                nodeTypes={NODE_TYPES}
-                edgeTypes={EDGE_TYPES}
-                defaultEdgeOptions={{
-                    type: "custom-edge",
-                    selectable: false,
-                    focusable: false,
-                }}
-                // While reconnecting, ReactFlow hides the original edge and
-                // shows this connection-line preview following the cursor.
-                // Match the custom-edge style so it stays visible/cursor-tracked.
-                connectionLineStyle={{
-                    strokeWidth: 3,
-                    stroke: "#94a3b8",
-                    strokeLinecap: "round",
-                }}
-                onSelectionChange={onSelectionChange}
-                onNodeDoubleClick={handleNodeDoubleClick}
-                onPaneClick={handlePaneClick}
-                nodeOrigin={[0.5, 0.5]}
-                selectNodesOnDrag={false}
-                fitView
-                minZoom={0.001} // Minimum zoom limit
-                maxZoom={1000} // Maximum zoom limit
-                proOptions={{ hideAttribution: true }}
-                colorMode={colorMode}
+            <div
+                className={cn(
+                    "w-full h-full",
+                    isAppMode && "invisible pointer-events-none",
+                )}
+                aria-hidden={isAppMode}
             >
-                <Background />
-                <Controls />
-                <Panel position="bottom-center" className="!mb-5 z-10">
-                    <SmartIsland />
-                </Panel>
-            </ReactFlow>
+                <ReactFlow
+                    nodes={nodes}
+                    onNodesChange={onNodesChange}
+                    edges={edges}
+                    onEdgesChange={onEdgesChange}
+                    onConnect={onConnect}
+                    isValidConnection={isValidConnection}
+                    // Manual new connections are disabled at the handle level
+                    // (isConnectableStart={false}); users may only reconnect an
+                    // existing edge's endpoint, validated by isValidConnection.
+                    onReconnect={onReconnect}
+                    onReconnectStart={onReconnectStart}
+                    onReconnectEnd={onReconnectEnd}
+                    nodeTypes={NODE_TYPES}
+                    edgeTypes={EDGE_TYPES}
+                    defaultEdgeOptions={{
+                        type: "custom-edge",
+                        selectable: false,
+                        focusable: false,
+                    }}
+                    // While reconnecting, ReactFlow hides the original edge and
+                    // shows this connection-line preview following the cursor.
+                    // Match the custom-edge style so it stays visible/cursor-tracked.
+                    connectionLineStyle={{
+                        strokeWidth: 3,
+                        stroke: "#94a3b8",
+                        strokeLinecap: "round",
+                    }}
+                    onSelectionChange={onSelectionChange}
+                    onNodeDoubleClick={handleNodeDoubleClick}
+                    onPaneClick={handlePaneClick}
+                    nodeOrigin={[0.5, 0.5]}
+                    selectNodesOnDrag={false}
+                    fitView
+                    minZoom={0.001} // Minimum zoom limit
+                    maxZoom={1000} // Maximum zoom limit
+                    proOptions={{ hideAttribution: true }}
+                    colorMode={colorMode}
+                >
+                    <Background />
+                    <Controls />
+                    <Panel position="bottom-center" className="!mb-5 z-10">
+                        <SmartIsland />
+                    </Panel>
+                </ReactFlow>
+            </div>
+
+            {isAppMode && (
+                <div className="absolute inset-0 z-5 overflow-y-auto bg-background">
+                    <AppView />
+                </div>
+            )}
 
             <div className="absolute left-5 top-5 z-10 flex items-center gap-3">
                 <WorkflowTitleMenu />

--- a/src/hooks/use-task.ts
+++ b/src/hooks/use-task.ts
@@ -63,7 +63,7 @@ export interface Task {
 export type NodeTaskHandler = (task: Task) => void;
 
 // Workspace mode type
-export type WorkspaceMode = "create" | "execute";
+export type WorkspaceMode = "create" | "execute" | "app";
 
 // Workflow execution status
 export type WorkflowExecutionStatus =

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -226,7 +226,34 @@
         "modeSwitch": {
             "createMode": "Create Mode",
             "executeMode": "Execute Mode",
+            "appMode": "App Mode",
             "upgradeRequired": "Upgrade to unlock Execute Mode"
+        },
+        "appView": {
+            "inputsTitle": "Inputs",
+            "outputsTitle": "Results",
+            "run": "Run",
+            "cancel": "Stop",
+            "stepProgress": "Step {current} of {total}",
+            "completed": "Done",
+            "failed": "Something went wrong",
+            "emptyWorkflow": "The canvas is empty. Build a workflow first.",
+            "invalidWorkflow": "This workflow has a cycle and can't run.",
+            "nothingToRun": "This workflow has no runnable steps yet.",
+            "noOutputsYet": "Results will show up here after a run.",
+            "dropFilesHere": "Drop files here or click to upload",
+            "copyText": "Copy",
+            "download": "Download",
+            "goToCreateMode": "Go to Create Mode",
+            "textPlaceholder": "Type here…",
+            "fieldType": {
+                "text": "Text",
+                "image": "Image",
+                "audio": "Audio",
+                "video": "Video",
+                "model": "3D model",
+                "file": "File"
+            }
         },
         "smartIsland": {
             "category": {

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -226,7 +226,34 @@
         "modeSwitch": {
             "createMode": "作成モード",
             "executeMode": "実行モード",
+            "appMode": "アプリモード",
             "upgradeRequired": "実行モードを解除するにはアップグレードが必要です"
+        },
+        "appView": {
+            "inputsTitle": "入力",
+            "outputsTitle": "結果",
+            "run": "実行",
+            "cancel": "停止",
+            "stepProgress": "ステップ {current}/{total}",
+            "completed": "完了",
+            "failed": "実行に失敗しました",
+            "emptyWorkflow": "キャンバスが空です。まずワークフローを作成してください",
+            "invalidWorkflow": "ワークフローに循環があるため実行できません",
+            "nothingToRun": "このワークフローには実行できるステップがありません",
+            "noOutputsYet": "実行すると結果がここに表示されます",
+            "dropFilesHere": "ここにファイルをドロップ、またはクリックしてアップロード",
+            "copyText": "コピー",
+            "download": "ダウンロード",
+            "goToCreateMode": "作成モードへ",
+            "textPlaceholder": "ここに入力…",
+            "fieldType": {
+                "text": "テキスト",
+                "image": "画像",
+                "audio": "音声",
+                "video": "動画",
+                "model": "3Dモデル",
+                "file": "ファイル"
+            }
         },
         "smartIsland": {
             "category": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -226,7 +226,34 @@
         "modeSwitch": {
             "createMode": "생성 모드",
             "executeMode": "실행 모드",
+            "appMode": "앱 모드",
             "upgradeRequired": "실행 모드를 사용하려면 업그레이드하세요"
+        },
+        "appView": {
+            "inputsTitle": "입력",
+            "outputsTitle": "결과",
+            "run": "실행",
+            "cancel": "중지",
+            "stepProgress": "{current}/{total} 단계",
+            "completed": "완료",
+            "failed": "실행에 실패했습니다",
+            "emptyWorkflow": "캔버스가 비어 있습니다. 먼저 워크플로를 만들어 주세요",
+            "invalidWorkflow": "워크플로에 순환 연결이 있어 실행할 수 없습니다",
+            "nothingToRun": "이 워크플로에는 실행할 단계가 없습니다",
+            "noOutputsYet": "실행하면 결과가 여기에 표시됩니다",
+            "dropFilesHere": "파일을 여기에 끌어다 놓거나 클릭해서 업로드",
+            "copyText": "복사",
+            "download": "다운로드",
+            "goToCreateMode": "생성 모드로 이동",
+            "textPlaceholder": "여기에 입력…",
+            "fieldType": {
+                "text": "텍스트",
+                "image": "이미지",
+                "audio": "오디오",
+                "video": "비디오",
+                "model": "3D 모델",
+                "file": "파일"
+            }
         },
         "smartIsland": {
             "category": {

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -226,7 +226,34 @@
         "modeSwitch": {
             "createMode": "创作模式",
             "executeMode": "执行模式",
+            "appMode": "应用模式",
             "upgradeRequired": "升级订阅以解锁执行模式"
+        },
+        "appView": {
+            "inputsTitle": "输入",
+            "outputsTitle": "结果",
+            "run": "运行",
+            "cancel": "停止",
+            "stepProgress": "第 {current}/{total} 步",
+            "completed": "已完成",
+            "failed": "运行失败",
+            "emptyWorkflow": "画布还是空的，先去搭一个工作流吧",
+            "invalidWorkflow": "工作流存在循环连接，无法运行",
+            "nothingToRun": "这个工作流还没有可运行的步骤",
+            "noOutputsYet": "运行后结果会显示在这里",
+            "dropFilesHere": "拖拽文件到这里，或点击上传",
+            "copyText": "复制",
+            "download": "下载",
+            "goToCreateMode": "去创作模式",
+            "textPlaceholder": "在这里输入…",
+            "fieldType": {
+                "text": "文本",
+                "image": "图片",
+                "audio": "音频",
+                "video": "视频",
+                "model": "3D 模型",
+                "file": "文件"
+            }
         },
         "smartIsland": {
             "category": {


### PR DESCRIPTION
## What

A third workspace mode ("应用模式", next to create/execute in the bottom-right mode switch) that renders the current workflow as a simple form, ComfyUI-app-mode style:

- **Inputs on top** — derived from the workflow's level-0 data / Add nodes (text → textarea, image/video/audio/model/file → upload dropzone with previews). Edits write back to the canvas nodes (Add-node values land on the downstream data node via `expands`, mirroring canvas behavior), so canvas ⇄ form stay in sync both ways.
- **Run button** — reuses `useWorkflowExecution` (save dialog on first run, `/api/workflow/execute`, cancel).
- **Step progress** — progress bar + "step n/m · node label", driven by the SSE-fed `nodeExecutionStatusMap`.
- **Results below** — leaf outputs rendered per modality (image grid, video/audio players, text with copy, file/model download), appearing live as SSE applies outputs.

## How

- The ReactFlow canvas stays **mounted but visibility-hidden** in app mode: the exporter resolves specs through the ABI mount registry, which is populated by mounted node components — unmounting would break both export and SSE output application.
- The form model is a `useMemo` over `exportWorkflow(nodes, edges)` (plus a post-registration tick), so no new derivation logic: level-0 `dataNodes` become fields, `outputs` become results.
- `WorkspaceMode` gains an `"app"` value; the old two-state switch becomes a three-segment control. Persisted values remain backward compatible.
- No changes to exporter / API / DB / SDK. i18n added for en/zh/ja/ko.

## Verified

- `pnpm lint:check`, `pnpm typecheck`, `pnpm build` all pass.
- Headless-browser smoke test on the bundled example workflow: form renders both text prompts + cached image result, mode round-trips (app → create → app) keep the canvas intact, three-segment switch highlights correctly (after a `.next` cache clear — the usual stale-Tailwind-class pitfall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)