### PR TITLE
feat(workspace): canvas undo/redo (Cmd+Z / Cmd+Shift+Z + toolbar buttons)

### DIFF
--- a/src/components/workspace/nodes/base/node-header.tsx
+++ b/src/components/workspace/nodes/base/node-header.tsx
@@ -249,7 +249,9 @@ export const NodeHeaderMenuAction = forwardRef<
                 nodes,
                 setNodes,
                 setEdges,
+                commitHistory,
             } = useFlow.getState();
+            commitHistory();
             const descendants = getDescendantNodeIds(id, curEdges);
             const toRemove = new Set([id, ...descendants]);
             setNodes(nodes.filter((node) => !toRemove.has(node.id)));
@@ -271,7 +273,9 @@ export const NodeHeaderMenuAction = forwardRef<
                 nodes,
                 setNodes,
                 setEdges,
+                commitHistory,
             } = useFlow.getState();
+            commitHistory();
             const descendants = getDescendantNodeIds(id, curEdges);
             setNodes(nodes.filter((node) => !descendants.has(node.id)));
             setEdges(

--- a/src/components/workspace/nodes/base/node-plugin-model-select.tsx
+++ b/src/components/workspace/nodes/base/node-plugin-model-select.tsx
@@ -40,7 +40,9 @@ export function NodePluginModelSelect({
     // useNodePluginResolver.
     useEffect(() => {
         if (resolved === current) return;
-        updates(id, { ...data, pluginModel: resolved });
+        // Programmatic normalization — must not create (or invalidate) undo
+        // history, or it re-fires after every undo and breaks the chain.
+        updates(id, { ...data, pluginModel: resolved }, { history: false });
     }, [id, data, current, resolved, updates]);
 
     const options = useMemo(

--- a/src/components/workspace/nodes/compose/image-gen-video-compose.tsx
+++ b/src/components/workspace/nodes/compose/image-gen-video-compose.tsx
@@ -72,7 +72,7 @@ const ImageGenVideoComposeNode = ({
 
     useEffect(() => {
         if (form.state.duration === undefined)
-            form.set("duration", VIDEO_DURATION_DEFAULT);
+            form.set("duration", VIDEO_DURATION_DEFAULT, { history: false });
     }, [form.state.duration, form.set]);
 
     const currentRatio: AspectRatio =

--- a/src/components/workspace/nodes/compose/music-cover.tsx
+++ b/src/components/workspace/nodes/compose/music-cover.tsx
@@ -65,7 +65,8 @@ const MusicCoverNode = ({
     // Persist the default so the workflow exporter / runtime sees the same
     // value the user sees in the UI.
     useEffect(() => {
-        if (form.state.strength == null) form.set("strength", DEFAULT_STRENGTH);
+        if (form.state.strength == null)
+            form.set("strength", DEFAULT_STRENGTH, { history: false });
     }, [form.state.strength, form.set]);
 
     return (

--- a/src/components/workspace/nodes/compose/speech-image-gen-video.tsx
+++ b/src/components/workspace/nodes/compose/speech-image-gen-video.tsx
@@ -83,7 +83,7 @@ const SpeechImageGenVideoNode = ({
 
     useEffect(() => {
         if (form.state.width === undefined && form.state.height === undefined) {
-            form.patch({ width: 1024, height: 576 });
+            form.patch({ width: 1024, height: 576 }, { history: false });
         }
     }, [form.state.width, form.state.height, form.patch]);
 

--- a/src/components/workspace/nodes/compose/video-image-gen-video-move.tsx
+++ b/src/components/workspace/nodes/compose/video-image-gen-video-move.tsx
@@ -88,7 +88,7 @@ const VideoImageGenVideoMoveNode = ({
 
     useEffect(() => {
         if (form.state.duration === undefined)
-            form.set("duration", VIDEO_DURATION_DEFAULT);
+            form.set("duration", VIDEO_DURATION_DEFAULT, { history: false });
     }, [form.state.duration, form.set]);
 
     return (

--- a/src/components/workspace/nodes/transfer/music-extract.tsx
+++ b/src/components/workspace/nodes/transfer/music-extract.tsx
@@ -59,7 +59,8 @@ const MusicExtractNode = ({
     // Persist the default so the workflow exporter / runtime sees the same
     // value the user sees in the UI.
     useEffect(() => {
-        if (form.state.track == null) form.set("track", DEFAULT_TRACK);
+        if (form.state.track == null)
+            form.set("track", DEFAULT_TRACK, { history: false });
     }, [form.state.track, form.set]);
 
     return (

--- a/src/components/workspace/nodes/transfer/text-gen-image.tsx
+++ b/src/components/workspace/nodes/transfer/text-gen-image.tsx
@@ -54,10 +54,13 @@ const TextGenImageNode = ({ selected, data }: TextGenImageNodeProps) => {
     // shows (otherwise the plugin falls back to its own default resolution).
     useEffect(() => {
         if (form.state.width === undefined || form.state.height === undefined)
-            form.patch({
-                width: DEFAULT_RATIO.width * DEFAULT_TIER.scale,
-                height: DEFAULT_RATIO.height * DEFAULT_TIER.scale,
-            });
+            form.patch(
+                {
+                    width: DEFAULT_RATIO.width * DEFAULT_TIER.scale,
+                    height: DEFAULT_RATIO.height * DEFAULT_TIER.scale,
+                },
+                { history: false },
+            );
     }, [form.state.width, form.state.height, form.patch]);
 
     const applySize = useCallback(

--- a/src/components/workspace/undo-redo-buttons.tsx
+++ b/src/components/workspace/undo-redo-buttons.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * Undo/redo button pair shown next to the workspace left nav.
+ */
+
+import { Redo2, Undo2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useUndoRedo } from "@/hooks/use-undo-redo";
+
+const BUTTON_CLASS =
+    "h-10 w-10 rounded-xl bg-white border border-gray-100 hover:bg-gray-50 disabled:opacity-40 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-700 transition-all duration-200";
+
+export function UndoRedoButtons() {
+    const t = useTranslations("Navigation");
+    const { undo, redo, canUndo, canRedo } = useUndoRedo();
+
+    return (
+        <div className="flex items-center gap-2">
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={undo}
+                        disabled={!canUndo}
+                        aria-label={t("undo")}
+                        className={BUTTON_CLASS}
+                    >
+                        <Undo2 className="h-5 w-5 text-gray-600 dark:text-gray-200" />
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{t("undo")}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={redo}
+                        disabled={!canRedo}
+                        aria-label={t("redo")}
+                        className={BUTTON_CLASS}
+                    >
+                        <Redo2 className="h-5 w-5 text-gray-600 dark:text-gray-200" />
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{t("redo")}</TooltipContent>
+            </Tooltip>
+        </div>
+    );
+}

--- a/src/components/workspace/workflow-dialog.tsx
+++ b/src/components/workspace/workflow-dialog.tsx
@@ -279,6 +279,8 @@ export function WorkflowDialog({ trigger, tooltip }: WorkflowDialogProps) {
 
                 useFlow.getState().setNodes(flowData.nodes);
                 useFlow.getState().setEdges(flowData.edges);
+                // Switching workflows must not allow undoing into the old one
+                useFlow.getState().clearHistory();
                 useFlow.getState().setWorkflowName(workflow.name);
                 useFlow
                     .getState()

--- a/src/components/workspace/workflow-title-menu.tsx
+++ b/src/components/workspace/workflow-title-menu.tsx
@@ -198,6 +198,8 @@ export function WorkflowTitleMenu() {
     };
 
     const confirmClear = () => {
+        // One undoable entry for the whole clear
+        useFlow.getState().commitHistory();
         setNodes([]);
         setEdges([]);
         setWorkflowName(tIndex("title"));
@@ -270,6 +272,8 @@ export function WorkflowTitleMenu() {
                 }
                 return;
             }
+            // One undoable entry for the whole import
+            useFlow.getState().commitHistory();
             setNodes(result.nodes);
             setEdges(result.edges);
             if (result.name?.trim()) {

--- a/src/components/workspace/workspace.tsx
+++ b/src/components/workspace/workspace.tsx
@@ -47,6 +47,7 @@ import { ModeSwitch } from "./mode-switch";
 import { OnboardingGate } from "./onboarding/onboarding-gate";
 import SmartIsland from "./smart-island";
 import { EDGE_TYPES, NODE_TYPES } from "./types";
+import { UndoRedoButtons } from "./undo-redo-buttons";
 import { WorkflowTitleMenu } from "./workflow-title-menu";
 import { WorkspaceLeftNav } from "./workspace-left-nav";
 import { WorkspaceNav } from "./workspace-nav";
@@ -108,7 +109,8 @@ function WorkspaceInner({
 
     const onReconnect = useCallback<OnReconnect<Edge>>(
         (oldEdge, newConnection) => {
-            const { edges, setEdges } = useFlow.getState();
+            const { edges, setEdges, commitHistory } = useFlow.getState();
+            commitHistory();
             setEdges(reconnectEdge(oldEdge, newConnection, edges));
         },
         [],
@@ -132,7 +134,8 @@ function WorkspaceInner({
 
     const confirmDeleteEdge = useCallback(() => {
         if (!pendingDeleteEdgeId) return;
-        const { edges, setEdges } = useFlow.getState();
+        const { edges, setEdges, commitHistory } = useFlow.getState();
+        commitHistory();
         setEdges(edges.filter((e) => e.id !== pendingDeleteEdgeId));
         setPendingDeleteEdgeId(null);
     }, [pendingDeleteEdgeId]);
@@ -184,7 +187,10 @@ function WorkspaceInner({
                 if (data.texts && data.texts.length > 0) {
                     newData.texts = data.texts;
                 }
-                useFlow.getState().updates(nodeId, newData);
+                // Programmatic task-result write — not an undoable user action
+                useFlow.getState().updates(nodeId, newData, {
+                    history: false,
+                });
             }
         },
         [],
@@ -226,6 +232,12 @@ function WorkspaceInner({
             minZoom: 0.1,
         });
     };
+
+    // Snapshot once at drag start so a whole drag is a single undo entry
+    // (position changes then stream through onNodesChange without committing)
+    const handleDragStart = useCallback(() => {
+        useFlow.getState().commitHistory();
+    }, []);
 
     // Click on empty canvas to exit Combo Mode
     const handlePaneClick = useCallback(() => {
@@ -381,6 +393,9 @@ function WorkspaceInner({
                 onSelectionChange={onSelectionChange}
                 onNodeDoubleClick={handleNodeDoubleClick}
                 onPaneClick={handlePaneClick}
+                onNodeDragStart={handleDragStart}
+                onSelectionDragStart={handleDragStart}
+                nodeDragThreshold={1}
                 nodeOrigin={[0.5, 0.5]}
                 selectNodesOnDrag={false}
                 fitView
@@ -399,6 +414,7 @@ function WorkspaceInner({
             <div className="absolute left-5 top-5 z-10 flex items-center gap-3">
                 <WorkflowTitleMenu />
                 <WorkspaceLeftNav />
+                <UndoRedoButtons />
             </div>
 
             <div className="absolute right-5 top-5 z-10">

--- a/src/hooks/use-abi-execution.ts
+++ b/src/hooks/use-abi-execution.ts
@@ -183,7 +183,8 @@ export function useAbiExecution<F extends NodeSlot>(
             if (!needsSync) return;
 
             hasSyncedRef.current = true;
-            flowUpdates(nodeId, { ...data, feature });
+            // Programmatic normalization — keep it out of undo history
+            flowUpdates(nodeId, { ...data, feature }, { history: false });
         });
         return () => {
             cancelled = true;

--- a/src/hooks/use-abi-form.ts
+++ b/src/hooks/use-abi-form.ts
@@ -37,13 +37,17 @@ export interface UseAbiFormReturn<F extends NodeSlot> {
     spec: ResolvedSpec;
     /** Current config snapshot (handle-fed fields are excluded). */
     state: ConfigState<F>;
-    /** Set a single field. */
+    /**
+     * Set a single field. Pass `{ history: false }` for programmatic writes
+     * (e.g. mount-time defaults) so they stay out of undo history.
+     */
     set: <K extends keyof ConfigState<F>>(
         field: K,
         value: ConfigState<F>[K],
+        opts?: { history?: boolean },
     ) => void;
-    /** Merge a partial patch. */
-    patch: (partial: ConfigState<F>) => void;
+    /** Merge a partial patch. Same `history` semantics as `set`. */
+    patch: (partial: ConfigState<F>, opts?: { history?: boolean }) => void;
     /** Bind a callback-style control: returns `{ value, onChange(value) }`. */
     bind: <K extends keyof ConfigState<F>>(
         field: K,
@@ -113,9 +117,9 @@ export function useAbiForm<F extends NodeSlot>(
     }, [data]);
 
     const writeBack = useCallback(
-        (next: ConfigState<F>) => {
+        (next: ConfigState<F>, opts?: { history?: boolean }) => {
             if (!nodeId) return;
-            flowUpdates(nodeId, { ...(dataRef.current ?? {}), ...next });
+            flowUpdates(nodeId, { ...(dataRef.current ?? {}), ...next }, opts);
         },
         [nodeId, flowUpdates],
     );
@@ -124,21 +128,22 @@ export function useAbiForm<F extends NodeSlot>(
         <K extends keyof ConfigState<F>>(
             field: K,
             value: ConfigState<F>[K],
+            opts?: { history?: boolean },
         ) => {
             const next = { ...stateRef.current, [field]: value };
             stateRef.current = next;
             setState(next);
-            writeBack(next);
+            writeBack(next, opts);
         },
         [writeBack],
     );
 
     const patch = useCallback(
-        (partial: ConfigState<F>) => {
+        (partial: ConfigState<F>, opts?: { history?: boolean }) => {
             const next = { ...stateRef.current, ...partial };
             stateRef.current = next;
             setState(next);
-            writeBack(next);
+            writeBack(next, opts);
         },
         [writeBack],
     );

--- a/src/hooks/use-flow.ts
+++ b/src/hooks/use-flow.ts
@@ -21,6 +21,12 @@ import {
     resolveEdgeHandles,
 } from "@/lib/abi/node-feature-registry";
 import { DATA_NODE_TYPES } from "@/lib/workflow/executable-workflow";
+import {
+    currentFocusGeneration,
+    type FlowSnapshot,
+    pushSnapshot,
+    snapshotFlow,
+} from "@/lib/workflow/flow-history";
 
 // True when React Flow reports a persisted data/input node type
 function isDataNode(nodeType: string): boolean {
@@ -54,6 +60,16 @@ const debouncedSaveNodes = createDebounce((nodes: Node[]) => {
 const debouncedSaveEdges = createDebounce((edges: Edge[]) => {
     localStorage.setItem("edges", JSON.stringify(edges));
 }, 500);
+
+// Coalescing tracker for history commits: repeated commits with the same
+// source are skipped while the focused element stays the same, so a typing
+// burst in one form field becomes a single undo entry.
+const lastCommit = { source: "", focusGen: -1 };
+
+function resetCommitTracker() {
+    lastCommit.source = "";
+    lastCommit.focusGen = -1;
+}
 
 // Persist workflow meta (title, ids, notes)
 const debouncedSaveWorkflowMeta = createDebounce(
@@ -103,7 +119,23 @@ export interface FlowState {
     setReconnectingEdgeId: (id: string | null) => void;
     expands: (nodeId: string | null, possibleNodes: PossibleNode[]) => string[];
     compose: (newNode: { type: string; data: unknown }) => string;
-    updates: (nodeId: string, data: Record<string, unknown>) => void;
+    updates: (
+        nodeId: string,
+        data: Record<string, unknown>,
+        opts?: { history?: boolean },
+    ) => void;
+
+    // Undo/redo history (snapshots of { nodes, edges })
+    historyPast: FlowSnapshot[];
+    historyFuture: FlowSnapshot[];
+    /**
+     * Snapshot the current state onto the past stack and clear the future
+     * stack. Commits with the same `source` coalesce while focus stays put.
+     */
+    commitHistory: (source?: string) => void;
+    undo: () => void;
+    redo: () => void;
+    clearHistory: () => void;
     addNode: (
         node: PossibleNode,
         position?: { x: number; y: number },
@@ -129,6 +161,65 @@ export const useFlow = create<FlowState>((set, get) => ({
     comboSelectedIds: new Set<string>(),
     reconnectingEdgeId: null,
 
+    historyPast: [],
+    historyFuture: [],
+    commitHistory: (source) => {
+        const focusGen = currentFocusGeneration();
+        if (
+            source &&
+            source === lastCommit.source &&
+            focusGen === lastCommit.focusGen
+        ) {
+            // Same source within the same focus session — coalesce
+            return;
+        }
+        lastCommit.source = source ?? "";
+        lastCommit.focusGen = focusGen;
+        const { nodes, edges, historyPast } = get();
+        set({
+            historyPast: pushSnapshot(historyPast, snapshotFlow(nodes, edges)),
+            historyFuture: [],
+        });
+    },
+    undo: () => {
+        const { historyPast, historyFuture, nodes, edges } = get();
+        const previous = historyPast[historyPast.length - 1];
+        if (!previous) return;
+        resetCommitTracker();
+        set({
+            nodes: previous.nodes,
+            edges: previous.edges,
+            historyPast: historyPast.slice(0, -1),
+            historyFuture: historyFuture.concat(snapshotFlow(nodes, edges)),
+            selectedNodes: [],
+            comboMode: false,
+            comboSelectedIds: new Set(),
+        });
+        debouncedSaveNodes(previous.nodes);
+        debouncedSaveEdges(previous.edges);
+    },
+    redo: () => {
+        const { historyPast, historyFuture, nodes, edges } = get();
+        const next = historyFuture[historyFuture.length - 1];
+        if (!next) return;
+        resetCommitTracker();
+        set({
+            nodes: next.nodes,
+            edges: next.edges,
+            historyPast: pushSnapshot(historyPast, snapshotFlow(nodes, edges)),
+            historyFuture: historyFuture.slice(0, -1),
+            selectedNodes: [],
+            comboMode: false,
+            comboSelectedIds: new Set(),
+        });
+        debouncedSaveNodes(next.nodes);
+        debouncedSaveEdges(next.edges);
+    },
+    clearHistory: () => {
+        resetCommitTracker();
+        set({ historyPast: [], historyFuture: [] });
+    },
+
     nodeCreatedCallbacks: new Set(),
     onNodeCreated: (callback) => {
         const callbacks = get().nodeCreatedCallbacks;
@@ -153,6 +244,15 @@ export const useFlow = create<FlowState>((set, get) => ({
         });
     },
     onNodesChange: (changes) => {
+        // Only removals commit history here; position changes stream per-frame
+        // during drags and are captured once via onNodeDragStart instead.
+        // React Flow's keyboard delete emits edge and node removals as two
+        // synchronous callbacks — the shared "remove" source coalesces them
+        // into one entry, and the microtask reset keeps the next delete fresh.
+        if (changes.some((c) => c.type === "remove")) {
+            get().commitHistory("remove");
+            queueMicrotask(resetCommitTracker);
+        }
         const nodes = applyNodeChanges(changes, get().nodes);
         let edges = get().edges;
         const removedIds: string[] = [];
@@ -175,6 +275,10 @@ export const useFlow = create<FlowState>((set, get) => ({
         debouncedSaveEdges(edges);
     },
     onEdgesChange: (changes) => {
+        if (changes.some((c) => c.type === "remove")) {
+            get().commitHistory("remove");
+            queueMicrotask(resetCommitTracker);
+        }
         const edges = applyEdgeChanges(changes, get().edges);
         set({
             edges: edges,
@@ -182,6 +286,7 @@ export const useFlow = create<FlowState>((set, get) => ({
         debouncedSaveEdges(edges);
     },
     onConnect: (connection) => {
+        get().commitHistory();
         const edges = addEdge(
             { ...connection, type: "custom-edge" },
             get().edges,
@@ -200,7 +305,10 @@ export const useFlow = create<FlowState>((set, get) => ({
         debouncedSaveEdges(edges);
     },
     setReconnectingEdgeId: (id) => set({ reconnectingEdgeId: id }),
-    updates: (nodeId: string, data: Record<string, unknown>) => {
+    updates: (nodeId, data, opts) => {
+        if (opts?.history !== false) {
+            get().commitHistory(`update:${nodeId}`);
+        }
         const newNodes = get().nodes.map((node) => {
             if (node.id === nodeId) {
                 return {
@@ -216,6 +324,7 @@ export const useFlow = create<FlowState>((set, get) => ({
         debouncedSaveNodes(newNodes);
     },
     addNode: (node: PossibleNode, position?: { x: number; y: number }) => {
+        get().commitHistory();
         const { nodes } = get();
 
         let defaultX = 100;
@@ -260,6 +369,7 @@ export const useFlow = create<FlowState>((set, get) => ({
         return nodeId;
     },
     removeNode: (nodeId: string) => {
+        get().commitHistory();
         const { nodes, edges } = get();
         const newNodes = nodes.filter((node) => node.id !== nodeId);
         const newEdges = edges.filter(
@@ -280,6 +390,7 @@ export const useFlow = create<FlowState>((set, get) => ({
         if (!currNode) {
             return [];
         }
+        get().commitHistory();
 
         // Track whether upstream node emits persistent artifacts
         const sourceIsDataNode = isDataNode(currNode.type ?? "");
@@ -413,6 +524,7 @@ export const useFlow = create<FlowState>((set, get) => ({
         return ids;
     },
     compose: ({ type, data }: { type: string; data: unknown }) => {
+        get().commitHistory();
         const { comboSelectedIds, nodes, edges } = get();
         const nodeId = v4();
 

--- a/src/hooks/use-undo-redo.ts
+++ b/src/hooks/use-undo-redo.ts
@@ -1,0 +1,52 @@
+"use client";
+
+/**
+ * Canvas undo/redo: keyboard shortcuts (Cmd/Ctrl+Z, Cmd+Shift+Z / Ctrl+Y)
+ * plus canUndo/canRedo selectors for toolbar buttons. Also tracks global
+ * focus changes so form-edit history entries split per focus session.
+ */
+
+import { useEffect } from "react";
+import { useFlow } from "@/hooks/use-flow";
+import { bumpFocusGeneration } from "@/lib/workflow/flow-history";
+
+// Inside editable elements Cmd/Ctrl+Z must stay native text undo.
+const EDITABLE_SELECTOR = "input, textarea, select, [contenteditable]";
+
+export function useUndoRedo() {
+    const canUndo = useFlow((s) => s.historyPast.length > 0);
+    const canRedo = useFlow((s) => s.historyFuture.length > 0);
+    const undo = useFlow((s) => s.undo);
+    const redo = useFlow((s) => s.redo);
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (!(e.metaKey || e.ctrlKey) || e.altKey || e.isComposing) return;
+            const target = e.target as HTMLElement | null;
+            if (target?.closest(EDITABLE_SELECTOR)) return;
+
+            const key = e.key.toLowerCase();
+            const { undo, redo } = useFlow.getState();
+            if (key === "z") {
+                e.preventDefault();
+                if (e.shiftKey) redo();
+                else undo();
+            } else if (key === "y" && !e.shiftKey) {
+                e.preventDefault();
+                redo();
+            }
+        };
+
+        // New focus target → next form edit opens a fresh history entry
+        const handleFocusIn = () => bumpFocusGeneration();
+
+        window.addEventListener("keydown", handleKeyDown);
+        window.addEventListener("focusin", handleFocusIn);
+        return () => {
+            window.removeEventListener("keydown", handleKeyDown);
+            window.removeEventListener("focusin", handleFocusIn);
+        };
+    }, []);
+
+    return { undo, redo, canUndo, canRedo };
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -178,6 +178,8 @@
         "restart": "Restart to update"
     },
     "Navigation": {
+        "undo": "Undo",
+        "redo": "Redo",
         "toggleTheme": "Toggle theme",
         "language": "Language",
         "workflows": "My Workflows",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -178,6 +178,8 @@
         "restart": "再起動して更新"
     },
     "Navigation": {
+        "undo": "元に戻す",
+        "redo": "やり直す",
         "toggleTheme": "テーマ切り替え",
         "language": "言語",
         "workflows": "マイワークフロー",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -178,6 +178,8 @@
         "restart": "다시 시작하여 업데이트"
     },
     "Navigation": {
+        "undo": "실행 취소",
+        "redo": "다시 실행",
         "toggleTheme": "테마 전환",
         "language": "언어",
         "workflows": "내 워크플로",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -178,6 +178,8 @@
         "restart": "重启并更新"
     },
     "Navigation": {
+        "undo": "撤销",
+        "redo": "重做",
         "toggleTheme": "切换主题",
         "language": "语言",
         "workflows": "我的工作流",

--- a/src/lib/workflow/flow-history.ts
+++ b/src/lib/workflow/flow-history.ts
@@ -1,0 +1,54 @@
+/**
+ * Undo/redo history helpers for the workflow canvas.
+ *
+ * The flow store keeps explicit past/future snapshot stacks and calls
+ * commitHistory() at semantic boundaries (add node, drag start, ...).
+ * These helpers are pure so they can be unit-tested in isolation.
+ */
+
+import type { Edge, Node } from "@xyflow/react";
+
+export interface FlowSnapshot {
+    nodes: Node[];
+    edges: Edge[];
+}
+
+/** Maximum number of undoable entries kept in the past stack. */
+export const HISTORY_LIMIT = 100;
+
+/**
+ * Deep-copy the current canvas state for the history stack, stripping
+ * transient interaction flags so undo never restores a stale selection
+ * or a mid-drag state.
+ */
+export function snapshotFlow(nodes: Node[], edges: Edge[]): FlowSnapshot {
+    const snapshot = structuredClone({ nodes, edges });
+    for (const node of snapshot.nodes) {
+        delete node.selected;
+        delete node.dragging;
+    }
+    return snapshot;
+}
+
+/** Append a snapshot to the past stack, dropping the oldest beyond the cap. */
+export function pushSnapshot(
+    past: FlowSnapshot[],
+    snapshot: FlowSnapshot,
+    limit: number = HISTORY_LIMIT,
+): FlowSnapshot[] {
+    const next = past.concat(snapshot);
+    return next.length > limit ? next.slice(next.length - limit) : next;
+}
+
+// Focus generation counter: bumped on every global focus change so that
+// form edits coalesce into one history entry per focus session — repeated
+// updates() calls with the same source only commit again after focus moves.
+let focusGeneration = 0;
+
+export function bumpFocusGeneration(): void {
+    focusGeneration++;
+}
+
+export function currentFocusGeneration(): number {
+    return focusGeneration;
+}


### PR DESCRIPTION
## Summary

Adds canvas undo/redo to the workspace: Cmd+Z / Cmd+Shift+Z (Ctrl on Windows) plus toolbar buttons at the top-left of the canvas, localized in en/zh/ja/ko.

### Design

- Hand-rolled past/future snapshot stacks in the flow store (`use-flow.ts` + `src/lib/workflow/flow-history.ts`). Every structural mutator commits a pre-mutation snapshot: add/remove node, expand/compose, connect/disconnect, drag-start, edge reconnect, canvas clear/import.
- Form edits coalesce per focus session (a `focusin` generation counter), so typing a sentence is one undo step, not one per keystroke.
- Keyboard shortcuts skip editable targets so native text-input undo keeps working inside textareas.

### The echo-write pitfall (main bug class fixed here)

Programmatic `node.data` writes fired from `useEffect` (mount-time normalization/defaults) must stay **out** of history — otherwise they re-fire right after every undo, push the just-restored state back onto the past stack and clear the redo stack, which surfaces as "undo only works once" / "the expanded node won't undo away". All such writes now pass `{ history: false }`:

- `pluginModel` default normalization (`node-plugin-model-select`)
- `feature` mirror on mount (`use-abi-execution`)
- mount-time picker defaults in six nodes (`text-gen-image`, `image-gen-video-compose`, `video-image-gen-video-move`, `speech-image-gen-video`, `music-cover`, `music-extract`) via new `form.set` / `form.patch` history opts (`use-abi-form`)

User-driven writes (typing, selects, tab switches) keep the default and enter history.

## Test plan

- [x] `pnpm lint:check` / `pnpm typecheck` / `pnpm build` green
- [x] Store-level repro script: add text node → type → expand `textGenImageNode` → undo removes node+edge, redo restores
- [x] Manual: multi-step undo/redo chains across add/type/expand/delete/drag; text node → SmartIsland → generate image → single undo removes the spawned node

🤖 Generated with [Claude Code](https://claude.com/claude-code)
