### PR TITLE
fix(workspace): mount-time defaults broke undo in six more nodes

### DIFF
--- a/src/components/workspace/nodes/decompose/split-video.tsx
+++ b/src/components/workspace/nodes/decompose/split-video.tsx
@@ -18,7 +18,8 @@ const SplitVideoNode = ({
 
     // Default threshold once.
     useEffect(() => {
-        if (form.state.threshold == null) form.set("threshold", 20.0);
+        if (form.state.threshold == null)
+            form.set("threshold", 20.0, { history: false });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/src/components/workspace/nodes/mount-defaults-history.test.ts
+++ b/src/components/workspace/nodes/mount-defaults-history.test.ts
@@ -1,0 +1,71 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Programmatic `node.data` writes inside an effect (mount-time picker
+ * defaults, normalization) must pass `{ history: false }`.
+ *
+ * Without it the write lands in the undo stack and clears the redo stack;
+ * after an undo the effect's guard is true again, so it re-fires, commits
+ * another entry and the node can never be undone away. The failure is
+ * invisible in review — an omitted optional argument — and has already
+ * shipped twice, so it is checked here rather than by eye.
+ *
+ * A genuine user action (typing, picking a value from a menu) must NOT pass
+ * the flag: those belong in history. Only calls inside `useEffect` bodies
+ * are examined.
+ */
+
+const ROOT = join(process.cwd(), "src/components/workspace");
+const WRITE_CALL = /\b(form\.set|form\.patch|updates|updateNodeData)\(/g;
+
+function tsxFiles(dir: string): string[] {
+    return readdirSync(dir).flatMap((entry) => {
+        const path = join(dir, entry);
+        if (statSync(path).isDirectory()) return tsxFiles(path);
+        return path.endsWith(".tsx") ? [path] : [];
+    });
+}
+
+/** Source slice balanced from the opener at `start` to its matching closer. */
+function balanced(src: string, start: number, open: string, close: string) {
+    let depth = 0;
+    for (let i = start; i < src.length; i++) {
+        if (src[i] === open) depth++;
+        else if (src[i] === close) {
+            depth--;
+            if (depth === 0) return src.slice(start, i + 1);
+        }
+    }
+    return src.slice(start);
+}
+
+function violations(src: string): number[] {
+    const out: number[] = [];
+    for (const effect of src.matchAll(/useEffect\(\s*\(\)\s*=>\s*\{/g)) {
+        const bodyStart = src.indexOf("{", effect.index + "useEffect(".length);
+        const body = balanced(src, bodyStart, "{", "}");
+        for (const call of body.matchAll(WRITE_CALL)) {
+            const argsStart = body.indexOf("(", call.index + call[1].length);
+            const args = balanced(body, argsStart, "(", ")");
+            if (!args.includes("history: false")) {
+                out.push(
+                    src.slice(0, bodyStart + call.index).split("\n").length,
+                );
+            }
+        }
+    }
+    return out;
+}
+
+describe("programmatic node.data writes stay out of undo history", () => {
+    it("every effect-driven write passes { history: false }", () => {
+        const offenders = tsxFiles(ROOT).flatMap((file) =>
+            violations(readFileSync(file, "utf8")).map(
+                (line) => `${file.slice(process.cwd().length + 1)}:${line}`,
+            ),
+        );
+        expect(offenders).toEqual([]);
+    });
+});

--- a/src/components/workspace/nodes/transfer/image-gen-video.tsx
+++ b/src/components/workspace/nodes/transfer/image-gen-video.tsx
@@ -63,7 +63,7 @@ const ImageGenVideoNode = ({
 
     useEffect(() => {
         if (form.state.duration === undefined)
-            form.set("duration", VIDEO_DURATION_DEFAULT);
+            form.set("duration", VIDEO_DURATION_DEFAULT, { history: false });
     }, [form.state.duration, form.set]);
 
     const currentRatio: AspectRatio =

--- a/src/components/workspace/nodes/transfer/music-repaint.tsx
+++ b/src/components/workspace/nodes/transfer/music-repaint.tsx
@@ -42,7 +42,8 @@ const MusicRepaintNode = ({
     // Persist the default so the workflow exporter / runtime sees the same
     // value the user sees in the UI.
     useEffect(() => {
-        if (form.state.strength == null) form.set("strength", DEFAULT_STRENGTH);
+        if (form.state.strength == null)
+            form.set("strength", DEFAULT_STRENGTH, { history: false });
     }, [form.state.strength, form.set]);
 
     return (

--- a/src/components/workspace/nodes/transfer/text-gen-music.tsx
+++ b/src/components/workspace/nodes/transfer/text-gen-music.tsx
@@ -230,10 +230,12 @@ const TextGenMusicNode = ({ selected, data }: TextGenMusicNodeProps) => {
     // Persist non-ABI-required defaults so the workflow exporter / runtime
     // sees the same values the user sees in the UI.
     useEffect(() => {
-        if (form.state.bpm == null) form.set("bpm", DEFAULT_BPM);
+        if (form.state.bpm == null)
+            form.set("bpm", DEFAULT_BPM, { history: false });
     }, [form.state.bpm, form.set]);
     useEffect(() => {
-        if (form.state.keyscale == null) form.set("keyscale", DEFAULT_KEYSCALE);
+        if (form.state.keyscale == null)
+            form.set("keyscale", DEFAULT_KEYSCALE, { history: false });
     }, [form.state.keyscale, form.set]);
 
     const [tagsExpanded, setTagsExpanded] = useState(false);

--- a/src/components/workspace/nodes/transfer/text-gen-video.tsx
+++ b/src/components/workspace/nodes/transfer/text-gen-video.tsx
@@ -87,7 +87,7 @@ const TextGenVideoNode = ({
     // their own default, often 10s).
     useEffect(() => {
         if (form.state.duration === undefined)
-            form.set("duration", VIDEO_DURATION_DEFAULT);
+            form.set("duration", VIDEO_DURATION_DEFAULT, { history: false });
     }, [form.state.duration, form.set]);
 
     const currentRatio: AspectRatio =


### PR DESCRIPTION
## The bug

Reported on the 文本生成音乐 (ACE-Step) node: pressing undo never removes it.

`917ecf3` (canvas undo/redo) established that programmatic `node.data` writes must pass `{ history: false }` and fixed six nodes — but six more sites were missed. On those nodes:

1. Node is added → snapshot pushed.
2. A mount effect writes a default (`bpm`, `duration`, …) → **commits its own history entry**, clears redo.
3. Undo → restores the pre-write state, i.e. **the node is still there**.
4. The effect's `== null` guard is true again → re-fires → commits anew.

Steps 3–4 loop forever, so the node can never be undone away.

## Fixed

`text-gen-music` (bpm, keyscale), `text-gen-video` (duration), `image-gen-video` (duration), `music-repaint` (strength), `split-video` (threshold). User-initiated writes (typing, picking from a menu) are untouched — those belong in history.

## Regression test

The omission is an invisible missing optional argument and has now shipped twice, so `mount-defaults-history.test.ts` walks every `useEffect` body under `components/workspace` (brace-matched, not regex windows) and fails with `file:line` on any `form.set`/`form.patch`/`updates`/`updateNodeData` call lacking the flag. Verified it fails when a fix is reverted.

## Checks
`pnpm lint:check` / `typecheck` / `build` / `vitest run` (38 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)