### PR TITLE
feat(sdk): direct-stream terminal callback + model passthrough (0.2.20)

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tongflow"
-version = "0.2.19"
+version = "0.2.20"
 description = "Python SDK for TongFlow — author plugins and run multi-modal GenAI workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/tests/test_serve_stream.py
+++ b/sdk/tests/test_serve_stream.py
@@ -1,0 +1,112 @@
+import json
+
+import tongflow.serve as serve_mod
+
+
+def _frames(gen):
+    return [json.loads(f[len("data: ") :]) for f in gen if f.startswith("data: ")]
+
+
+def test_stream_success_reports_completed(monkeypatch):
+    posted = []
+    monkeypatch.setattr(serve_mod, "serve_slot", lambda p, invoke: {"success": True, "text": "hi"})
+    monkeypatch.setattr(serve_mod, "_post", lambda url, body: posted.append((url, body)))
+
+    frames = _frames(
+        serve_mod.serve_stream(
+            {}, invoke=lambda m, i: None, task_id="t1",
+            callback_url="https://cb", callback_token="tok",
+        )
+    )
+    assert frames[-1]["status"] == "COMPLETED"
+    assert posted == [("https://cb", {"token": "tok", "type": "completed", "result": {"success": True, "text": "hi"}})]
+
+
+def test_stream_slot_failure_is_failed_with_coded_fields(monkeypatch):
+    posted = []
+    result = {
+        "success": False,
+        "error": "XAI_API_KEY is not set.",
+        "errorCode": "missing_api_key",
+        "errorParams": {"key": "XAI_API_KEY"},
+    }
+    monkeypatch.setattr(serve_mod, "serve_slot", lambda p, invoke: result)
+    monkeypatch.setattr(serve_mod, "_post", lambda url, body: posted.append(body))
+
+    frames = _frames(
+        serve_mod.serve_stream(
+            {}, invoke=lambda m, i: None, task_id="t2",
+            callback_url="https://cb", callback_token="tok",
+        )
+    )
+    assert frames[-1]["status"] == "FAILED"
+    assert frames[-1]["data"]["errorCode"] == "missing_api_key"
+    assert posted[-1]["type"] == "failed"
+    assert posted[-1]["errorCode"] == "missing_api_key"
+    assert posted[-1]["errorParams"] == {"key": "XAI_API_KEY"}
+
+
+def test_stream_exception_reports_failed(monkeypatch):
+    posted = []
+
+    def _boom(p, invoke):
+        raise RuntimeError("kaput")
+
+    monkeypatch.setattr(serve_mod, "serve_slot", _boom)
+    monkeypatch.setattr(serve_mod, "_post", lambda url, body: posted.append(body))
+
+    frames = _frames(
+        serve_mod.serve_stream(
+            {}, invoke=lambda m, i: None, task_id="t3",
+            callback_url="https://cb", callback_token="tok",
+        )
+    )
+    assert frames[-1]["status"] == "FAILED"
+    assert posted[-1] == {"token": "tok", "type": "failed", "error": "kaput"}
+
+
+def test_stream_without_callback_posts_nothing(monkeypatch):
+    posted = []
+    monkeypatch.setattr(serve_mod, "serve_slot", lambda p, invoke: {"success": True})
+    monkeypatch.setattr(serve_mod, "_post", lambda url, body: posted.append(body))
+
+    frames = _frames(serve_mod.serve_stream({}, invoke=lambda m, i: None, task_id="t4"))
+    assert frames[-1]["status"] == "COMPLETED"
+    assert posted == []
+
+
+def test_from_spec_passes_model_and_callback(monkeypatch):
+    spec = {
+        "nodeSlot": "gen-text",
+        "input": {"text": "hi"},
+        "assetEndpoint": "https://o/api/engine-assets",
+        "assetToken": "at",
+        "model": "grok-4.5",
+        "callbackUrl": "https://o/api/executor/callback",
+        "callbackToken": "ct",
+    }
+
+    class _Resp:
+        def read(self):
+            return json.dumps(spec).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(serve_mod.urllib.request, "urlopen", lambda req, timeout=30: _Resp())
+    monkeypatch.setattr(serve_mod, "_resolve_method", lambda f, slot: "gen_text")
+
+    seen = {}
+
+    def _fake_stream(payload, *, invoke, task_id, callback_url, callback_token):
+        seen.update(payload=payload, task_id=task_id, cb=(callback_url, callback_token))
+        yield "data: {}\n\n"
+
+    monkeypatch.setattr(serve_mod, "serve_stream", _fake_stream)
+
+    list(serve_mod.serve_stream_from_spec("https://o", "t5", "tok", "deploy.py", invoke=lambda m, i: None))
+    assert seen["payload"]["model"] == "grok-4.5"
+    assert seen["cb"] == ("https://o/api/executor/callback", "ct")

--- a/sdk/tongflow/__init__.py
+++ b/sdk/tongflow/__init__.py
@@ -17,7 +17,7 @@ from .serve import (
     serve_stream_from_spec,
 )
 
-__version__ = "0.2.19"
+__version__ = "0.2.20"
 
 __all__ = [
     "deploy",

--- a/sdk/tongflow/serve.py
+++ b/sdk/tongflow/serve.py
@@ -116,7 +116,12 @@ def _sse(event: dict[str, Any]) -> str:
 
 
 def serve_stream(
-    payload: dict[str, Any], *, invoke: InvokeFn, task_id: str = ""
+    payload: dict[str, Any],
+    *,
+    invoke: InvokeFn,
+    task_id: str = "",
+    callback_url: str = "",
+    callback_token: str = "",
 ) -> Iterator[str]:
     """Run one ABI slot in this container and stream progress + result as SSE.
 
@@ -129,6 +134,11 @@ def serve_stream(
 
     Each event carries ``id: task_id`` so the browser can attribute it and
     persist the terminal state (its /api/task/update-status backup).
+
+    When ``callback_url``/``callback_token`` are given, the terminal state is
+    ALSO reported server-side (``type:"completed"``/``"failed"``, mirroring
+    the executor) — so a closed tab can no longer strand the task row in
+    ``processing``. The SSE stream is then a pure live-view optimization.
 
     The payload must NOT carry `_tongflow` (that installs an HTTP sink); here
     the sink is the in-process queue below.
@@ -149,6 +159,10 @@ def serve_stream(
 
     threading.Thread(target=_run, daemon=True).start()
 
+    def _report(body: dict[str, Any]) -> None:
+        if callback_url and callback_token:
+            _post(callback_url, {"token": callback_token, **body})
+
     while True:
         try:
             kind, data = q.get(timeout=10)
@@ -160,9 +174,23 @@ def serve_stream(
         if kind == "progress":
             yield _sse({"id": task_id, "status": "RUNNING", "data": data})
         elif kind == "done":
-            yield _sse({"id": task_id, "status": "COMPLETED", "data": data})
+            if isinstance(data, dict) and data.get("success") is False:
+                # A slot-reported failure is FAILED (executor semantics) —
+                # coded fields (errorCode/errorParams) ride along for the
+                # client's guided-fix dialogs and localized history.
+                msg = str(data.get("error") or "Task failed")
+                yield _sse({"id": task_id, "status": "FAILED", "data": {**data, "message": msg}})
+                fail: dict[str, Any] = {"type": "failed", "error": msg}
+                if isinstance(data.get("errorCode"), str):
+                    fail["errorCode"] = data["errorCode"]
+                    fail["errorParams"] = data.get("errorParams") or {}
+                _report(fail)
+            else:
+                yield _sse({"id": task_id, "status": "COMPLETED", "data": data})
+                _report({"type": "completed", "result": data})
         elif kind == "error":
             yield _sse({"id": task_id, "status": "FAILED", "data": {"message": "Task execution failed", "error": data}})
+            _report({"type": "failed", "error": str(data)})
 
 
 def _resolve_method(deploy_file: str, node_slot: str) -> str:
@@ -218,7 +246,16 @@ def serve_stream_from_spec(
             "assetEndpoint": spec["assetEndpoint"],
             "assetToken": spec["assetToken"],
         }
+        # Router-style plugins pick their backing model per request.
+        if spec.get("model"):
+            payload["model"] = spec["model"]
     except Exception as e:  # noqa: BLE001
         yield _sse({"id": task_id, "status": "FAILED", "data": {"message": "Spec fetch failed", "error": str(e)}})
         return
-    yield from serve_stream(payload, invoke=invoke, task_id=task_id)
+    yield from serve_stream(
+        payload,
+        invoke=invoke,
+        task_id=task_id,
+        callback_url=str(spec.get("callbackUrl") or ""),
+        callback_token=str(spec.get("callbackToken") or ""),
+    )


### PR DESCRIPTION
## What

Three fixes to the direct-serve streaming path (`sdk/tongflow/serve.py`), groundwork for browser-direct executor streaming:

- **Server-side terminal callback**: when the spec carries `callbackUrl`/`callbackToken`, `serve_stream` POSTs `type:"completed"/"failed"` after the terminal SSE frame — closing the tab no longer strands the task row in `processing`. Absent fields → behavior unchanged (old plugins compatible).
- **Correct terminal status**: a slot-reported failure (`success: false`) now streams as `FAILED` (matching executor semantics) with `errorCode`/`errorParams` passthrough, so coded failures (e.g. `missing_api_key`) trigger the guided dialog on the direct path too.
- **Model passthrough**: `serve_stream_from_spec` forwards `spec.model` — the browser-direct path silently dropped it, costing router-style plugins their per-request model selection.

## Tests
`cd sdk && pytest` — 71 passed (5 new in `test_serve_stream.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)