### PR TITLE
feat(workspace): agent panel — chat-driven workflow building on the canvas

### DIFF
--- a/docs/agent-workflow-manual.md
+++ b/docs/agent-workflow-manual.md
@@ -14,29 +14,42 @@ assets, executable nodes transform them, edges carry values downstream.
 
 ## Build rules (iron laws)
 
-1. **Alternate data and executable nodes.** An executable node's wired inputs
-   come from upstream modality nodes. Its outputs need no downstream nodes —
-   result nodes appear automatically when the workflow runs. Never create
-   empty result nodes ahead of execution.
-2. **Multiplicity is a runtime effect.** One textNode holding 5 texts wired to
+1. **The graph strictly alternates — this is THE structural invariant:**
+   `add node → data node → executable → data node → executable → … → data node`.
+   - An executable's wired inputs always come from **data (modality) nodes**.
+   - An executable's every output gets a **downstream data node of the
+     output's modality, created empty at build time** (e.g. `imageNode` after
+     a text-to-image node, `videoNode` after a video generator). At run time
+     the result fills exactly that node, and the next executable reads from
+     it. A chain therefore always ends in a data node.
+   - **Executables never connect directly to executables**, and data nodes
+     never connect to each other. Such edges are rejected.
+2. **Every chain starts with an add node feeding its data node.** Prompt text
+   you author: `addTextNode {manualValue} → textNode {texts:[same text]}`.
+   User uploads: `addImageNode {fromAttachment} → imageNode {fromAttachment}`
+   (same pattern for video/audio/model/file). Add nodes are what make the
+   workflow's inputs replaceable in App Mode.
+3. **Multiplicity is a runtime effect.** One textNode holding 5 texts wired to
    a "batch" input fans out into 5 tasks and 5 results. Splitter nodes emit N
    results from one node. Never duplicate chains or pre-create N children to
-   express "N versions"; put N values in one data node instead.
-3. **Prompt delivery differs per node — read the catalog line.** A field shown
+   express "N versions"; put N values in one data node instead. (One empty
+   result data node per output is still created per rule 1 — the runtime
+   fills and extends it.)
+4. **Prompt delivery differs per node — read the catalog line.** A field shown
    as `wire(textNode)` needs an upstream textNode; a plain config field is set
    directly in the node's data; `or-config` accepts either (wire wins). Never
    set `prompt` in data — it is derived at run time.
-4. **Patch, don't rebuild.** Extend and adjust what is on the canvas. Reuse
+5. **Patch, don't rebuild.** Extend and adjust what is on the canvas. Reuse
    existing nodes and their generated assets ("that image" = wire the existing
    image node, not a new generation chain). Only touch what the request is
    about.
-5. **Never invent identifiers.** New nodes get an alias; existing nodes are
+6. **Never invent identifiers.** New nodes get an alias; existing nodes are
    referenced by the short id from the canvas listing; user uploads by
    attachment index. Layout is automatic.
-6. **Stay inside the catalog.** If a capability has no installed plugin (or no
+7. **Stay inside the catalog.** If a capability has no installed plugin (or no
    node exists for it), say so and offer the closest alternative — do not
    build a graph that cannot run.
-7. **Confirm before destroying.** Deleting or rewiring nodes you did not
+8. **Confirm before destroying.** Deleting or rewiring nodes you did not
    create this turn deserves a one-line warning first. All your changes in a
    turn are undoable with one Cmd+Z.
 
@@ -59,42 +72,57 @@ Request: "generate a cat picture, then turn it into a video"
 ```json
 {
   "add_nodes": [
+    { "alias": "add1", "type": "addTextNode",
+      "data": { "manualValue": "a cute cat, cartoon style" } },
     { "alias": "t1", "type": "textNode",
       "data": { "texts": ["a cute cat, cartoon style"] } },
-    { "alias": "img", "type": "textGenImageNode" },
-    { "alias": "vid", "type": "imageGenVideoNode",
-      "data": { "text": "the cat starts walking", "duration": 5 } }
+    { "alias": "genImg", "type": "textGenImageNode" },
+    { "alias": "img", "type": "imageNode" },
+    { "alias": "genVid", "type": "imageGenVideoNode",
+      "data": { "text": "the cat starts walking", "duration": 5 } },
+    { "alias": "vid", "type": "videoNode" }
   ],
   "add_edges": [
-    { "from": "t1", "to": "img" },
-    { "from": "img", "to": "vid" }
+    { "from": "add1", "to": "t1" },
+    { "from": "t1", "to": "genImg" },
+    { "from": "genImg", "to": "img" },
+    { "from": "img", "to": "genVid" },
+    { "from": "genVid", "to": "vid" }
   ]
 }
 ```
 
-Note: `textGenImageNode`'s prompt is wired (rule 3), `imageGenVideoNode`'s
-prompt is config. No result imageNode/videoNode was created (rule 1) — the
-edge from `img` to `vid` still carries the generated image at run time.
+Note the full alternation (rule 1): the empty `img` node is where the
+generated image lands, and it is what feeds the video node — wiring
+`genImg` straight into `genVid` would be rejected. `textGenImageNode`'s
+prompt is wired from `t1` (rule 4); `imageGenVideoNode`'s prompt is config.
 
 Request: user attached two photos — "merge these into one picture"
 
 ```json
 {
   "add_nodes": [
-    { "alias": "srcA", "type": "addImageNode", "fromAttachment": 1 },
-    { "alias": "srcB", "type": "addImageNode", "fromAttachment": 2 },
+    { "alias": "addA", "type": "addImageNode", "fromAttachment": 1 },
+    { "alias": "srcA", "type": "imageNode", "fromAttachment": 1 },
+    { "alias": "addB", "type": "addImageNode", "fromAttachment": 2 },
+    { "alias": "srcB", "type": "imageNode", "fromAttachment": 2 },
     { "alias": "fuse", "type": "imageFusionNode",
-      "data": { "text": "blend both subjects into one scene" } }
+      "data": { "text": "blend both subjects into one scene" } },
+    { "alias": "out", "type": "imageNode" }
   ],
   "add_edges": [
+    { "from": "addA", "to": "srcA" },
+    { "from": "addB", "to": "srcB" },
     { "from": "srcA", "to": "fuse", "toHandle": "in:images" },
-    { "from": "srcB", "to": "fuse", "toHandle": "in:images" }
+    { "from": "srcB", "to": "fuse", "toHandle": "in:images" },
+    { "from": "fuse", "to": "out" }
   ]
 }
 ```
 
-Note: both uploads land on the same `in:images` handle (collect-many); the
-add-nodes make the two photos swappable inputs in App Mode.
+Note: both photos land on the same `in:images` handle (collect-many); the
+add-node pairs make them swappable inputs in App Mode; `out` receives the
+fused result.
 
 ## Product FAQ
 

--- a/docs/agent-workflow-manual.md
+++ b/docs/agent-workflow-manual.md
@@ -1,0 +1,118 @@
+# TongFlow Agent Manual
+
+This document is loaded verbatim into the workspace agent's system prompt.
+Rules and examples only — the node/plugin catalog is generated from code and
+appended after this manual, so never list concrete node types here.
+
+## What TongFlow is
+
+Every AI model is a modality transform: LLMs are text→text, image models are
+text→image, speech models are text→audio. TongFlow wraps each capability as a
+canvas node; users create with three operations — add, transform, combine.
+A workflow is a directed graph on the canvas: data (modality) nodes carry
+assets, executable nodes transform them, edges carry values downstream.
+
+## Build rules (iron laws)
+
+1. **Alternate data and executable nodes.** An executable node's wired inputs
+   come from upstream modality nodes. Its outputs need no downstream nodes —
+   result nodes appear automatically when the workflow runs. Never create
+   empty result nodes ahead of execution.
+2. **Multiplicity is a runtime effect.** One textNode holding 5 texts wired to
+   a "batch" input fans out into 5 tasks and 5 results. Splitter nodes emit N
+   results from one node. Never duplicate chains or pre-create N children to
+   express "N versions"; put N values in one data node instead.
+3. **Prompt delivery differs per node — read the catalog line.** A field shown
+   as `wire(textNode)` needs an upstream textNode; a plain config field is set
+   directly in the node's data; `or-config` accepts either (wire wins). Never
+   set `prompt` in data — it is derived at run time.
+4. **Patch, don't rebuild.** Extend and adjust what is on the canvas. Reuse
+   existing nodes and their generated assets ("that image" = wire the existing
+   image node, not a new generation chain). Only touch what the request is
+   about.
+5. **Never invent identifiers.** New nodes get an alias; existing nodes are
+   referenced by the short id from the canvas listing; user uploads by
+   attachment index. Layout is automatic.
+6. **Stay inside the catalog.** If a capability has no installed plugin (or no
+   node exists for it), say so and offer the closest alternative — do not
+   build a graph that cannot run.
+7. **Confirm before destroying.** Deleting or rewiring nodes you did not
+   create this turn deserves a one-line warning first. All your changes in a
+   turn are undoable with one Cmd+Z.
+
+## Working style
+
+- Ask one clarifying question when the request is genuinely ambiguous
+  (orientation? duration? own material or generated?); otherwise build with
+  sensible defaults and say what you assumed.
+- After each patch, explain in one or two sentences what you built and why —
+  in the user's language.
+- When a run fails, read the node's failure detail from the canvas state,
+  explain the cause plainly, and propose the fixing patch.
+- When the build is done, offer to save the workflow. Mention that assets fed
+  through add-nodes can be swapped in App Mode.
+
+## Examples
+
+Request: "generate a cat picture, then turn it into a video"
+
+```json
+{
+  "add_nodes": [
+    { "alias": "t1", "type": "textNode",
+      "data": { "texts": ["a cute cat, cartoon style"] } },
+    { "alias": "img", "type": "textGenImageNode" },
+    { "alias": "vid", "type": "imageGenVideoNode",
+      "data": { "text": "the cat starts walking", "duration": 5 } }
+  ],
+  "add_edges": [
+    { "from": "t1", "to": "img" },
+    { "from": "img", "to": "vid" }
+  ]
+}
+```
+
+Note: `textGenImageNode`'s prompt is wired (rule 3), `imageGenVideoNode`'s
+prompt is config. No result imageNode/videoNode was created (rule 1) — the
+edge from `img` to `vid` still carries the generated image at run time.
+
+Request: user attached two photos — "merge these into one picture"
+
+```json
+{
+  "add_nodes": [
+    { "alias": "srcA", "type": "addImageNode", "fromAttachment": 1 },
+    { "alias": "srcB", "type": "addImageNode", "fromAttachment": 2 },
+    { "alias": "fuse", "type": "imageFusionNode",
+      "data": { "text": "blend both subjects into one scene" } }
+  ],
+  "add_edges": [
+    { "from": "srcA", "to": "fuse", "toHandle": "in:images" },
+    { "from": "srcB", "to": "fuse", "toHandle": "in:images" }
+  ]
+}
+```
+
+Note: both uploads land on the same `in:images` handle (collect-many); the
+add-nodes make the two photos swappable inputs in App Mode.
+
+## Product FAQ
+
+- **Modes:** Create Mode is the full canvas editor. Execute Mode locks
+  editing and runs the whole workflow with one click. App Mode presents the
+  workflow as a simple form app — only add-node inputs are replaceable.
+- **Run:** each executable node has a run button; Execute Mode runs the whole
+  graph in dependency order. Results appear as new nodes on the canvas.
+- **Save / export / import:** the workflow menu (canvas top bar) saves to your
+  account, exports JSON, and imports a previously exported JSON.
+- **Plugins:** every executable node is powered by a plugin. Install official
+  plugins from Settings → Plugins; each node's plugin (and model, when the
+  plugin offers several) is switchable on the node itself.
+- **API keys:** API-based plugins need provider keys — Settings → Connect.
+  GPU plugins run on your Modal account — Settings → Modal connect walks
+  through it.
+- **Desktop:** the desktop app is a shell over the cloud version; download is
+  on the GitHub releases page.
+- Anything beyond this FAQ: use `search_docs` before answering; if the docs
+  do not cover it, say so and point to the project's GitHub or Discord —
+  never invent UI steps.

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,9 @@ const nextConfig: NextConfig = {
                 url: false,
             },
         };
+        // Markdown imported as a raw string (agent manual is bundled into the
+        // server code so it survives serverless/Workers deploys with no fs).
+        config.module.rules.push({ test: /\.md$/, type: "asset/source" });
         return config;
     },
 };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "lint:check": "pnpm exec biome check --error-on-warnings .",
         "typecheck": "tsc --noEmit",
         "gen:abi": "tsx scripts/gen-abi-types.ts",
+        "gen:agent-docs": "node scripts/gen-agent-docs.mjs",
         "abi:generate": "node scripts/generate-tongflow-abi.mjs",
         "tongflow:publish": "bash scripts/publish-tongflow-pypi.sh",
         "test": "vitest run",

--- a/scripts/gen-agent-docs.mjs
+++ b/scripts/gen-agent-docs.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Chunk the user-facing READMEs into a searchable corpus for the agent's
+ * `search_docs` tool. Mirrors the gen:abi convention: output is committed
+ * under src/generated/ and regenerated whenever the docs change.
+ *
+ *   pnpm gen:agent-docs
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const SOURCES = {
+    en: ["README.md"],
+    zh: ["docs/README_ZH.md"],
+    ja: ["docs/README_JA.md"],
+};
+
+/** Sections that are noise for product Q&A. */
+const SKIP_HEADINGS =
+    /star history|license|open-source|オープンソース|开源|ライセンス|许可/i;
+
+function chunk(markdown, source) {
+    const lines = markdown.split("\n");
+    const chunks = [];
+    let heading = "";
+    let breadcrumb = [];
+    let buf = [];
+
+    const flush = () => {
+        const body = buf.join("\n").trim();
+        if (!body || SKIP_HEADINGS.test(heading)) {
+            buf = [];
+            return;
+        }
+        chunks.push({
+            source,
+            heading: [...breadcrumb, heading].filter(Boolean).join(" › "),
+            body: body.length > 2500 ? `${body.slice(0, 2500)}…` : body,
+        });
+        buf = [];
+    };
+
+    for (const line of lines) {
+        const m = /^(#{1,3})\s+(.*)$/.exec(line);
+        if (m) {
+            flush();
+            const level = m[1].length;
+            heading = m[2].trim();
+            breadcrumb = breadcrumb.slice(0, level - 1);
+            if (level > 1) breadcrumb[level - 2] = heading;
+        } else {
+            buf.push(line);
+        }
+    }
+    flush();
+    return chunks;
+}
+
+const outDir = join(root, "src/generated/agent-docs");
+mkdirSync(outDir, { recursive: true });
+
+for (const [locale, files] of Object.entries(SOURCES)) {
+    const chunks = files.flatMap((f) =>
+        chunk(readFileSync(join(root, f), "utf-8"), f),
+    );
+    writeFileSync(
+        join(outDir, `${locale}.json`),
+        `${JSON.stringify({ chunks }, null, 1)}\n`,
+    );
+    console.log(`agent-docs: ${locale} → ${chunks.length} chunks`);
+}

--- a/src/app/api/agent/chat/route.ts
+++ b/src/app/api/agent/chat/route.ts
@@ -1,0 +1,190 @@
+import type { NextRequest } from "next/server";
+import OpenAI from "openai";
+import { resolveAgentProvider } from "@/lib/agent/chat-adapters";
+import { buildSystemPrompt } from "@/lib/agent/prompt.server";
+import { AGENT_TOOLS } from "@/lib/agent/tools";
+import type { AgentChatRequest, AgentStreamEvent } from "@/lib/agent/types";
+import { jsonStringifyForSse } from "@/lib/json-sse";
+import { logger } from "@/lib/logger";
+import { loadEnvStore } from "@/lib/settings/env-store.server";
+
+/**
+ * POST /api/agent/chat — one stateless streaming LLM turn.
+ *
+ * The agentic loop (tool execution, canvas mutation, history) lives in the
+ * browser; this route only resolves the selected plugin's key from the env
+ * store, injects the system prompt, and re-emits the upstream stream as SSE.
+ * One upstream fetch piped to one response keeps it Workers-compatible.
+ */
+
+/** Total serialized request budget — the client truncates long histories. */
+const MAX_BODY_BYTES = 400_000;
+const MAX_MESSAGES = 120;
+
+export async function POST(request: NextRequest) {
+    const raw = await request.text();
+    if (raw.length > MAX_BODY_BYTES) {
+        return Response.json({ error: "request too large" }, { status: 413 });
+    }
+
+    let body: AgentChatRequest;
+    try {
+        body = JSON.parse(raw) as AgentChatRequest;
+    } catch {
+        return Response.json({ error: "invalid JSON" }, { status: 400 });
+    }
+    if (
+        !Array.isArray(body.messages) ||
+        body.messages.length === 0 ||
+        body.messages.length > MAX_MESSAGES ||
+        typeof body.pluginId !== "string"
+    ) {
+        return Response.json({ error: "invalid request" }, { status: 400 });
+    }
+
+    const env = await loadEnvStore();
+    const resolved = resolveAgentProvider(body.pluginId, env);
+    if (!resolved.ok) {
+        // 428: the client shows the "connect a provider" card and deep-links
+        // to settings with the missing env key.
+        return Response.json(
+            { error: resolved.error, envKey: resolved.envKey },
+            { status: resolved.error === "missing_key" ? 428 : 400 },
+        );
+    }
+
+    const client = new OpenAI({
+        baseURL: resolved.provider.baseURL,
+        apiKey: resolved.provider.apiKey,
+    });
+
+    let upstream: Awaited<ReturnType<typeof client.chat.completions.create>> &
+        AsyncIterable<OpenAI.ChatCompletionChunk>;
+    try {
+        upstream = (await client.chat.completions.create({
+            model: body.model || "",
+            stream: true,
+            messages: [
+                { role: "system", content: buildSystemPrompt(body.locale) },
+                ...(body.messages as OpenAI.ChatCompletionMessageParam[]),
+            ],
+            tools: AGENT_TOOLS,
+            tool_choice: "auto",
+            // Sequential tool execution keeps the on-canvas build legible.
+            parallel_tool_calls: false,
+        })) as typeof upstream;
+    } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        logger.error("[agent/chat] upstream request failed:", message);
+        return Response.json(
+            { error: "upstream_error", message },
+            { status: 502 },
+        );
+    }
+
+    const encoder = new TextEncoder();
+
+    const stream = new ReadableStream({
+        async start(controller) {
+            let closed = false;
+            const close = () => {
+                if (!closed) {
+                    closed = true;
+                    try {
+                        controller.close();
+                    } catch {
+                        /* already closed */
+                    }
+                }
+            };
+            const emit = (event: AgentStreamEvent) => {
+                if (closed) return;
+                controller.enqueue(
+                    encoder.encode(`data: ${jsonStringifyForSse(event)}\n\n`),
+                );
+            };
+
+            request.signal.addEventListener("abort", close);
+
+            // Argument fragments stream as partial JSON; buffer per tool-call
+            // index and emit each call only once complete so the client never
+            // parses half a JSON document.
+            const pendingCalls = new Map<
+                number,
+                { id: string; name: string; args: string }
+            >();
+            let finishReason = "stop";
+
+            const flushCalls = () => {
+                for (const call of pendingCalls.values()) {
+                    let parsed: Record<string, unknown> = {};
+                    try {
+                        parsed = call.args
+                            ? (JSON.parse(call.args) as Record<string, unknown>)
+                            : {};
+                    } catch {
+                        emit({
+                            type: "error",
+                            message: `tool call ${call.name}: arguments were not valid JSON`,
+                        });
+                        continue;
+                    }
+                    emit({
+                        type: "tool_call",
+                        id: call.id,
+                        name: call.name,
+                        arguments: parsed,
+                    });
+                }
+                pendingCalls.clear();
+            };
+
+            try {
+                for await (const chunk of upstream) {
+                    if (closed) break;
+                    const choice = chunk.choices?.[0];
+                    if (!choice) continue;
+
+                    const delta = choice.delta;
+                    if (delta?.content) {
+                        emit({ type: "text_delta", text: delta.content });
+                    }
+                    for (const tc of delta?.tool_calls ?? []) {
+                        const entry = pendingCalls.get(tc.index) ?? {
+                            id: tc.id ?? "",
+                            name: "",
+                            args: "",
+                        };
+                        if (tc.id) entry.id = tc.id;
+                        if (tc.function?.name) entry.name = tc.function.name;
+                        if (tc.function?.arguments) {
+                            entry.args += tc.function.arguments;
+                        }
+                        pendingCalls.set(tc.index, entry);
+                    }
+
+                    if (choice.finish_reason) {
+                        finishReason = choice.finish_reason;
+                        flushCalls();
+                    }
+                }
+                emit({ type: "done", finishReason });
+            } catch (e) {
+                const message = e instanceof Error ? e.message : String(e);
+                logger.error("[agent/chat] stream failed:", message);
+                emit({ type: "error", message });
+            } finally {
+                close();
+            }
+        },
+    });
+
+    return new Response(stream, {
+        headers: {
+            "Content-Type": "text/event-stream; charset=utf-8",
+            "Cache-Control": "no-cache",
+            Connection: "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    });
+}

--- a/src/components/workspace/agent/agent-message.tsx
+++ b/src/components/workspace/agent/agent-message.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { AlertCircle, Check, Loader2, Wrench, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { AgentUiEntry } from "@/hooks/use-agent-chat";
+import type { GraphPatch } from "@/lib/agent/types";
+import { cn } from "@/lib/utils";
+
+/** One-line human description of a tool call for the activity row. */
+function useToolLabel() {
+    const t = useTranslations("Agent.tools");
+    return (name: string, args: Record<string, unknown>): string => {
+        switch (name) {
+            case "apply_graph_patch": {
+                const patch = args as GraphPatch;
+                const parts: string[] = [];
+                const adds = patch.add_nodes?.length ?? 0;
+                const edges = patch.add_edges?.length ?? 0;
+                const updates = patch.update_nodes?.length ?? 0;
+                const removes = patch.remove_nodes?.length ?? 0;
+                if (adds) parts.push(t("addNodes", { count: adds }));
+                if (edges) parts.push(t("addEdges", { count: edges }));
+                if (updates) parts.push(t("updateNodes", { count: updates }));
+                if (removes) parts.push(t("removeNodes", { count: removes }));
+                return parts.join(" · ") || t("patch");
+            }
+            case "read_canvas":
+                return t("readCanvas");
+            case "validate_workflow":
+                return t("validate");
+            case "describe_node_type":
+                return t("describe", { type: String(args.type ?? "") });
+            case "search_docs":
+                return t("searchDocs", { query: String(args.query ?? "") });
+            case "list_workflows":
+                return t("listWorkflows");
+            case "load_workflow":
+                return t("loadWorkflow");
+            case "save_workflow":
+                return t("saveWorkflow");
+            default:
+                return name;
+        }
+    };
+}
+
+export function AgentEntryView({ entry }: { entry: AgentUiEntry }) {
+    const t = useTranslations("Agent");
+    const toolLabel = useToolLabel();
+
+    switch (entry.kind) {
+        case "user":
+            return (
+                <div className="flex justify-end">
+                    <div className="max-w-[85%] rounded-2xl rounded-br-sm bg-primary text-primary-foreground px-3 py-2 text-sm whitespace-pre-wrap break-words">
+                        {entry.text}
+                        {entry.attachments && entry.attachments.length > 0 && (
+                            <div className="mt-1 text-xs opacity-80">
+                                {entry.attachments
+                                    .map((a) => `#${a.index} ${a.name}`)
+                                    .join(", ")}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            );
+
+        case "assistant":
+            if (!entry.text && !entry.streaming) return null;
+            return (
+                <div className="flex justify-start">
+                    <div className="max-w-[92%] text-sm whitespace-pre-wrap break-words leading-relaxed">
+                        {entry.text}
+                        {entry.streaming && (
+                            <span className="inline-block w-1.5 h-4 ml-0.5 align-text-bottom bg-foreground/60 animate-pulse" />
+                        )}
+                    </div>
+                </div>
+            );
+
+        case "tool": {
+            const pending = entry.result === undefined;
+            const failed = entry.result !== undefined && !entry.result.ok;
+            return (
+                <div
+                    className={cn(
+                        "flex items-center gap-2 text-xs rounded-md border px-2 py-1.5",
+                        failed
+                            ? "border-destructive/40 text-destructive"
+                            : "text-muted-foreground",
+                    )}
+                >
+                    {pending ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin shrink-0" />
+                    ) : failed ? (
+                        <X className="h-3.5 w-3.5 shrink-0" />
+                    ) : (
+                        <Check className="h-3.5 w-3.5 shrink-0 text-green-600" />
+                    )}
+                    <Wrench className="h-3 w-3 shrink-0 opacity-60" />
+                    <span className="truncate">
+                        {toolLabel(entry.name, entry.args)}
+                        {failed && entry.result && "error" in entry.result
+                            ? ` — ${entry.result.error}`
+                            : ""}
+                    </span>
+                </div>
+            );
+        }
+
+        case "error":
+            return (
+                <div className="flex items-start gap-2 text-xs rounded-md border border-destructive/40 bg-destructive/5 text-destructive px-2 py-1.5">
+                    <AlertCircle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                    <span className="break-words">
+                        {entry.code === "turn_limit"
+                            ? t("turnLimit")
+                            : entry.message}
+                    </span>
+                </div>
+            );
+    }
+}

--- a/src/components/workspace/agent/agent-panel.tsx
+++ b/src/components/workspace/agent/agent-panel.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+/**
+ * Right-side agent chat panel. Rendered as a flex sibling of the canvas so
+ * ReactFlow resizes naturally; the toggle button lives in the workspace's
+ * top-right cluster.
+ */
+
+import { ArrowUp, Eraser, Loader2, Paperclip, Square, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { type ChangeEvent, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useAgentChat } from "@/hooks/use-agent-chat";
+import {
+    useNodePluginIds,
+    useNodePluginModels,
+    usePluginsRegistry,
+} from "@/hooks/use-plugins-registry";
+import { useMultipleUpload } from "@/hooks/use-upload";
+import { isChatCapablePlugin } from "@/lib/agent/chat-adapters";
+import type { AgentAttachment } from "@/lib/agent/types";
+import { isImageFile, isVideoFile } from "@/lib/upload/validation";
+import { cn } from "@/lib/utils";
+import { pluginDisplayName } from "../nodes/base/node-plugin-id-select";
+import { AgentEntryView } from "./agent-message";
+
+const PROVIDER_STORAGE_KEY = "agentProvider";
+
+function classifyFile(
+    file: File,
+): Pick<AgentAttachment, "modality" | "addNodeType"> {
+    if (isImageFile(file)) {
+        return { modality: "imageNode", addNodeType: "addImageNode" };
+    }
+    if (isVideoFile(file)) {
+        return { modality: "videoNode", addNodeType: "addVideoNode" };
+    }
+    if (file.type.startsWith("audio/")) {
+        return { modality: "audioNode", addNodeType: "addAudioNode" };
+    }
+    if (/\.(glb|gltf|obj|fbx|ply|splat)$/i.test(file.name)) {
+        return { modality: "modelNode", addNodeType: "addModelNode" };
+    }
+    return { modality: "fileNode", addNodeType: "addFileNode" };
+}
+
+function ProviderPicker() {
+    const t = useTranslations("Agent");
+    usePluginsRegistry();
+    const { pluginId, model, setProvider } = useAgentChat();
+
+    const genTextPlugins = useNodePluginIds("gen-text");
+    const chatPlugins = genTextPlugins.filter(isChatCapablePlugin);
+    const models = useNodePluginModels("gen-text", pluginId);
+
+    // Restore persisted choice / default to the first chat-capable plugin.
+    useEffect(() => {
+        if (pluginId || chatPlugins.length === 0) return;
+        let initial: { pluginId?: string; model?: string } = {};
+        try {
+            initial = JSON.parse(
+                localStorage.getItem(PROVIDER_STORAGE_KEY) ?? "{}",
+            ) as { pluginId?: string; model?: string };
+        } catch {
+            /* corrupted entry — fall through to defaults */
+        }
+        const plugin =
+            initial.pluginId && chatPlugins.includes(initial.pluginId)
+                ? initial.pluginId
+                : chatPlugins[0];
+        setProvider(plugin, initial.model ?? "");
+    }, [pluginId, chatPlugins, setProvider]);
+
+    const persist = (p: string, m: string) => {
+        setProvider(p, m);
+        localStorage.setItem(
+            PROVIDER_STORAGE_KEY,
+            JSON.stringify({ pluginId: p, model: m }),
+        );
+    };
+
+    if (chatPlugins.length === 0) {
+        return (
+            <span className="text-xs text-muted-foreground">
+                {t("noLlmPlugin")}
+            </span>
+        );
+    }
+
+    return (
+        <div className="flex items-center gap-1 min-w-0">
+            <Select value={pluginId} onValueChange={(v) => persist(v, "")}>
+                <SelectTrigger className="h-7 text-xs w-[120px]">
+                    <SelectValue placeholder={t("selectPlugin")} />
+                </SelectTrigger>
+                <SelectContent>
+                    {chatPlugins.map((p) => (
+                        <SelectItem key={p} value={p} className="text-xs">
+                            {pluginDisplayName(p)}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+            {models.length > 0 && (
+                <Select
+                    value={model || models[0]}
+                    onValueChange={(v) => persist(pluginId, v)}
+                >
+                    <SelectTrigger className="h-7 text-xs w-[150px]">
+                        <SelectValue placeholder={t("selectModel")} />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {models.map((m) => (
+                            <SelectItem key={m} value={m} className="text-xs">
+                                {m}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            )}
+        </div>
+    );
+}
+
+export function AgentPanel() {
+    const t = useTranslations("Agent");
+    const {
+        open,
+        status,
+        entries,
+        attachments,
+        missingEnvKey,
+        toggle,
+        send,
+        stop,
+        clear,
+        addAttachments,
+        removeAttachment,
+        model,
+        setProvider,
+        pluginId,
+    } = useAgentChat();
+    const models = useNodePluginModels("gen-text", pluginId);
+
+    const [input, setInput] = useState("");
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const { upload, isUploading } = useMultipleUpload();
+
+    // Default the model once the plugin's model list is known.
+    useEffect(() => {
+        if (pluginId && !model && models.length > 0) {
+            setProvider(pluginId, models[0]);
+        }
+    }, [pluginId, model, models, setProvider]);
+
+    // Follow the transcript.
+    useEffect(() => {
+        scrollRef.current?.scrollTo({
+            top: scrollRef.current.scrollHeight,
+            behavior: "smooth",
+        });
+    }, [entries.length, status]);
+
+    if (!open) return null;
+
+    const busy = status !== "idle";
+
+    const handleSend = () => {
+        const text = input.trim();
+        if (!text || busy) return;
+        setInput("");
+        void send(text);
+    };
+
+    const handleFiles = async (e: ChangeEvent<HTMLInputElement>) => {
+        const files = Array.from(e.target.files ?? []);
+        e.target.value = "";
+        if (files.length === 0) return;
+        // One at a time so file name/mime stay zipped with the upload result.
+        const uploaded: AgentAttachment[] = [];
+        for (const file of files) {
+            const responses = await upload([file]);
+            const res = responses[0];
+            if (!res) continue;
+            uploaded.push({
+                index: 0, // assigned by the store
+                fileKey: res.key,
+                url: res.url,
+                name: file.name,
+                mime: file.type || "application/octet-stream",
+                size: file.size,
+                ...classifyFile(file),
+            });
+        }
+        if (uploaded.length > 0) addAttachments(uploaded);
+    };
+
+    return (
+        <div className="w-[380px] shrink-0 h-full border-l bg-background flex flex-col">
+            {/* Header */}
+            <div className="flex items-center justify-between gap-2 px-3 py-2 border-b">
+                <span className="text-sm font-medium shrink-0">
+                    {t("title")}
+                </span>
+                <ProviderPicker />
+                <div className="flex items-center shrink-0">
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7"
+                        onClick={clear}
+                        title={t("clear")}
+                        disabled={entries.length === 0}
+                    >
+                        <Eraser className="h-4 w-4" />
+                    </Button>
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7"
+                        onClick={toggle}
+                        title={t("close")}
+                    >
+                        <X className="h-4 w-4" />
+                    </Button>
+                </div>
+            </div>
+
+            {/* Transcript */}
+            <div
+                ref={scrollRef}
+                className="flex-1 overflow-y-auto px-3 py-3 space-y-3"
+            >
+                {entries.length === 0 && (
+                    <div className="text-sm text-muted-foreground space-y-2 mt-4">
+                        <p>{t("emptyHint")}</p>
+                        <ul className="space-y-1">
+                            {[t("example1"), t("example2"), t("example3")].map(
+                                (ex) => (
+                                    <li key={ex}>
+                                        <button
+                                            type="button"
+                                            className="text-left w-full rounded-md border px-2 py-1.5 hover:bg-accent text-xs"
+                                            onClick={() => setInput(ex)}
+                                        >
+                                            {ex}
+                                        </button>
+                                    </li>
+                                ),
+                            )}
+                        </ul>
+                    </div>
+                )}
+                {entries.map((entry, i) => (
+                    // The transcript is append-only, so the index is stable.
+                    <AgentEntryView key={`entry-${i}`} entry={entry} />
+                ))}
+                {missingEnvKey !== null && (
+                    <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs space-y-1">
+                        <p className="font-medium">{t("missingKeyTitle")}</p>
+                        <p className="text-muted-foreground">
+                            {missingEnvKey
+                                ? t("missingKeyBody", { envKey: missingEnvKey })
+                                : t("noProviderBody")}
+                        </p>
+                    </div>
+                )}
+            </div>
+
+            {/* Attachments */}
+            {attachments.length > 0 && (
+                <div className="px-3 pb-1 flex flex-wrap gap-1">
+                    {attachments.map((a) => (
+                        <span
+                            key={a.index}
+                            className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs bg-muted"
+                        >
+                            #{a.index} {a.name}
+                            <button
+                                type="button"
+                                onClick={() => removeAttachment(a.index)}
+                                className="hover:text-destructive"
+                            >
+                                <X className="h-3 w-3" />
+                            </button>
+                        </span>
+                    ))}
+                </div>
+            )}
+
+            {/* Input */}
+            <div className="border-t p-2">
+                <Textarea
+                    value={input}
+                    onChange={(e) => setInput(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (
+                            e.key === "Enter" &&
+                            !e.shiftKey &&
+                            !e.nativeEvent.isComposing
+                        ) {
+                            e.preventDefault();
+                            handleSend();
+                        }
+                    }}
+                    placeholder={t("placeholder")}
+                    className="min-h-[60px] max-h-[160px] resize-none text-sm"
+                    disabled={busy}
+                />
+                <div className="flex items-center justify-between mt-1.5">
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7"
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={busy || isUploading}
+                        title={t("attach")}
+                    >
+                        {isUploading ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                            <Paperclip className="h-4 w-4" />
+                        )}
+                    </Button>
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        className="hidden"
+                        onChange={handleFiles}
+                    />
+                    {busy ? (
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-7"
+                            onClick={stop}
+                        >
+                            <Square className="h-3.5 w-3.5 mr-1" />
+                            {t("stop")}
+                        </Button>
+                    ) : (
+                        <Button
+                            size="icon"
+                            className={cn("h-7 w-7")}
+                            onClick={handleSend}
+                            disabled={!input.trim()}
+                            title={t("send")}
+                        >
+                            <ArrowUp className="h-4 w-4" />
+                        </Button>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/workspace/agent/agent-toggle-button.tsx
+++ b/src/components/workspace/agent/agent-toggle-button.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Bot } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useAgentChat } from "@/hooks/use-agent-chat";
+import { cn } from "@/lib/utils";
+
+// Matches navBtnClass in workspace-nav.tsx so the toggle sits naturally in
+// the top-right cluster.
+const btnClass =
+    "h-10 w-10 rounded-xl bg-white border border-gray-100 hover:bg-gray-50 text-gray-500 hover:text-gray-900 dark:bg-zinc-800 dark:border-zinc-700 dark:text-gray-400 dark:hover:text-white dark:hover:bg-zinc-700 transition-all duration-200";
+
+export function AgentToggleButton() {
+    const t = useTranslations("Agent");
+    const { open, toggle } = useAgentChat();
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={toggle}
+                    className={cn(
+                        btnClass,
+                        open &&
+                            "text-gray-900 bg-gray-50 dark:text-white dark:bg-zinc-700",
+                    )}
+                >
+                    <Bot className="h-5 w-5" />
+                </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t("title")}</TooltipContent>
+        </Tooltip>
+    );
+}

--- a/src/components/workspace/workspace.tsx
+++ b/src/components/workspace/workspace.tsx
@@ -45,6 +45,8 @@ import { logger } from "@/lib/logger";
 import { cn } from "@/lib/utils";
 import { isValidFlowConnection } from "@/lib/workflow/connection-rules";
 import { parseWorkflowImportJson } from "@/lib/workflow/exporter";
+import { AgentPanel } from "./agent/agent-panel";
+import { AgentToggleButton } from "./agent/agent-toggle-button";
 import { AppView } from "./app-view/app-view";
 import { ModeSwitch } from "./mode-switch";
 import { OnboardingGate } from "./onboarding/onboarding-gate";
@@ -370,111 +372,115 @@ function WorkspaceInner({
     }, [locale, tIndex]);
 
     return (
-        <div className="relative w-full h-full overflow-hidden [&_.react-flow]:!bg-[#f6f7f9] dark:[&_.react-flow]:!bg-background">
-            <div
-                className={cn(
-                    "w-full h-full",
-                    isAppMode && "invisible pointer-events-none",
-                )}
-                aria-hidden={isAppMode}
-            >
-                <ReactFlow
-                    nodes={nodes}
-                    onNodesChange={onNodesChange}
-                    edges={edges}
-                    onEdgesChange={onEdgesChange}
-                    onConnect={onConnect}
-                    isValidConnection={isValidConnection}
-                    // Manual new connections are disabled at the handle level
-                    // (isConnectableStart={false}); users may only reconnect an
-                    // existing edge's endpoint, validated by isValidConnection.
-                    onReconnect={onReconnect}
-                    onReconnectStart={onReconnectStart}
-                    onReconnectEnd={onReconnectEnd}
-                    nodeTypes={NODE_TYPES}
-                    edgeTypes={EDGE_TYPES}
-                    defaultEdgeOptions={{
-                        type: "custom-edge",
-                        selectable: false,
-                        focusable: false,
-                    }}
-                    // While reconnecting, ReactFlow hides the original edge and
-                    // shows this connection-line preview following the cursor.
-                    // Match the custom-edge style so it stays visible/cursor-tracked.
-                    connectionLineStyle={{
-                        strokeWidth: 3,
-                        stroke: "#94a3b8",
-                        strokeLinecap: "round",
-                    }}
-                    onSelectionChange={onSelectionChange}
-                    onNodeDoubleClick={handleNodeDoubleClick}
-                    onPaneClick={handlePaneClick}
-                    onNodeDragStart={handleDragStart}
-                    onSelectionDragStart={handleDragStart}
-                    nodeDragThreshold={1}
-                    nodeOrigin={[0.5, 0.5]}
-                    selectNodesOnDrag={false}
-                    fitView
-                    minZoom={0.001} // Minimum zoom limit
-                    maxZoom={1000} // Maximum zoom limit
-                    proOptions={{ hideAttribution: true }}
-                    colorMode={colorMode}
+        <div className="flex w-full h-full">
+            <div className="relative flex-1 min-w-0 h-full overflow-hidden [&_.react-flow]:!bg-[#f6f7f9] dark:[&_.react-flow]:!bg-background">
+                <div
+                    className={cn(
+                        "w-full h-full",
+                        isAppMode && "invisible pointer-events-none",
+                    )}
+                    aria-hidden={isAppMode}
                 >
-                    <Background />
-                    <Controls />
-                    <Panel position="bottom-center" className="!mb-5 z-10">
-                        <SmartIsland />
-                    </Panel>
-                </ReactFlow>
-            </div>
-
-            {isAppMode && (
-                <div className="absolute inset-0 z-5 overflow-y-auto bg-background">
-                    <AppView />
+                    <ReactFlow
+                        nodes={nodes}
+                        onNodesChange={onNodesChange}
+                        edges={edges}
+                        onEdgesChange={onEdgesChange}
+                        onConnect={onConnect}
+                        isValidConnection={isValidConnection}
+                        // Manual new connections are disabled at the handle level
+                        // (isConnectableStart={false}); users may only reconnect an
+                        // existing edge's endpoint, validated by isValidConnection.
+                        onReconnect={onReconnect}
+                        onReconnectStart={onReconnectStart}
+                        onReconnectEnd={onReconnectEnd}
+                        nodeTypes={NODE_TYPES}
+                        edgeTypes={EDGE_TYPES}
+                        defaultEdgeOptions={{
+                            type: "custom-edge",
+                            selectable: false,
+                            focusable: false,
+                        }}
+                        // While reconnecting, ReactFlow hides the original edge and
+                        // shows this connection-line preview following the cursor.
+                        // Match the custom-edge style so it stays visible/cursor-tracked.
+                        connectionLineStyle={{
+                            strokeWidth: 3,
+                            stroke: "#94a3b8",
+                            strokeLinecap: "round",
+                        }}
+                        onSelectionChange={onSelectionChange}
+                        onNodeDoubleClick={handleNodeDoubleClick}
+                        onPaneClick={handlePaneClick}
+                        onNodeDragStart={handleDragStart}
+                        onSelectionDragStart={handleDragStart}
+                        nodeDragThreshold={1}
+                        nodeOrigin={[0.5, 0.5]}
+                        selectNodesOnDrag={false}
+                        fitView
+                        minZoom={0.001} // Minimum zoom limit
+                        maxZoom={1000} // Maximum zoom limit
+                        proOptions={{ hideAttribution: true }}
+                        colorMode={colorMode}
+                    >
+                        <Background />
+                        <Controls />
+                        <Panel position="bottom-center" className="!mb-5 z-10">
+                            <SmartIsland />
+                        </Panel>
+                    </ReactFlow>
                 </div>
-            )}
 
-            <div className="absolute left-5 top-5 z-10 flex items-center gap-3">
-                <WorkflowTitleMenu />
-                <WorkspaceLeftNav />
-                <UndoRedoButtons />
+                {isAppMode && (
+                    <div className="absolute inset-0 z-5 overflow-y-auto bg-background">
+                        <AppView />
+                    </div>
+                )}
+
+                <div className="absolute left-5 top-5 z-10 flex items-center gap-3">
+                    <WorkflowTitleMenu />
+                    <WorkspaceLeftNav />
+                    <UndoRedoButtons />
+                </div>
+
+                <div className="absolute right-5 top-5 z-10 flex items-center gap-3">
+                    <AgentToggleButton />
+                    <WorkspaceNav />
+                </div>
+
+                <div className="absolute right-4 bottom-5 z-10">
+                    <ModeSwitch />
+                </div>
+
+                <OnboardingGate />
+
+                <AlertDialog
+                    open={pendingDeleteEdgeId !== null}
+                    onOpenChange={(open) => {
+                        if (!open) setPendingDeleteEdgeId(null);
+                    }}
+                >
+                    <AlertDialogContent>
+                        <AlertDialogHeader>
+                            <AlertDialogTitle>
+                                {tEdges("deleteConfirmTitle")}
+                            </AlertDialogTitle>
+                            <AlertDialogDescription>
+                                {tEdges("deleteConfirmDescription")}
+                            </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                            <AlertDialogCancel>
+                                {tEdges("cancel")}
+                            </AlertDialogCancel>
+                            <AlertDialogAction onClick={confirmDeleteEdge}>
+                                {tEdges("delete")}
+                            </AlertDialogAction>
+                        </AlertDialogFooter>
+                    </AlertDialogContent>
+                </AlertDialog>
             </div>
-
-            <div className="absolute right-5 top-5 z-10">
-                <WorkspaceNav />
-            </div>
-
-            <div className="absolute right-4 bottom-5 z-10">
-                <ModeSwitch />
-            </div>
-
-            <OnboardingGate />
-
-            <AlertDialog
-                open={pendingDeleteEdgeId !== null}
-                onOpenChange={(open) => {
-                    if (!open) setPendingDeleteEdgeId(null);
-                }}
-            >
-                <AlertDialogContent>
-                    <AlertDialogHeader>
-                        <AlertDialogTitle>
-                            {tEdges("deleteConfirmTitle")}
-                        </AlertDialogTitle>
-                        <AlertDialogDescription>
-                            {tEdges("deleteConfirmDescription")}
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel>
-                            {tEdges("cancel")}
-                        </AlertDialogCancel>
-                        <AlertDialogAction onClick={confirmDeleteEdge}>
-                            {tEdges("delete")}
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
+            <AgentPanel />
         </div>
     );
 }

--- a/src/generated/agent-docs/en.json
+++ b/src/generated/agent-docs/en.json
@@ -1,0 +1,129 @@
+{
+    "chunks": [
+        {
+            "source": "README.md",
+            "heading": "",
+            "body": "<div align=\"center\">\n  <img src=\"public/logo.svg\" alt=\"TongFlow\" width=\"320\" />\n\n  <h1>TongFlow : An Open-Source Multi-Modal GenAI Workflow Studio</h1>\n  <p>\n    <a href=\"https://github.com/tong-io/tongflow/stargazers\"><img src=\"https://img.shields.io/github/stars/tong-io/tongflow?style=flat&logo=github\" alt=\"GitHub stars\" /></a>\n    <a href=\"https://github.com/tong-io/tongflow/blob/main/LICENSE\"><img src=\"https://img.shields.io/badge/License-AGPL--3.0-blue.svg\" alt=\"License\" /></a>\n    <a href=\"https://github.com/tong-io/tongflow/actions/workflows/ci.yml\"><img src=\"https://github.com/tong-io/tongflow/actions/workflows/ci.yml/badge.svg\" alt=\"CI\" /></a>\n    <a href=\"https://pypi.org/project/tongflow/\"><img src=\"https://img.shields.io/pypi/v/tongflow?logo=pypi&logoColor=white&label=Python%20SDK\" alt=\"PyPI\" /></a>\n    <a href=\"https://discord.gg/K7V8az94Zf\"><img src=\"https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white\" alt=\"Discord\" /></a>\n    <a href=\"https://github.com/tong-io/tongflow/releases\"><img src=\"https://img.shields.io/github/v/release/tong-io/tongflow?logo=github\" alt=\"Latest Release\" /></a>\n  </p>\n  <p>\n    <video src=\"https://github.com/user-attachments/assets/407a7e7b-2d44-4c90-8016-33d0a9f5e7d5\"></video>\n  <p>\n  <p>\n    <strong>English</strong> · <a href=\"docs/README_ZH.md\">简体中文</a> · <a href=\"docs/README_JA.md\">日本語</a>\n  </p>\n</div>"
+        },
+        {
+            "source": "README.md",
+            "heading": "Demo Examples › Demo Examples",
+            "body": "| Workflow | Result |\n| :--: | :--: |\n| **Basic** — Type text (Add), generate images (Transform), then blend them into one (Compose).<br/><img src=\"https://file.tongflow.com/public/demos/basic.png\" width=\"620\" alt=\"workflow\" /> | <img src=\"https://file.tongflow.com/public/demos/basic_result.png\" width=\"200\" alt=\"result\" /> |\n| **Intermediate** — (Add topic → write script → generate speech) + (character description → generate image) → lip-synced video = talking-head avatar.<br/><img src=\"https://file.tongflow.com/public/demos/digitalhuman.png\" width=\"620\" alt=\"workflow\" /> | <video src=\"https://github.com/user-attachments/assets/a803394d-0ccf-4023-9b06-5c1581345758\" width=\"200\"></video> |\n| **Advanced** — Generate lyrics + song + characters + scenes + storyboard → produce a music video.<br/><img src=\"https://file.tongflow.com/public/demos/mv.png\" width=\"620\" alt=\"workflow\" /> | <video src=\"https://github.com/user-attachments/assets/2bc71e3c-3ed6-48b2-81e7-82ad5976d801\" width=\"200\"></video> |\n\nWith TongFlow, you can expand your imagination and stretch your ideas with generative AI, just have a try now!"
+        },
+        {
+            "source": "README.md",
+            "heading": "How To Start › How To Start",
+            "body": "The TongFlow **desktop app** is a lightweight (~10 MB) shell around the cloud studio at **[app.tongflow.com](https://app.tongflow.com)** — install it, sign in, and start creating. The cloud studio also runs in any modern browser."
+        },
+        {
+            "source": "README.md",
+            "heading": "How To Start › Step 1 — Install the desktop app › Step 1 — Install the desktop app",
+            "body": "Download the installer for your platform, install it, and open it.\n\n- **macOS (Universal — Apple Silicon & Intel):** [TongFlow-mac-universal.dmg](https://github.com/tong-io/tongflow/releases/latest/download/TongFlow-mac-universal.dmg)\n- **Windows:** [TongFlow-win-x64.msi](https://github.com/tong-io/tongflow/releases/latest/download/TongFlow-win-x64.msi)\n\nAll builds are on the [Releases](https://github.com/tong-io/tongflow/releases/latest) page.\n\n> **macOS:** the builds are not yet notarized with Apple, so Gatekeeper will block the first launch (\"TongFlow is damaged and can't be opened\"). After moving the app to Applications, clear the quarantine flag once and it opens normally:\n>\n> ```bash\n> xattr -cr /Applications/TongFlow.app\n> ```\n>\n> Download from this page directly — installers passed through chat apps (e.g. WeChat) may be renamed or re-flagged."
+        },
+        {
+            "source": "README.md",
+            "heading": "How To Start › Step 2 — Sign in and create › Step 2 — Sign in and create",
+            "body": "Sign in with Google or WeChat and start creating — the cloud studio manages plugins and execution for you.\n\n> **Prefer a fully local, account-free TongFlow?** That's what self-hosting is for — see [Run from source](#run-from-source) or [Run with Docker](#run-with-docker), then follow [Self-host setup](#self-host-setup-plugins--credentials). (The desktop app up to v0.1.13 bundled this local runtime; those installers remain on the [Releases](https://github.com/tong-io/tongflow/releases) page.)"
+        },
+        {
+            "source": "README.md",
+            "heading": "Core Concept › Core Concept",
+            "body": "- **All models**: AI models can be thought of as a **modality transform** (e.g. LLMs are text→text, image models are text→image, speech models are text→audio, and so on). TongFlow wraps each capability as a node.\n\n- **All modalities**: TongFlow supports almost every modality and file format that people actually ship over the web.\n\n- **Low barrier, high ceiling**: no complex AI parameters to learn, no manual node connecting; just three operations — **add**, **transform**, and **combine** — to arrange ideas freely. And by orchestrating AI models freely, you can generate unique creations and works of your own.\n\n- **Open ecosystem**: TongFlow's plugin-based design lets every platform package its own independent plugins, and we provide at least one official implementation plugin for each capability node. The core stays small, the ecosystem stays open."
+        },
+        {
+            "source": "README.md",
+            "heading": "What’s Defined › What’s Defined",
+            "body": "> ✅ = available out of the box with an official plugin · ⬜ = node exists in the canvas but has no official plugin yet (planned)."
+        },
+        {
+            "source": "README.md",
+            "heading": "What’s Defined › Add › Add",
+            "body": "- ✅ **Text input**: type text and add a text node.\n- ✅ **Add image**: pick a local file and add an image node.\n- ✅ **Add photo**: capture with the device camera and add an image node.\n- ✅ **Add sketch**: draw on the canvas and add an image node.\n- ✅ **Add audio**: pick a local audio file and add an audio node.\n- ✅ **Record audio**: record with the mic and add an audio node.\n- ✅ **Add video**: pick a local video file and add a video node.\n- ✅ **Record video**: record with the camera and add a video node.\n- ✅ **Add document**: pick a local file and add a document node.\n- ✅ **Add URL**: fetch a page from a link and add text, image, audio, or video nodes.\n- ✅ **Add 3D model**: choose a local model file and add a 3D model node."
+        },
+        {
+            "source": "README.md",
+            "heading": "What’s Defined › Transform › Transform",
+            "body": "#### Text\n\n- ✅ **Generate / rewrite**: create or edit copy from a prompt.\n\n#### Image\n\n- ✅ **Image generation**: images from text.\n- ✅ **Image editing**: inpaint, edit, or redraw with instructions.\n- ✅ **Image understanding**: captions, Q&A, or descriptions from an image.\n- ✅ **Image upscaling**: enlarge for sharper detail.\n- ✅ **Pose detection**: 308-keypoint whole-body skeleton overlay (body, hands, face).\n- ✅ **Body-part segmentation**: 29-class human parsing overlay.\n- ✅ **Surface normals**: per-pixel normal map — human-centric or full scene.\n- ✅ **Matting**: cut the human or salient foreground out as a transparent PNG.\n\n#### Video\n\n- ✅ **Video generation**: video from text.\n- ✅ **Image-to-video**: animate a still into motion.\n- ✅ **First/last-frame video**: two key images to interpolate a clip.\n- ✅ **Images → video**: multi-image reference fusion — several reference images plus text into a new video.\n- ✅ **Video understanding**: summaries or descriptions from video.\n- ✅ **Video upscaling**: higher-resolution output.\n- ✅ **Extract first / last frame**: grab a frame as an image.\n- ✅ **Video editing**: edit a video from a text instruction.\n- ✅ **Subtitle removal**: clean subtitles from a video.\n- ✅ **Watermark removal**: remove watermarks from a video.\n\n#### Audio\n\n- ✅ **Music generation**: music from text, with optional reference-audio conditioning.\n- ✅ **Audio understanding**: describe a clip (music, speech, or ambient sound) in text.\n- ✅ **Music repaint**: regenerate a chosen time range of a song.\n- ✅ **Music cover**: restyle a song via a caption and/or a reference track.\n- ✅ **Add track / complete arrangement**: generate one new stem over a mix, or fill in missing tracks.\n- ✅ **Music brief**: one-sentence idea → lyrics, style tags, BPM, key, and duration.\n- ✅ **Speech synthesis**: text-to-speech — preset style, voice clone (reference audio), or instruction-driven.\n- ✅ **Speech recognition**: transcribe speech from audio or video.\n- ✅ **Noise reduction**: denoise audio.\n- ⬜ **Speaker diarization**: separate audio by speaker.\n- ⬜ **Voice / timbre replacement**: replace or clone a voice with a reference sample.\n- ✅ **Multi-track / vocal-accompaniment separation**: isolate vocals, drums, bass, guitar, and 8 more stems.\n- ✅ **Open-vocabulary sound separation**: describe any sound in words (\"dog barking\") and split the audio into that sound and everything else."
+        },
+        {
+            "source": "README.md",
+            "heading": "What’s Defined › Combine › Combine",
+            "body": "- ✅ **Image fusion**: blend or edit multiple references into one image.\n- ✅ **Lip sync**: audio + video → video (lip-sync); also audio + image → video and audio + text → video variants.\n- ✅ **Character swap**: video + reference (scene blend / character replacement), Animate Mix-style generation.\n- ✅ **Motion transfer**: video + reference (motion / retarget), Animate Move-style generation.\n- ✅ **Combine text**: merge multiple text nodes into one."
+        },
+        {
+            "source": "README.md",
+            "heading": "What’s Defined › Other › Other",
+            "body": "- ✅ **Image → 3D**: single-view 3D model from an image.\n- ✅ **Video → motion capture**: monocular video to skeletal animation (body + fingers + face channels, GLB).\n- ✅ **Document → text**: extract plain text from documents.\n- ✅ **Link → text**: turn page content into text."
+        },
+        {
+            "source": "README.md",
+            "heading": "What’s Defined › Helpers › Helpers",
+            "body": "- ✅ **Concatenate clips**: join multiple videos end to end.\n- ✅ **Mux audio + video**: merge into one file.\n- ✅ **Split by shots**: cut a long video into segments by scene.\n- ✅ **Split video & audio**: demux a video into separate video and audio tracks.\n- ✅ **Extract audio track**: pull audio into its own asset.\n- ✅ **Split long text**: break a long passage into chunks.\n- ✅ **Merge / tidy text blocks**: combine segments (use the auto-merge option).\n- ✅ **Filter or drop clips**: drop unwanted clips by rule or selection.\n- ✅ **Arrange & batch groups**: group and arrange text/clip batches for downstream processing."
+        },
+        {
+            "source": "README.md",
+            "heading": "Official plugins › Official plugins",
+            "body": "> The official GPU/CPU plugins currently run on [Modal](https://modal.com) — up to **$30/month** of free GPU compute (H100/A100, etc.). See [Self-host setup](#self-host-setup-plugins--credentials) for the `MODAL_TOKEN_*` setup. Any other platform can publish its own plugins the same way."
+        },
+        {
+            "source": "README.md",
+            "heading": "Official plugins › API plugins › API plugins",
+            "body": "First-party providers (a lab's own models):\n\n- [tongflow-api-gemini](https://github.com/tong-io/tongflow-api-gemini) — Google Gemini with a per-node **model picker**: text, vision, image (Nano Banana / Imagen 4), Veo video, TTS and transcription\n- [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — OpenAI with a per-node **model picker**: `gen_text`, image gen/edit/fusion (`gpt-image-2`), vision, document OCR, Whisper transcription and TTS\n- [tongflow-api-deepseek](https://github.com/tong-io/tongflow-api-deepseek) — DeepSeek V4 (`flash` / `pro`, with a streaming **thinking** bubble) for `gen_text` / text tools\n- [tongflow-api-bytedance](https://github.com/tong-io/tongflow-api-bytedance) — ByteDance Volcengine Ark with a per-node **model picker**: Doubao text & vision, Seedream image gen/edit/fusion, Seedance text/image/audio → video\n- [tongflow-api-xai](https://github.com/tong-io/tongflow-api-xai) — xAI Grok with a per-node **model picker**: `gen_text` (Grok 4.x), image understanding, and Grok Imagine text-to-image\n- [tongflow-api-agnes](https://github.com/tong-io/tongflow-api-agnes) — Agnes AI: `gen_text` / text tools / image understanding (`agnes-2.0-flash`), image generation / editing / fusion (`agnes-image-2.x-flash`), and text / image / first-last-frame → video (`agnes-video-v2.0`)\n- [tongflow-api-runway](https://github.com/tong-io/tongflow-api-runway) — Runway Dev unified API with a per-node **model picker**: video (Gen-4.5, Gen-4 Turbo, Aleph edit, Act-Two, Seedance, Veo), image (GPT Image 2, Seedream 5, Gemini image 3) and ElevenLabs TTS"
+        },
+        {
+            "source": "README.md",
+            "heading": "Official plugins › Router plugins › Router plugins",
+            "body": "Aggregators — one key, many third-party models across labs:\n\n- [tongflow-router-openrouter](https://github.com/tong-io/tongflow-router-openrouter) — OpenRouter with a per-node **model picker**: `gen_text` (free by default, plus GPT-5.5 / Claude / Gemini / Grok / DeepSeek), vision / audio understanding, image gen/edit and transcription\n- [tongflow-router-apimart](https://github.com/tong-io/tongflow-router-apimart) — APIMart gateway with a per-node **model picker**: image gen/edit (Z-Image, Seedream, Nano Banana, GPT-Image), text/image → video (Kling, VEO3, Sora2, Seedance), `gen_text` (GPT-5, Claude, Gemini), Whisper transcription and TTS\n- [tongflow-router-replicate](https://github.com/tong-io/tongflow-router-replicate) — Replicate with a per-node **model picker** across the catalog: text, vision, image gen/edit/fusion/upscale/matting, text/image → video, transcription, TTS / voice clone, music, and image → 3D (FLUX, Seedream, Veo, Kling, Whisper, Hunyuan3D…)\n- [tongflow-router-fal](https://github.com/tong-io/tongflow-router-fal) — fal.ai with a per-node **model picker**: image (gen/edit/fusion/upscale/matting/pose/normal/seg), video (text/image → video, first-last frame, talking-head, lip-sync, upscale), audio (transcription, TTS, voice clone, music, source separation) and image → 3D"
+        },
+        {
+            "source": "README.md",
+            "heading": "Official plugins › GPU/CPU plugins › GPU/CPU plugins",
+            "body": "- [tongflow-modal-ffmpeg](https://github.com/tong-io/tongflow-modal-ffmpeg) — transcoding, muxing, media pipelines\n- [tongflow-modal-pyscenedetect](https://github.com/tong-io/tongflow-modal-pyscenedetect) — shot-boundary detection for splitting clips\n- [tongflow-modal-z-image](https://github.com/tong-io/tongflow-modal-z-image) — Z-Image text-to-image\n- [tongflow-modal-ernie-image](https://github.com/tong-io/tongflow-modal-ernie-image) — ERNIE Image text-to-image (alternative)\n- [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — FLUX.2 Klein 9B multi-reference fusion / image editing\n- [tongflow-modal-boogu](https://github.com/tong-io/tongflow-modal-boogu) — Boogu-Image-0.1 (fp8) text-to-image (dense bilingual text) & single-reference image editing\n- [tongflow-modal-ltx](https://github.com/tong-io/tongflow-modal-ltx) — LTX-2.3 text / image-to-video\n- [tongflow-modal-fastwan](https://github.com/tong-io/tongflow-modal-fastwan) — FastWan-QAD-FP8 fast text-to-video (3-step distilled Wan2.1-1.3B)\n- [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk audio-driven lip-sync (audio + image / video → talking-head video)\n- [tongflow-modal-wan-animate](https://github.com/tong-io/tongflow-modal-wan-animate) — Wan-Animate character swap & motion transfer (video + reference)\n- [tongflow-modal-scail2](https://github.com/tong-io/tongflow-modal-scail2) — SCAIL-2 controlled character animation (image + driving video; same two slots as wan-animate)\n- [tongflow-modal-bernini](https://github.com/tong-io/tongflow-modal-bernini) — Bernini-R 1.3B unified video renderer (text/image → image/video, video editing, subtitle / watermark removal)\n- [tongflow-modal-sam3](https://github.com/tong-io/tongflow-modal-sam3) — SAM 3 / SAM 3.1 text-guided matting: cut every instance of a described concept out of an image (transparent PNG) or track it through a video (green-screen matte)\n- [tongflow-modal-triposplat](https://github.com/tong-io/tongflow-modal-triposplat) — TripoSplat single image → 3D Gaussian splat\n- [tongflow-modal-sam-3d-objects](https://github.com/tong-io/tongflow-modal-sam-3d-objects) — SAM 3D Objects single image → 3D Gaussian splat of the foreground object (auto mask, robust to occlusion/clutter; alternative)\n- [tongflow-modal-sam-3d-body](https://github.com/tong-io/tongflow-modal-sam-3d-body) — SAM 3D Body single image → full-body 3D human mesh GLB (multi-person, MHR rig; alternative), and…"
+        },
+        {
+            "source": "README.md",
+            "heading": "Run from source › Run from source",
+            "body": "```bash\npnpm install\npnpm plugins:install   # clone official plugins into plugins/\npnpm start:prod        # builds once, then serves at http://localhost:3000\n```\n\nRequires **Node** (with `pnpm`) and a **Python 3.10+** interpreter on your `PATH` (set `PYTHON` to point at a specific one). Plugins run as local Python processes; TongFlow provisions an isolated venv for them automatically and installs each plugin's `requirements.txt` on first use — no manual Python setup.\n\nOpen **`http://localhost:3000`** and the canvas is live. Then follow [Self-host setup](#self-host-setup-plugins--credentials) (credentials go in the in-app **Settings** dialog, or a project `.env`)."
+        },
+        {
+            "source": "README.md",
+            "heading": "Run with Docker › Run with Docker",
+            "body": "A self-host image is published to GHCR — no Node/Python/pnpm setup required:\n\n```bash\ndocker run -d -p 3000:3000 \\\n  -v tongflow-data:/data -v tongflow-plugins:/plugins \\\n  ghcr.io/tong-io/tongflow:latest\n```\n\nThen open **`http://localhost:3000`**. Or with Compose (clones this repo's [`docker-compose.yml`](docker-compose.yml)):\n\n```bash\ndocker compose up -d\n```\n\nTo build the image yourself instead of pulling: `docker build -t tongflow .`\n\n**Data & credentials.** Everything writable lives in the `/data` volume (SQLite db, uploads, settings). API keys are optional — set them in the in-app **Settings** dialog, or pass them at launch (`-e OPENROUTER_API_KEY=…`); supported keys: `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`.\n\n**Plugins.** The image ships no plugins — install them from the in-app plugin manager (first install needs network access to GitHub). On first run, a plugin provisions a shared Python venv under `/data/.tongflow/plugin-venv` (installs the SDK + the plugin's `requirements.txt` from PyPI), so the first run is slower and needs network. Modal-backed plugins additionally need a Modal token."
+        },
+        {
+            "source": "README.md",
+            "heading": "Self-host setup (plugins & credentials) › Self-host setup (plugins & credentials)",
+            "body": "A self-hosted TongFlow ships with no plugins pre-installed, and the canvas is preloaded with an example workflow. Three steps get it running:"
+        },
+        {
+            "source": "README.md",
+            "heading": "Self-host setup (plugins & credentials) › 1 — Install plugins › 1 — Install plugins",
+            "body": "Open the **plugin manager** (the blocks icon, top-right) and install what you need. Newly installed plugins are usable immediately, no restart.\n\nTo run the preloaded **example workflow** (text → image → fusion → video), install these three plugins:\n\n- [tongflow-modal-z-image](https://github.com/tong-io/tongflow-modal-z-image) — text-to-image\n- [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — image fusion / blending\n- [tongflow-modal-ltx](https://github.com/tong-io/tongflow-modal-ltx) — image-to-video\n\nThese run on [Modal](https://modal.com) (up to **$30/month** of free GPU compute). Add `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` in **Settings**; create a token at [modal.com/settings/tokens](https://modal.com/settings/tokens). Any other platform can publish its own plugins the same way.\n\nBrowse the full catalog — the official API plugins (OpenAI / Gemini / OpenRouter) and other GPU/CPU plugins — in the plugin manager."
+        },
+        {
+            "source": "README.md",
+            "heading": "Self-host setup (plugins & credentials) › 2 — Configure credentials › 2 — Configure credentials",
+            "body": "Open **Settings** (the gear icon, top-right) and add the environment variables your plugins need — e.g. `OPENAI_API_KEY` for the API plugins, or the credentials your GPU/CPU plugins require.\n\n> **Plugin credentials live in Settings.** TongFlow is platform-agnostic and hardcodes no provider: the Settings dialog is a generic key/value editor for environment variables passed to plugins. Each plugin's README documents the keys it needs. Values are stored locally and take effect without a restart."
+        },
+        {
+            "source": "README.md",
+            "heading": "Self-host setup (plugins & credentials) › 3 — Run the example workflow › 3 — Run the example workflow",
+            "body": "Run the preloaded example node by node, or switch to Execute Mode and hit the run button to run the whole thing in one click."
+        },
+        {
+            "source": "README.md",
+            "heading": "Custom plugins › Custom plugins",
+            "body": "Every runnable node is backed by a **contract** — the ABI ([`config/tongflow.abi.json`](config/tongflow.abi.json)) — that defines *what capabilities exist* and *what each one's input/output looks like*, independent of *who* implements it. A plugin is just a small Python package that picks one or more ABI slots and supplies the **how**, annotated against the ABI-generated types via the tongflow Python SDK.\n\nThe full development flow — the ABI, the `@node_slot` decorator, the SDK, directory layout, and how to publish — lives in **[docs/plugins.md](docs/plugins.md)**."
+        },
+        {
+            "source": "README.md",
+            "heading": "Community › Community",
+            "body": "Join the community on **[Discord](https://discord.gg/K7V8az94Zf)** or scan the **WeChat group** QR code below.\n\n<div>\n  <img src=\"docs/assets/qr.png\" alt=\"WeChat group QR code\" width=\"180\" />\n</div>"
+        },
+        {
+            "source": "README.md",
+            "heading": "Business › Business",
+            "body": "For business inquiries, please contact business@tongflow.com.\n\n- **Open-source model owners**: I can integrate your models so users can try them out smoothly.\n- **Enterprise**: I can help you deploy on your local GPU, build custom nodes and plugins, and more.\n- **Platform / router**: I can integrate your APIs.\n- **VCs**: I’m interested in partnering on [tongflow.com](https://tongflow.com), a cloud-hosted AI studio."
+        }
+    ]
+}

--- a/src/generated/agent-docs/ja.json
+++ b/src/generated/agent-docs/ja.json
@@ -1,0 +1,134 @@
+{
+    "chunks": [
+        {
+            "source": "docs/README_JA.md",
+            "heading": "",
+            "body": "<div align=\"center\">\n  <img src=\"../public/logo.svg\" alt=\"TongFlow\" width=\"320\" />\n\n  <h1>TongFlow：オープンソースのマルチモーダル GenAI ワークフロースタジオ</h1>\n  <p>\n    <a href=\"https://github.com/tong-io/tongflow/stargazers\"><img src=\"https://img.shields.io/github/stars/tong-io/tongflow?style=flat&logo=github\" alt=\"GitHub Stars\" /></a>\n    <a href=\"https://github.com/tong-io/tongflow/blob/main/LICENSE\"><img src=\"https://img.shields.io/badge/License-AGPL--3.0-blue.svg\" alt=\"License\" /></a>\n    <a href=\"https://github.com/tong-io/tongflow/actions/workflows/ci.yml\"><img src=\"https://github.com/tong-io/tongflow/actions/workflows/ci.yml/badge.svg\" alt=\"CI\" /></a>\n    <a href=\"https://pypi.org/project/tongflow/\"><img src=\"https://img.shields.io/pypi/v/tongflow?logo=pypi&logoColor=white&label=Python%20SDK\" alt=\"PyPI\" /></a>\n    <a href=\"https://discord.gg/K7V8az94Zf\"><img src=\"https://img.shields.io/badge/Discord-参加-5865F2?logo=discord&logoColor=white\" alt=\"Discord\" /></a>\n    <a href=\"https://github.com/tong-io/tongflow/releases\"><img src=\"https://img.shields.io/github/v/release/tong-io/tongflow?logo=github\" alt=\"最新リリース\" /></a>\n  </p>\n  <p>\n    <video src=\"https://github.com/user-attachments/assets/407a7e7b-2d44-4c90-8016-33d0a9f5e7d5\"></video>\n  <p>\n  <p>\n    <a href=\"../README.md\">English</a> · <a href=\"README_ZH.md\">简体中文</a> · <strong>日本語</strong>\n  </p>\n</div>"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "Demo デモ › Demo デモ",
+            "body": "| ワークフローのスクリーンショット | 出力結果 |\n| :--: | :--: |\n| **基本** — テキストを入力（追加）し、画像を生成（変換）、さらに1枚に融合（結合）。<br/><img src=\"https://file.tongflow.com/public/demos/basic.png\" width=\"620\" alt=\"ワークフロー\" /> | <img src=\"https://file.tongflow.com/public/demos/basic_result.png\" width=\"200\" alt=\"結果\" /> |\n| **中級** — （テーマ追加 → 台本生成 → 音声生成） + （人物の説明 → 画像生成） → リップシンク動画を生成 = デジタルヒューマンのナレーション。<br/><img src=\"https://file.tongflow.com/public/demos/digitalhuman.png\" width=\"620\" alt=\"ワークフロー\" /> | <video src=\"https://github.com/user-attachments/assets/a803394d-0ccf-4023-9b06-5c1581345758\" width=\"200\"></video> |\n| **上級** — 歌詞生成 + 楽曲生成 + 人物生成 + シーン生成 + 絵コンテ生成 → MV生成<br/><img src=\"https://file.tongflow.com/public/demos/mv.png\" width=\"620\" alt=\"ワークフロー\" /> | <video src=\"https://github.com/user-attachments/assets/2bc71e3c-3ed6-48b2-81e7-82ad5976d801\" width=\"200\"></video> |\n\nTongFlowで生成AIを活用し、創造力を解き放とう！"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "クイックスタート › クイックスタート",
+            "body": "TongFlow **デスクトップ版**は、クラウドスタジオ **[app.tongflow.com](https://app.tongflow.com)** を直接読み込む軽量（約 10 MB）のシェルアプリです——インストールしてサインインすれば、すぐに創作を始められます。クラウドスタジオはブラウザから直接開くこともできます。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "クイックスタート › Step 1 — デスクトップ版をインストール › Step 1 — デスクトップ版をインストール",
+            "body": "対応プラットフォームのインストーラーをダウンロードし、インストールして起動します。\n\n- **macOS（Universal — Apple Silicon / Intel 共通）：** [TongFlow-mac-universal.dmg](https://github.com/tong-io/tongflow/releases/latest/download/TongFlow-mac-universal.dmg)\n- **Windows：** [TongFlow-win-x64.msi](https://github.com/tong-io/tongflow/releases/latest/download/TongFlow-win-x64.msi)\n\nすべてのバージョンは [Releases](https://github.com/tong-io/tongflow/releases/latest) ページを参照してください。\n\n> **macOS をお使いの方へ：** インストーラーはまだ Apple の公証（notarization）を受けていないため、初回起動時に Gatekeeper にブロックされます（「\"TongFlow\"は壊れているため開けません」と表示されます）。アプリを「アプリケーション」フォルダに移動した後、ターミナルで以下のコマンドを一度実行すると正常に開けます：\n>\n> ```bash\n> xattr -cr /Applications/TongFlow.app\n> ```\n>\n> インストーラーは必ずこのページから直接ダウンロードしてください——WeChat などのチャットアプリ経由で転送されたファイルは、リネームや隔離フラグの再付与が行われる場合があります。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "クイックスタート › Step 2 — サインインして創作を開始 › Step 2 — サインインして創作を開始",
+            "body": "Google または WeChat でサインインすれば、すぐに創作を始められます——プラグインと実行はクラウド側で管理されます。\n\n> **完全ローカル・アカウント不要の TongFlow をお望みですか？** セルフホストをご利用ください——[ソースコードから起動](#ソースコードから起動)または [Docker で起動](#docker-で起動)を参照し、[セルフホストのセットアップ](#セルフホストのセットアッププラグインと認証情報)に従って設定してください。（v0.1.13 以前のデスクトップ版は完全なローカルランタイムを同梱していました。それらのインストーラーは [Releases](https://github.com/tong-io/tongflow/releases) ページに残っています。）"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "コアコンセプト › コアコンセプト",
+            "body": "- **全モデル対応**: AIモデルは**モダリティ変換**として捉えることができます（例：LLMはテキスト→テキスト、画像モデルはテキスト→画像、音声モデルはテキスト→音声など）。TongFlow は各能力をノードとしてカプセル化します。\n\n- **全モダリティ対応**: TongFlow は、Web上で実際に流通しているほぼすべてのモダリティとファイル形式をサポートします。\n\n- **低い参入障壁、高い可能性**: 複雑なAIパラメータを学ぶ必要も、手動でノードを接続する必要もありません。**追加**、**変換**、**結合**の3つの操作だけで、自由に創意を組み立てられます。さらに、AIモデルを自由に編成することで、独自の創作物を生み出せます。\n\n- **オープンなエコシステム**: TongFlow のプラグインベースの設計により、各プラットフォームが独立したプラグインをカプセル化でき、公式は各能力ノードに対して少なくとも1つの実装プラグインを提供します。コアは軽量に、エコシステムはオープンに。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "実装済み機能 › 実装済み機能",
+            "body": "> ✅ = すぐに使える（公式プラグインあり）· ⬜ = キャンバスにノードはあるが、公式プラグインは未提供（計画中）。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "実装済み機能 › 追加 › 追加",
+            "body": "- ✅ **テキスト入力**: 文字を入力してテキストノードを追加。\n- ✅ **画像を追加**: ローカルファイルを選択して画像ノードを追加。\n- ✅ **写真を撮影**: デバイスのカメラで撮影して画像ノードを追加。\n- ✅ **スケッチを追加**: キャンバス上に描画して画像ノードを追加。\n- ✅ **音声を追加**: ローカルの音声ファイルを選択して音声ノードを追加。\n- ✅ **録音**: マイクで録音して音声ノードを追加。\n- ✅ **動画を追加**: ローカルの動画ファイルを選択して動画ノードを追加。\n- ✅ **動画を録画**: カメラで録画して動画ノードを追加。\n- ✅ **ドキュメントを追加**: ローカルファイルを選択してドキュメントノードを追加。\n- ✅ **リンクを追加**: リンクからページを取得し、テキスト・画像・音声・動画ノードを追加。\n- ✅ **3Dモデルを追加**: ローカルのモデルファイルを選択して3Dモデルノードを追加。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "実装済み機能 › 変換 › 変換",
+            "body": "#### テキスト\n\n- ✅ **生成 / 書き換え**: プロンプトに基づいて文章を作成または編集。\n\n#### 画像\n\n- ✅ **画像生成**: テキストから画像を生成。\n- ✅ **画像編集**: 部分的な再描画、編集、または指示に基づく描き直し。\n- ✅ **画像理解**: 画像から説明・質問応答・キャプションを生成。\n- ✅ **画像超解像**: 拡大してより鮮明なディテールを得る。\n- ✅ **ポーズ検出**: 308 キーポイントの全身スケルトンオーバーレイ（身体・両手・顔）。\n- ✅ **身体部位セグメンテーション**: 29 クラスの人体パーシング。\n- ✅ **表面法線**: ピクセル単位の法線マップ——人物にもシーン全体にも対応。\n- ✅ **前景マッティング**: 人物や顕著な被写体を透過 PNG として切り抜き。\n\n#### 動画\n\n- ✅ **動画生成**: テキストから動画を生成。\n- ✅ **画像から動画**: 静止画を動かす。\n- ✅ **最初/最後のフレームから動画**: 2枚のキーフレームを補間してクリップを生成。\n- ✅ **複数画像から動画**: 複数の参照画像とテキストを融合して新しい動画を生成。\n- ✅ **動画理解**: 動画から要約や説明を生成。\n- ✅ **動画超解像**: より高解像度の動画を出力。\n- ✅ **最初/最後のフレームを抽出**: フレームを画像として抽出。\n- ✅ **動画編集**: テキスト指示で動画を編集。\n- ✅ **字幕除去**: 動画から字幕を消去。\n- ✅ **ウォーターマーク除去**: 動画からウォーターマークを除去。\n\n#### 音声\n\n- ✅ **音楽生成**: テキストから音楽を生成。参照音声による誘導にも対応。\n- ✅ **音声理解**: 音声クリップ（音楽・スピーチ・環境音）をテキストで説明。\n- ✅ **音楽リペイント**: 曲の指定区間を再生成。\n- ✅ **音楽カバー**: 説明文や参照曲でスタイルを変えて再構成。\n- ✅ **トラック追加 / 編曲補完**: 既存ミックスに新しいトラックを生成、または不足パートを補完。\n- ✅ **音楽ブリーフ**: 一文のアイデア → 歌詞・スタイルタグ・BPM・キー・長さ。\n- ✅ **音声合成**: テキストから音声へ——プリセットスタイル、声のクローン（参照音声）、または指示駆動。\n- ✅ **音声認識**: 音声または動画中の発話を文字起こし。\n- ✅ **ノイズ除去**: 音声のノイズを除去。\n- ⬜ **話者分離**: 話者ごとに音声を分離。\n- ⬜ **音色変換**: 参照サンプルを使って音色を置き換えまたはクローン。\n- ✅ **マルチトラック / ボーカル・伴奏分離**: ボーカル・ドラム・ベース・ギターなど 12 種のステムを分離。\n- ✅ **オープン語彙の音源分離**: 任意の音を言葉で指定（「犬の鳴き声」）し、その音とそれ以外の 2 トラックに分割。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "実装済み機能 › 結合 › 結合",
+            "body": "- ✅ **画像融合**: 複数の参照画像を1枚に融合または編集。\n- ✅ **リップシンク**: 音声 + 動画 → 動画（リップシンク）。音声 + 画像 → 動画、音声 + テキスト → 動画などのバリエーションにも対応。\n- ✅ **キャラクター置換**: 動画 + 参照（シーン融合 / キャラクター置換）、Animate Mix スタイルの生成。\n- ✅ **モーション転送**: 動画 + 参照（モーション / リターゲット）、Animate Move スタイルの生成。\n- ✅ **テキスト結合**: 複数のテキストノードを1つに結合。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "実装済み機能 › その他 › その他",
+            "body": "- ✅ **画像 → 3D**: 1枚の画像から3Dモデルを生成。\n- ✅ **動画 → モーションキャプチャ**: 単眼動画からスケルタルアニメーション（身体 + 指 + 表情チャンネル、GLB）。\n- ✅ **ドキュメント → テキスト**: ドキュメントからプレーンテキストを抽出。\n- ✅ **リンク → テキスト**: ページの内容をテキストに変換。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "実装済み機能 › 補助ツール › 補助ツール",
+            "body": "- ✅ **クリップ連結**: 複数の動画を前後につなげる。\n- ✅ **音声・映像の結合**: 1つのファイルに統合。\n- ✅ **ショット単位で分割**: 長い動画をシーンごとに分割。\n- ✅ **音声・映像の分離**: 動画を独立した映像トラックと音声トラックに分離。\n- ✅ **音声トラックを抽出**: 音声を独立したアセットとして書き出す。\n- ✅ **長文を分割**: 長い段落をブロックに分割。\n- ✅ **テキストブロックの結合 / 整理**: 断片を結合（自動結合オプション利用可）。\n- ✅ **クリップのフィルタ / 破棄**: ルールまたは手動選択で不要なクリップを破棄。\n- ✅ **整列とバッチグループ化**: テキストやクリップのバッチをグループ化して整列し、下流処理に渡す。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "公式プラグイン › 公式プラグイン",
+            "body": "> 公式のGPU/CPUプラグインは現在 [Modal](https://modal.com) 上で動作しています——毎月最大 **$30** 分の無料GPU演算（H100/A100など）。`MODAL_TOKEN_*` の設定は[セルフホストのセットアップ](#セルフホストのセットアッププラグインと認証情報)を参照してください。他のどのプラットフォームでも同じ方法で自分のプラグインを公開できます。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "公式プラグイン › API プラグイン › API プラグイン",
+            "body": "ファーストパーティ（各ラボ自身のモデル）：\n\n- [tongflow-api-gemini](https://github.com/tong-io/tongflow-api-gemini) — Google Gemini、ノードごとの**モデルピッカー**：テキスト、視覚、画像（Nano Banana / Imagen 4）、Veo 動画、TTS、文字起こし\n- [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — OpenAI、ノードごとの**モデルピッカー**：`gen_text`、画像生成/編集/融合（`gpt-image-2`）、視覚、ドキュメント OCR、Whisper 文字起こし、TTS\n- [tongflow-api-deepseek](https://github.com/tong-io/tongflow-api-deepseek) — DeepSeek V4（`flash` / `pro`、ストリーミング**思考**バブル付き）ベースの `gen_text` およびテキストツール\n- [tongflow-api-bytedance](https://github.com/tong-io/tongflow-api-bytedance) — ByteDance Volcengine Ark、ノードごとの**モデルピッカー**：Doubao テキスト・視覚、Seedream 画像生成/編集/融合、Seedance テキスト / 画像 / 音声 → 動画\n- [tongflow-api-xai](https://github.com/tong-io/tongflow-api-xai) — xAI Grok、ノードごとの**モデルピッカー**：`gen_text`（Grok 4.x）、画像理解、Grok Imagine テキスト→画像\n- [tongflow-api-agnes](https://github.com/tong-io/tongflow-api-agnes) — Agnes AI：`gen_text` / テキストツール / 画像理解（`agnes-2.0-flash`）、画像生成 / 編集 / 融合（`agnes-image-2.x-flash`）、テキスト / 画像 / 最初・最後フレーム → 動画（`agnes-video-v2.0`）\n- [tongflow-api-runway](https://github.com/tong-io/tongflow-api-runway) — Runway Dev 統合 API、ノードごとの**モデルピッカー**：動画（Gen-4.5、Gen-4 Turbo、Aleph 編集、Act-Two、Seedance、Veo）、画像（GPT Image 2、Seedream 5、Gemini image 3）、ElevenLabs TTS"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "公式プラグイン › ルーター / 集約プラグイン › ルーター / 集約プラグイン",
+            "body": "1 つの key で複数ラボのモデルを転送：\n\n- [tongflow-router-openrouter](https://github.com/tong-io/tongflow-router-openrouter) — OpenRouter、ノードごとの**モデルピッカー**：`gen_text`（デフォルト無料、GPT-5.5 / Claude / Gemini / Grok / DeepSeek も選択可）、視覚 / 音声理解、画像生成/編集、文字起こし\n- [tongflow-router-apimart](https://github.com/tong-io/tongflow-router-apimart) — APIMart ゲートウェイ。ノード上で**モデルを選択**可能：画像生成 / 編集（Z-Image、Seedream、Nano Banana、GPT-Image）、テキスト / 画像 → 動画（Kling、VEO3、Sora2、Seedance）、`gen_text`（GPT-5、Claude、Gemini）、Whisper 文字起こしと TTS\n- [tongflow-router-replicate](https://github.com/tong-io/tongflow-router-replicate) — Replicate、ノードごとの**モデルピッカー**でカタログ全体をカバー：テキスト、視覚、画像 生成/編集/融合/アップスケール/切り抜き、テキスト / 画像 → 動画、文字起こし、TTS / ボイスクローン、音楽、画像 → 3D（FLUX、Seedream、Veo、Kling、Whisper、Hunyuan3D…）\n- [tongflow-router-fal](https://github.com/tong-io/tongflow-router-fal) — fal.ai、ノードごとの**モデルピッカー**：画像（生成/編集/融合/アップスケール/切り抜き/ポーズ/法線/セグメンテーション）、動画（テキスト / 画像 → 動画、最初・最後フレーム、トーキングヘッド、リップシンク、アップスケール）、音声（文字起こし、TTS、ボイスクローン、音楽、音源分離）、画像 → 3D"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "公式プラグイン › GPU/CPU プラグイン › GPU/CPU プラグイン",
+            "body": "- [tongflow-modal-ffmpeg](https://github.com/tong-io/tongflow-modal-ffmpeg) — トランスコード、ミキシング、メディア処理パイプライン\n- [tongflow-modal-pyscenedetect](https://github.com/tong-io/tongflow-modal-pyscenedetect) — ショット境界の検出、クリップ分割用\n- [tongflow-modal-z-image](https://github.com/tong-io/tongflow-modal-z-image) — Z-Image テキストから画像生成\n- [tongflow-modal-ernie-image](https://github.com/tong-io/tongflow-modal-ernie-image) — ERNIE Image テキストから画像生成（代替）\n- [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — FLUX.2 Klein 9B マルチ参照融合と画像編集\n- [tongflow-modal-boogu](https://github.com/tong-io/tongflow-modal-boogu) — Boogu-Image-0.1（fp8）テキストから画像生成（高密度な多言語テキスト）と単一参照画像編集\n- [tongflow-modal-ltx](https://github.com/tong-io/tongflow-modal-ltx) — LTX-2.3 テキスト / 画像から動画生成\n- [tongflow-modal-fastwan](https://github.com/tong-io/tongflow-modal-fastwan) — FastWan-QAD-FP8 高速テキストから動画生成（3 ステップ蒸留 Wan2.1-1.3B）\n- [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk 音声駆動リップシンク（音声 + 画像 / 動画 → デジタルヒューマン動画）\n- [tongflow-modal-wan-animate](https://github.com/tong-io/tongflow-modal-wan-animate) — Wan-Animate キャラクター置換とモーション転送（動画 + 参照）\n- [tongflow-modal-scail2](https://github.com/tong-io/tongflow-modal-scail2) — SCAIL-2 制御可能なキャラクターアニメーション（画像 + 駆動動画；wan-animate と同じ 2 スロット）\n- [tongflow-modal-bernini](https://github.com/tong-io/tongflow-modal-bernini) — Bernini-R 1.3B 統合動画レンダラー（テキスト/画像 → 画像/動画、動画編集、字幕 / ウォーターマーク除去）\n- [tongflow-modal-sam3](https://github.com/tong-io/tongflow-modal-sam3) — SAM 3 / SAM 3.1 テキスト誘導マッティング：記述した概念の全インスタンスを画像から切り抜き（透過 PNG）、動画では全編トラッキング（グリーンバック出力）\n- [tongflow-modal-triposplat](https://github.com/tong-io/tongflow-modal-triposplat) — TripoSplat 1 枚の画像から 3D ガウシアンスプラット\n- [tongflow-modal-sam-3d-objects](https://github.com/tong-io/tongflow-modal-sam-3d-objects) — SAM 3D Objects 1 枚の画像から前景オブジェクトの 3D ガウシアンスプラットを再構築（自動マスク、オクルージョンに強い；代替）\n- [tongflow-modal-sam-3d-body](https://github.com/tong-io/tongflow-modal-sam-3d-body) — SAM 3D Body 1 枚の画像から全身 3D 人体メッシュ GLB（複数人、MHR リグ；代替）、および**動画モーションキャプチャ**（フレーム毎 MHR 回帰 → キャラクターアニメーション GLB；代替）\n- [tongflow-modal-sapiens2](https://github.com/tong-io/tongflow-modal-sapiens2) — Sapiens2（Meta）人体スイート：ポーズ検出、身体部位セグメンテーション、表面法線、人物マッティング、画像 → 3D 点群、**動画モーションキャプチャ**（幾何エンジン：キーポイント + pointmap → MHR キャラクターアニメーション GLB）\n- [tongflow-modal-sensenova-vision](https://github.com/tong-io/tongflow-modal-sensenova-vision) — SenseNova-Vision（SenseTime）統一ビジョンモデル：画像理解 / ビジュアル QA、検出・OCR の構造化テキスト、シーン全体の表面法線、顕著オブジェクトの…"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "ソースコードから起動 › ソースコードから起動",
+            "body": "```bash\npnpm install\npnpm plugins:install   # 公式プラグインを plugins/ にクローン\npnpm start:prod        # 一度ビルドしてから http://localhost:3000 で起動\n```\n\n**Node**（`pnpm` を含む）と、`PATH` 上に **Python 3.10+** インタープリタが必要です（`PYTHON` で特定のものを指定可能）。プラグインはローカルのPythonプロセスとして実行されます。TongFlow は自動的に各プラグイン用の隔離された venv を作成し、初回利用時に各プラグインの `requirements.txt` をインストールします——Pythonの手動設定は不要です。\n\n**`http://localhost:3000`** を開けば、キャンバスがすぐに使えます。その後は[セルフホストのセットアップ](#セルフホストのセットアッププラグインと認証情報)に従って設定してください（認証情報はアプリ内の**設定**ダイアログ、またはプロジェクトの `.env` に入力）。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "Docker で起動 › Docker で起動",
+            "body": "セルフホスト用イメージが GHCR に公開されています——Node/Python/pnpm のセットアップは不要です：\n\n```bash\ndocker run -d -p 3000:3000 \\\n  -v tongflow-data:/data -v tongflow-plugins:/plugins \\\n  ghcr.io/tong-io/tongflow:latest\n```\n\nその後 **`http://localhost:3000`** を開きます。または Compose で（本リポジトリの [`docker-compose.yml`](../docker-compose.yml) をクローンします）：\n\n```bash\ndocker compose up -d\n```\n\nプルする代わりに自分でイメージをビルドするには：`docker build -t tongflow .`\n\n**データと認証情報。** 書き込み可能なものはすべて `/data` ボリュームに保存されます（SQLite DB、アップロード、設定）。API キーは任意です——アプリ内の**設定**ダイアログで設定するか、起動時に渡します（`-e OPENROUTER_API_KEY=…`）。対応キー：`OPENROUTER_API_KEY`、`GEMINI_API_KEY`、`OPENAI_API_KEY`、`MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`。\n\n**プラグイン。** イメージにはプラグインが含まれていません——アプリ内のプラグインマネージャーからインストールしてください（初回インストールには GitHub へのネットワークアクセスが必要）。初回実行時、プラグインは `/data/.tongflow/plugin-venv` の下に共有 Python venv を作成します（PyPI から SDK とそのプラグインの `requirements.txt` をインストール）。そのため初回実行は遅く、ネットワークが必要です。Modal ベースのプラグインにはさらに Modal トークンが必要です。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "セルフホストのセットアップ（プラグインと認証情報） › セルフホストのセットアップ（プラグインと認証情報）",
+            "body": "セルフホストの TongFlow はプラグインを一切同梱しておらず、キャンバスにはサンプルワークフローがあらかじめ読み込まれています。以下の3ステップで動かせます："
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "セルフホストのセットアップ（プラグインと認証情報） › 1 — プラグインをインストール › 1 — プラグインをインストール",
+            "body": "**プラグインマネージャー**（右上の四角いアイコン）を開き、必要に応じてインストールしてください。新しくインストールしたプラグインは再起動不要で即座に利用できます。\n\nあらかじめ読み込まれた**サンプルワークフロー**（テキスト → 画像 → 融合 → 動画）を実行するには、以下の3つのプラグインが必要です：\n\n- [tongflow-modal-z-image](https://github.com/tong-io/tongflow-modal-z-image) — テキストから画像生成\n- [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — 画像の融合 / ミックス\n- [tongflow-modal-ltx](https://github.com/tong-io/tongflow-modal-ltx) — 画像から動画生成\n\nこれらのプラグインは [Modal](https://modal.com) 上で動作します（毎月最大 **$30** 分の無料GPU演算）。**設定**で `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` を入力してください。トークンは [modal.com/settings/tokens](https://modal.com/settings/tokens) で作成できます。他のどのプラットフォームでも同じ方法で自分のプラグインを公開できます。\n\nプラグインマネージャーでは完全なカタログを閲覧できます——公式API プラグイン（OpenAI / Gemini / OpenRouter）やその他のGPU/CPUプラグインなど。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "セルフホストのセットアップ（プラグインと認証情報） › 2 — 認証情報を設定 › 2 — 認証情報を設定",
+            "body": "**設定**（右上の歯車アイコン）を開き、プラグインが必要とする環境変数を入力します——たとえばAPIプラグイン用の `OPENAI_API_KEY` や、GPU/CPUプラグインに必要な認証情報など。\n\n> **プラグインの認証情報はすべて「設定」にあります。** TongFlow は特定のプラットフォームに縛られず、どのプロバイダーもハードコードしていません。設定ダイアログは汎用的な環境変数の key/value エディタで、その値がプラグインに渡されます。各プラグインがどのキーを必要とするかは、それぞれの README に記載されています。値はローカルに保存され、変更は即座に反映され、再起動は不要です。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "セルフホストのセットアップ（プラグインと認証情報） › 3 — サンプルワークフローを実行 › 3 — サンプルワークフローを実行",
+            "body": "あらかじめ読み込まれたサンプルをノードごとに実行することも、実行モードに切り替えて実行ボタンをクリックし、一括で実行することもできます。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "カスタムプラグイン › カスタムプラグイン",
+            "body": "キャンバス上で動作するすべてのノードの背後には、**契約**——ABI（[`config/tongflow.abi.json`](../config/tongflow.abi.json)）があります。これは「どんな能力があるか」と「各能力の入出力がどんな形か」を定義し、「誰が実装するか」とは無関係です。プラグインとは小さなPythonパッケージで、ABI の中の1つまたは複数のスロットを選び、tongflow Python SDK を使って、ABI から生成された型で**どう実装するか**の部分を提供します。\n\n完全な開発フロー——ABI、`@node_slot` デコレータ、SDK、ディレクトリ構造、公開方法については **[docs/plugins.md](plugins.md)** を参照してください。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "コミュニティ › コミュニティ",
+            "body": "**[Discord](https://discord.gg/K7V8az94Zf)** に参加するか、下記の**WeChatグループ**のQRコードをスキャンしてください。\n\n<div>\n  <img src=\"assets/qr.png\" alt=\"WeChatグループQRコード\" width=\"180\" />\n</div>"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "ビジネス協業 › ビジネス協業",
+            "body": "ビジネス協業については business@tongflow.com までお問い合わせください。\n\n- **オープンソースモデルのオーナー**：あなたのモデルを統合し、ユーザーにスムーズな体験を提供できます。\n- **エンタープライズユーザー**：ローカルGPUへのデプロイ、カスタムノードやプラグインの構築などを支援できます。\n- **プラットフォーム / ルーター**：あなたのAPIを接続できます。\n- **VC**：[tongflow.com](https://tongflow.com) のクラウドAIスタジオでの協業をぜひご相談ください。"
+        },
+        {
+            "source": "docs/README_JA.md",
+            "heading": "Star 履歴 › Star 履歴",
+            "body": "<a href=\"https://www.star-history.com/?repos=tong-io%2Ftongflow&type=date&legend=top-left\">\n <picture>\n   <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&theme=dark&legend=top-left\" />\n   <source media=\"(prefers-color-scheme: light)\" srcset=\"https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left\" />\n   <img alt=\"Star History Chart\" src=\"https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left\" />\n </picture>\n</a>"
+        }
+    ]
+}

--- a/src/generated/agent-docs/zh.json
+++ b/src/generated/agent-docs/zh.json
@@ -1,0 +1,139 @@
+{
+    "chunks": [
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "",
+            "body": "<div align=\"center\">\n  <img src=\"../public/logo.svg\" alt=\"TongFlow\" width=\"320\" />\n\n  <h1>TongFlow：开源多模态 GenAI 工作流工作室</h1>\n  <p>\n    <a href=\"https://github.com/tong-io/tongflow/stargazers\"><img src=\"https://img.shields.io/github/stars/tong-io/tongflow?style=flat&logo=github\" alt=\"GitHub Stars\" /></a>\n    <a href=\"https://github.com/tong-io/tongflow/blob/main/LICENSE\"><img src=\"https://img.shields.io/badge/License-AGPL--3.0-blue.svg\" alt=\"License\" /></a>\n    <a href=\"https://github.com/tong-io/tongflow/actions/workflows/ci.yml\"><img src=\"https://github.com/tong-io/tongflow/actions/workflows/ci.yml/badge.svg\" alt=\"CI\" /></a>\n    <a href=\"https://pypi.org/project/tongflow/\"><img src=\"https://img.shields.io/pypi/v/tongflow?logo=pypi&logoColor=white&label=Python%20SDK\" alt=\"PyPI\" /></a>\n    <a href=\"https://discord.gg/K7V8az94Zf\"><img src=\"https://img.shields.io/badge/Discord-加入-5865F2?logo=discord&logoColor=white\" alt=\"Discord\" /></a>\n    <a href=\"https://github.com/tong-io/tongflow/releases\"><img src=\"https://img.shields.io/github/v/release/tong-io/tongflow?logo=github\" alt=\"最新版本\" /></a>\n  </p>\n  <p>\n    <video src=\"https://github.com/user-attachments/assets/407a7e7b-2d44-4c90-8016-33d0a9f5e7d5\"></video>\n  <p>\n  <p>\n    <a href=\"../README.md\">English</a> · <strong>简体中文</strong> · <a href=\"README_JA.md\">日本語</a>\n  </p>\n</div>"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "Demo 示例 › Demo 示例",
+            "body": "| 工作流截图 | 输出结果 |\n| :--: | :--: |\n| **基本** — 输入文本（添加），生成图像（转换），再融合成一张（组合）。<br/><img src=\"https://file.tongflow.com/public/demos/basic.png\" width=\"620\" alt=\"工作流\" /> | <img src=\"https://file.tongflow.com/public/demos/basic_result.png\" width=\"200\" alt=\"结果\" /> |\n| **中级** — （添加主题 → 生成文案 → 生成语音） + （人物描述 → 生成图像） → 生成对口型视频 = 数字人口播。<br/><img src=\"https://file.tongflow.com/public/demos/digitalhuman.png\" width=\"620\" alt=\"工作流\" /> | <video src=\"https://github.com/user-attachments/assets/a803394d-0ccf-4023-9b06-5c1581345758\" width=\"200\"></video> |\n| **高级** — 生成歌词 + 生成歌曲 + 生成人物 + 生成场景 + 生成分镜 → 生成MV<br/><img src=\"https://file.tongflow.com/public/demos/mv.png\" width=\"620\" alt=\"工作流\" /> | <video src=\"https://github.com/user-attachments/assets/2bc71e3c-3ed6-48b2-81e7-82ad5976d801\" width=\"200\"></video> |\n\n用TongFlow借助生成式AI释放想创意！"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "快速开始 › 快速开始",
+            "body": "TongFlow **桌面版**是一个轻量（约 10 MB）的壳应用，直接加载云端工作室 **[app.tongflow.com](https://app.tongflow.com)** ——安装、登录，即可开始创作。云端工作室也可以直接在浏览器里打开。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "快速开始 › Step 1 — 安装桌面版 › Step 1 — 安装桌面版",
+            "body": "下载对应平台的安装包，安装并打开。\n\n- **macOS（Universal — Apple Silicon 和 Intel 通用）：** [TongFlow-mac-universal.dmg](https://github.com/tong-io/tongflow/releases/latest/download/TongFlow-mac-universal.dmg)\n- **Windows：** [TongFlow-win-x64.msi](https://github.com/tong-io/tongflow/releases/latest/download/TongFlow-win-x64.msi)\n\n全部版本见 [Releases](https://github.com/tong-io/tongflow/releases/latest) 页面。\n\n> **macOS 用户注意：** 安装包暂未经过 Apple 公证，首次打开会被 Gatekeeper 拦截（提示\"TongFlow 已损坏，无法打开\"）。把 app 拖入「应用程序」后，在终端执行一次以下命令即可正常打开：\n>\n> ```bash\n> xattr -cr /Applications/TongFlow.app\n> ```\n>\n> 请直接从本页面下载安装包——通过微信等聊天工具转发的安装包可能被改名或重新打上隔离标记。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "快速开始 › Step 2 — 登录并开始创作 › Step 2 — 登录并开始创作",
+            "body": "用 Google 或微信登录即可开始创作——插件与执行都由云端托管。\n\n> **想要完全本地、无需账号的 TongFlow？** 请使用自托管——参见[从源代码启动](#从源代码启动)或[用 Docker 启动](#用-docker-启动)，然后按照[自托管配置](#自托管配置插件与凭据)完成设置。（v0.1.13 及之前的桌面版内置了完整本地运行时，安装包仍保留在 [Releases](https://github.com/tong-io/tongflow/releases) 页面。）"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "核心概念 › 核心概念",
+            "body": "- **全模型**: AI 模型可理解为**模态转换**（例如 LLM 是文本→文本，图像模型是文本→图像，语音模型是文本→音频等）。TongFlow 将每种能力封装为节点。\n\n- **全模态**: TongFlow 支持 Web 上实际流通的几乎所有模态与文件格式。\n\n- **低门槛，高可能性**: 无需学习复杂的AI参数，无需手动连接节点；只需**添加**、**转换**和**组合**三种操作，就能自由排列创意。同时，通过对AI模型的自由编排，可以生成独有的创意和作品。\n\n- **开放生态**: TongFlow 基于插件的设计，使得每个平台都可以封装独立的插件，官方将对每个能力节点提供至少一个实现插件。核心精简，生态开放。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "已实现功能 › 已实现功能",
+            "body": "> ✅ = 开箱即用（已有官方插件）· ⬜ = 画布中已有节点，但暂无官方插件（规划中）。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "已实现功能 › 添加 › 添加",
+            "body": "- ✅ **文本输入**: 输入文字并添加文本节点。\n- ✅ **添加图片**: 选择本地文件并添加图片节点。\n- ✅ **拍照**: 用设备摄像头拍摄并添加图片节点。\n- ✅ **添加草图**: 在画布上绘制并添加图片节点。\n- ✅ **添加音频**: 选择本地音频文件并添加音频节点。\n- ✅ **录音**: 用麦克风录音并添加音频节点。\n- ✅ **添加视频**: 选择本地视频文件并添加视频节点。\n- ✅ **录制视频**: 用摄像头录制并添加视频节点。\n- ✅ **添加文档**: 选择本地文件并添加文档节点。\n- ✅ **添加链接**: 从链接抓取页面，添加文本、图片、音频或视频节点。\n- ✅ **添加 3D 模型**: 选择本地模型文件并添加 3D 模型节点。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "已实现功能 › 转换 › 转换",
+            "body": "#### 文本\n\n- ✅ **生成 / 改写**: 根据提示创建或编辑文案。\n\n#### 图像\n\n- ✅ **图像生成**: 从文本生成图像。\n- ✅ **图像编辑**: 局部重绘、编辑或按指令重画。\n- ✅ **图像理解**: 从图像生成描述、问答或说明。\n- ✅ **图像超分**: 放大以获得更清晰的细节。\n- ✅ **姿态检测**: 308 关键点全身骨架叠加（身体、双手、脸部）。\n- ✅ **人体部位分割**: 29 类人体解析叠加图。\n- ✅ **表面法线**: 逐像素法线图——人物特写或整幅场景均可。\n- ✅ **前景抠图**: 将人物或显著主体抠为透明 PNG。\n\n#### 视频\n\n- ✅ **视频生成**: 从文本生成视频。\n- ✅ **图生视频**: 将静态图像动态化。\n- ✅ **首尾帧视频**: 用两张关键帧插值生成片段。\n- ✅ **多图生视频**: 多图参考融合——若干参考图加文本生成全新视频。\n- ✅ **视频理解**: 从视频生成摘要或描述。\n- ✅ **视频超分**: 输出更高分辨率的视频。\n- ✅ **提取首帧 / 尾帧**: 将帧提取为图片。\n- ✅ **视频编辑**: 根据文本指令编辑视频。\n- ✅ **去字幕**: 从视频中清除字幕。\n- ✅ **去水印**: 从视频中去除水印。\n\n#### 音频\n\n- ✅ **音乐生成**: 从文本生成音乐，可选参考音频引导。\n- ✅ **音频理解**: 用文字描述一段音频（音乐 / 语音 / 环境音）。\n- ✅ **音乐重绘**: 重新生成歌曲中指定的时间段。\n- ✅ **音乐翻唱**: 按描述或参考曲目改编歌曲风格。\n- ✅ **加轨 / 补全编曲**: 在现有音乐上生成新乐轨，或补全缺失的声部。\n- ✅ **音乐企划**: 一句话灵感 → 歌词、风格标签、BPM、调式、时长。\n- ✅ **语音合成**: 文字转语音——预设风格、声音克隆（参考音频）或指令驱动。\n- ✅ **语音识别**: 转录音频或视频中的语音。\n- ✅ **降噪**: 对音频降噪处理。\n- ⬜ **说话人分离**: 按说话人分离音频。\n- ⬜ **音色转换**: 使用参考样本替换或克隆音色。\n- ✅ **多轨 / 人声伴奏分离**: 分离人声、鼓、贝斯、吉他等 12 种乐轨。\n- ✅ **开放词汇声音分离**: 用一句话描述任意声音（“狗叫”），把它和其余声音拆成两轨。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "已实现功能 › 组合 › 组合",
+            "body": "- ✅ **图像融合**: 将多张参考图融合或编辑为一张图。\n- ✅ **口型同步**: 音频 + 视频 → 视频（口型同步）；也支持音频 + 图片 → 视频、音频 + 文本 → 视频等变体。\n- ✅ **换角色**: 视频 + 参考（场景融合 / 角色替换），Animate Mix 风格生成。\n- ✅ **动作迁移**: 视频 + 参考（动作 / 重定向），Animate Move 风格生成。\n- ✅ **文本合并**: 将多个文本节点合并为一个。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "已实现功能 › 其他 › 其他",
+            "body": "- ✅ **图像 → 3D**: 从单张图像生成 3D 模型。\n- ✅ **视频 → 动作捕捉**: 单目视频转骨骼动画（身体 + 手指 + 表情通道，GLB）。\n- ✅ **文档 → 文本**: 从文档中提取纯文本。\n- ✅ **链接 → 文本**: 将页面内容转换为文本。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "已实现功能 › 辅助工具 › 辅助工具",
+            "body": "- ✅ **拼接片段**: 将多个视频首尾相接。\n- ✅ **音视频合并**: 合并为单个文件。\n- ✅ **按镜头分割**: 按场景将长视频切分。\n- ✅ **拆分音视频**: 将视频解封装为独立的视频轨和音频轨。\n- ✅ **提取音轨**: 将音频单独导出为资源。\n- ✅ **分割长文本**: 将长段落拆分为块。\n- ✅ **合并 / 整理文本块**: 合并片段（可使用自动合并选项）。\n- ✅ **过滤 / 丢弃片段**: 按规则或手动选择丢弃不需要的片段。\n- ✅ **排列与批量分组**: 对文本或片段批次进行分组排列，供下游处理使用。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "官方插件 › 官方插件",
+            "body": "> 官方 GPU/CPU 插件目前运行在 [Modal](https://modal.com) 上——每月最多 **$30** 免费 GPU 算力（H100/A100 等）。`MODAL_TOKEN_*` 的配置见[自托管配置](#自托管配置插件与凭据)。任何其他平台都可以用同样方式发布自己的插件。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "官方插件 › API 插件 › API 插件",
+            "body": "一线厂商（各自发布自研模型）：\n\n- [tongflow-api-gemini](https://github.com/tong-io/tongflow-api-gemini) — Google Gemini，按节点**模型选择**：文本、视觉、图像（Nano Banana / Imagen 4）、Veo 视频、TTS 与转写\n- [tongflow-api-openai](https://github.com/tong-io/tongflow-api-openai) — OpenAI，按节点**模型选择**：`gen_text`、图像生成/编辑/融合（`gpt-image-2`）、视觉、文档 OCR、Whisper 转写与 TTS\n- [tongflow-api-deepseek](https://github.com/tong-io/tongflow-api-deepseek) — 基于 DeepSeek V4（`flash` / `pro`，带流式**思考**气泡）的 `gen_text` 及文本工具\n- [tongflow-api-bytedance](https://github.com/tong-io/tongflow-api-bytedance) — 火山方舟，按节点**模型选择**：豆包文本与视觉、Seedream 图像生成/编辑/融合、Seedance 文 / 图 / 音 → 视频\n- [tongflow-api-xai](https://github.com/tong-io/tongflow-api-xai) — xAI Grok，按节点**模型选择**：`gen_text`（Grok 4.x）、图像理解、Grok Imagine 文生图\n- [tongflow-api-agnes](https://github.com/tong-io/tongflow-api-agnes) — Agnes AI：`gen_text` / 文本工具 / 图像理解（`agnes-2.0-flash`）、图像生成 / 编辑 / 融合（`agnes-image-2.x-flash`）、文 / 图 / 首尾帧 → 视频（`agnes-video-v2.0`）\n- [tongflow-api-runway](https://github.com/tong-io/tongflow-api-runway) — Runway Dev 统一 API，按节点**模型选择**：视频（Gen-4.5、Gen-4 Turbo、Aleph 编辑、Act-Two、Seedance、Veo）、图像（GPT Image 2、Seedream 5、Gemini image 3）与 ElevenLabs TTS"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "官方插件 › 中转 / 聚合插件 › 中转 / 聚合插件",
+            "body": "一个 key 转发多家厂商模型：\n\n- [tongflow-router-openrouter](https://github.com/tong-io/tongflow-router-openrouter) — OpenRouter，按节点**模型选择**：`gen_text`（默认免费，另可选 GPT-5.5 / Claude / Gemini / Grok / DeepSeek）、视觉 / 音频理解、图像生成/编辑与转写\n- [tongflow-router-apimart](https://github.com/tong-io/tongflow-router-apimart) — APIMart 聚合网关，支持节点上**按模型选择**：图像生成 / 编辑（Z-Image、Seedream、Nano Banana、GPT-Image）、文 / 图 → 视频（可灵、VEO3、Sora2、Seedance）、`gen_text`（GPT-5、Claude、Gemini）、Whisper 转录与 TTS\n- [tongflow-router-replicate](https://github.com/tong-io/tongflow-router-replicate) — Replicate，按节点**模型选择**覆盖全目录：文本、视觉、图像 生成/编辑/融合/放大/抠图、文 / 图 → 视频、转写、TTS / 声音克隆、音乐、图 → 3D（FLUX、Seedream、Veo、Kling、Whisper、Hunyuan3D…）\n- [tongflow-router-fal](https://github.com/tong-io/tongflow-router-fal) — fal.ai，按节点**模型选择**：图像（生成/编辑/融合/放大/抠图/姿态/法线/分割）、视频（文 / 图 → 视频、首尾帧、说话头、唇同步、放大）、音频（转写、TTS、声音克隆、音乐、声源分离）与 图 → 3D"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "官方插件 › GPU/CPU 插件 › GPU/CPU 插件",
+            "body": "- [tongflow-modal-ffmpeg](https://github.com/tong-io/tongflow-modal-ffmpeg) — 转码、混流、媒体处理管线\n- [tongflow-modal-pyscenedetect](https://github.com/tong-io/tongflow-modal-pyscenedetect) — 镜头边界检测，用于分割片段\n- [tongflow-modal-z-image](https://github.com/tong-io/tongflow-modal-z-image) — Z-Image 文本生图\n- [tongflow-modal-ernie-image](https://github.com/tong-io/tongflow-modal-ernie-image) — ERNIE Image 文本生图（备选）\n- [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — FLUX.2 Klein 9B 多参考融合与图像编辑\n- [tongflow-modal-boogu](https://github.com/tong-io/tongflow-modal-boogu) — Boogu-Image-0.1（fp8）文本生图（密集中英文字）与单图编辑\n- [tongflow-modal-ltx](https://github.com/tong-io/tongflow-modal-ltx) — LTX-2.3 文本 / 图像生视频\n- [tongflow-modal-fastwan](https://github.com/tong-io/tongflow-modal-fastwan) — FastWan-QAD-FP8 极速文生视频（3 步蒸馏 Wan2.1-1.3B）\n- [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk 音频驱动口型同步（音频 + 图片 / 视频 → 数字人视频）\n- [tongflow-modal-wan-animate](https://github.com/tong-io/tongflow-modal-wan-animate) — Wan-Animate 换角色与动作迁移（视频 + 参考）\n- [tongflow-modal-scail2](https://github.com/tong-io/tongflow-modal-scail2) — SCAIL-2 可控角色动画（角色图 + 驱动视频；与 wan-animate 相同的两个槽位）\n- [tongflow-modal-bernini](https://github.com/tong-io/tongflow-modal-bernini) — Bernini-R 1.3B 统一视频渲染器（文/图 → 图/视频、视频编辑、去字幕 / 去水印）\n- [tongflow-modal-sam3](https://github.com/tong-io/tongflow-modal-sam3) — SAM 3 / SAM 3.1 文本引导抠像：按描述抠出图像中某概念的全部实例（透明 PNG），或在视频中全程跟踪（绿幕输出）\n- [tongflow-modal-triposplat](https://github.com/tong-io/tongflow-modal-triposplat) — TripoSplat 单图生成 3D 高斯泼溅\n- [tongflow-modal-sam-3d-objects](https://github.com/tong-io/tongflow-modal-sam-3d-objects) — SAM 3D Objects 单图重建前景物体 3D 高斯泼溅（自动抠前景，抗遮挡；备选）\n- [tongflow-modal-sam-3d-body](https://github.com/tong-io/tongflow-modal-sam-3d-body) — SAM 3D Body 单图重建全身人体 3D 网格 GLB（多人、MHR 骨骼；备选），以及**视频动作捕捉**（逐帧回归 MHR → 角色动画 GLB；备选）\n- [tongflow-modal-sapiens2](https://github.com/tong-io/tongflow-modal-sapiens2) — Sapiens2（Meta）人体套件：姿态检测、人体部位分割、表面法线、人像抠图、图像 → 3D 点云，以及**视频动作捕捉**（几何引擎：关键点 + pointmap → MHR 角色动画 GLB）\n- [tongflow-modal-sensenova-vision](https://github.com/tong-io/tongflow-modal-sensenova-vision) — SenseNova-Vision（商汤）统一视觉模型：图像理解 / 看图问答、检测与 OCR 结构化文本、全场景表面法线、显著主体抠图、人体姿态叠加（备选）\n- [tongflow-modal-seedvr2](https://github.com/tong-io/tongflow-modal-seedvr2) — SeedVR2 图像 / 视频超分辨率\n- [tongflow-modal-gemma4](https://github.com/tong-io/tongflow-modal-gemma4) — Gemma-4 多模态文本（图像 / 视频理解）\n- [tongflow-modal-qwen3as…"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "从源代码启动 › 从源代码启动",
+            "body": "```bash\npnpm install\npnpm plugins:install   # 克隆官方插件到 plugins/\npnpm start:prod        # 先构建一次,再启动于 http://localhost:3000\n```\n\n需要 **Node**（含 `pnpm`）以及 `PATH` 上有一个 **Python 3.10+** 解释器（可用 `PYTHON` 指定具体的那个）。插件以本地 Python 进程运行；TongFlow 会自动为它们创建隔离的 venv，并在首次使用时安装各插件的 `requirements.txt`——无需手动配置 Python。\n\n打开 **`http://localhost:3000`**，画布已就绪。然后按照[自托管配置](#自托管配置插件与凭据)完成设置（凭据填在 app 内的**设置**对话框，或用项目 `.env`）。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "用 Docker 启动 › 用 Docker 启动",
+            "body": "GHCR 上已发布自托管镜像——无需配置 Node/Python/pnpm：\n\n```bash\ndocker run -d -p 3000:3000 \\\n  -v tongflow-data:/data -v tongflow-plugins:/plugins \\\n  ghcr.io/tong-io/tongflow:latest\n```\n\n然后打开 **`http://localhost:3000`**。或者用 Compose（会克隆本仓库的 [`docker-compose.yml`](../docker-compose.yml)）：\n\n```bash\ndocker compose up -d\n```\n\n想自己构建镜像而不是拉取：`docker build -t tongflow .`\n\n**数据与凭据。** 所有可写内容都存放在 `/data` 卷（SQLite 数据库、上传文件、设置）。API key 是可选的——在 app 内的**设置**对话框里填写，或在启动时传入（`-e OPENROUTER_API_KEY=…`）；支持的 key：`OPENROUTER_API_KEY`、`GEMINI_API_KEY`、`OPENAI_API_KEY`、`MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`。\n\n**插件。** 镜像不自带任何插件——请从 app 内的插件管理器安装（首次安装需要访问 GitHub 的网络）。首次运行时，插件会在 `/data/.tongflow/plugin-venv` 下创建一个共享的 Python venv（从 PyPI 安装 SDK 以及该插件的 `requirements.txt`），因此首次运行较慢且需要网络。基于 Modal 的插件还需要一个 Modal token。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "自托管配置（插件与凭据） › 自托管配置（插件与凭据）",
+            "body": "自托管的 TongFlow 默认不预装任何插件，画布已预加载一个示例工作流。三步即可跑起来："
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "自托管配置（插件与凭据） › 1 — 安装插件 › 1 — 安装插件",
+            "body": "打开**插件管理器**（右上角的方块图标），按需安装。新装的插件即时可用，无需重启。\n\n要运行预加载的**示例工作流**（文本 → 图像 → 融合 → 视频），需安装以下三个插件：\n\n- [tongflow-modal-z-image](https://github.com/tong-io/tongflow-modal-z-image) — 文本生图\n- [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — 图像融合 / 混合\n- [tongflow-modal-ltx](https://github.com/tong-io/tongflow-modal-ltx) — 图生视频\n\n这些插件运行在 [Modal](https://modal.com) 上（每月最多 **$30** 免费 GPU 算力）。在**设置**里填入 `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`；可在 [modal.com/settings/tokens](https://modal.com/settings/tokens) 创建 token。任何其他平台都可以用同样方式发布自己的插件。\n\n在插件管理器里可浏览完整目录——官方 API 插件（OpenAI / Gemini / OpenRouter）以及其他 GPU/CPU 插件。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "自托管配置（插件与凭据） › 2 — 配置凭据 › 2 — 配置凭据",
+            "body": "打开**设置**（右上角齿轮图标），填入插件需要的环境变量——比如 API 插件用的 `OPENAI_API_KEY`，或 GPU/CPU 插件所需的凭据。\n\n> **插件凭据都在「设置」里。** TongFlow 不绑定任何平台、不硬编码任何 provider：设置对话框是一个通用的环境变量 key/value 编辑器，传给插件使用。各插件需要哪些 key 由它自己的 README 说明。值保存在本地，改动即时生效、无需重启。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "自托管配置（插件与凭据） › 3 — 运行示例工作流 › 3 — 运行示例工作流",
+            "body": "逐个节点执行预加载的示例，也可以切换到执行模式，点击运行按钮即可一键执行。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "自定义插件 › 自定义插件",
+            "body": "画布上每一个能跑的节点，背后都是一份**契约**——ABI（[`config/tongflow.abi.json`](../config/tongflow.abi.json)），它定义「有哪些能力」以及「每个能力的输入输出长什么样」，而与「由谁实现」无关。一个插件就是一个小小的 Python 包，挑 ABI 里一个或多个槽，借助 tongflow Python SDK，用 ABI 生成的类型给出**怎么做**的那部分。\n\n完整的开发流程——ABI、`@node_slot` 装饰器、SDK、目录结构以及如何发布，请见 **[docs/plugins.md](plugins.md)**。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "社区 › 社区",
+            "body": "加入 **[Discord](https://discord.gg/K7V8az94Zf)** 或扫描下方**微信群**二维码。\n\n<div>\n  <img src=\"assets/qr.png\" alt=\"微信群二维码\" width=\"180\" />\n</div>"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "商务合作 › 商务合作",
+            "body": "商务合作请联系 business@tongflow.com。\n\n- **开源模型 owner**：我可以集成你的模型，让用户流畅体验。\n- **企业用户**：我可以协助在本地 GPU 上部署、构建定制节点和插件等。\n- **平台 / 路由**：我可以接入你的 API。\n- **VCs**：欢迎探讨在 [tongflow.com](https://tongflow.com) 云端 AI 工作室上的合作。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "授权协议 › 授权协议",
+            "body": "TongFlow 采用 **双授权(dual-licensing)** 模式:\n\n- **[AGPL-3.0](../LICENSE)** —— 对个人、研究、开源项目,以及愿意遵守 AGPL(含第 13 条\n  网络/源码公开义务)的使用者**免费**。\n- **[商业授权](../COMMERCIAL-LICENSE.md)** —— 面向希望在**闭源 / SaaS** 产品中使用\n  TongFlow 且**不愿公开源码**,或需要保证条款与平台技术支持的组织。\n  价格面议,联系 **business@tongflow.com**。\n\n以上授权覆盖整个仓库,包括 `sdk/` 目录(发布到 PyPI 的 `tongflow` 包)。\n贡献代码受 [CLA](../CLA.md) 约束。"
+        },
+        {
+            "source": "docs/README_ZH.md",
+            "heading": "Star 历史 › Star 历史",
+            "body": "<a href=\"https://www.star-history.com/?repos=tong-io%2Ftongflow&type=date&legend=top-left\">\n <picture>\n   <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&theme=dark&legend=top-left\" />\n   <source media=\"(prefers-color-scheme: light)\" srcset=\"https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left\" />\n   <img alt=\"Star History Chart\" src=\"https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left\" />\n </picture>\n</a>"
+        }
+    ]
+}

--- a/src/hooks/use-agent-chat.ts
+++ b/src/hooks/use-agent-chat.ts
@@ -1,0 +1,440 @@
+"use client";
+
+/**
+ * Agent chat store: panel state + the client-side agentic loop.
+ *
+ * Each loop round POSTs the transcript to /api/agent/chat, renders streamed
+ * text live, executes tool calls against the canvas, appends their results
+ * and re-POSTs — until the model stops calling tools or MAX_AGENT_TURNS is
+ * reached. Session-only by design (no persistence in the MVP).
+ */
+
+import { create } from "zustand";
+import useFlow from "@/hooks/use-flow";
+import { useTaskStore } from "@/hooks/use-task";
+import { executeAgentTool } from "@/lib/agent/executor";
+import { renderCanvas } from "@/lib/agent/serialize";
+import type {
+    AgentAttachment,
+    AgentStreamEvent,
+    AgentToolCall,
+    AgentWireMessage,
+    ToolResult,
+} from "@/lib/agent/types";
+import { logger } from "@/lib/logger";
+
+const MAX_AGENT_TURNS = 16;
+/** Keep the transcript bounded; oldest tool payloads are dropped first. */
+const MAX_WIRE_MESSAGES = 40;
+
+const CANVAS_DIGEST_OPEN = "\n\n<canvas-state>\n";
+const CANVAS_DIGEST_CLOSE = "\n</canvas-state>";
+
+/* ------------------------------------------------------------------ */
+/* UI transcript model                                                 */
+/* ------------------------------------------------------------------ */
+
+export type AgentUiEntry =
+    | { kind: "user"; text: string; attachments?: AgentAttachment[] }
+    | { kind: "assistant"; text: string; streaming?: boolean }
+    | {
+          kind: "tool";
+          name: string;
+          args: Record<string, unknown>;
+          result?: ToolResult;
+      }
+    | { kind: "error"; code?: string; message: string };
+
+export type AgentStatus = "idle" | "streaming" | "executing";
+
+interface AgentChatState {
+    open: boolean;
+    status: AgentStatus;
+    entries: AgentUiEntry[];
+    /** OpenAI-shaped transcript sent to the route. */
+    wire: AgentWireMessage[];
+    attachments: AgentAttachment[];
+    pluginId: string;
+    model: string;
+    /** Set when the route answered 428 — drives the connect-provider card. */
+    missingEnvKey: string | null;
+
+    toggle: () => void;
+    setProvider: (pluginId: string, model: string) => void;
+    addAttachments: (files: AgentAttachment[]) => void;
+    removeAttachment: (index: number) => void;
+    send: (text: string) => Promise<void>;
+    stop: () => void;
+    clear: () => void;
+}
+
+/* ------------------------------------------------------------------ */
+/* Internals                                                           */
+/* ------------------------------------------------------------------ */
+
+let abortController: AbortController | null = null;
+
+/**
+ * The digest rides on the latest user message only: older copies are
+ * stripped before each request so the context never accumulates stale
+ * canvas snapshots.
+ */
+function stripDigest(content: string): string {
+    const at = content.indexOf(CANVAS_DIGEST_OPEN);
+    return at >= 0 ? content.slice(0, at) : content;
+}
+
+function buildDigest(attachments: AgentAttachment[]): string {
+    const { nodes, edges, selectedNodes } = useFlow.getState();
+    const statusByNodeId = useTaskStore.getState().nodeExecutionStatusMap;
+    const canvas = renderCanvas(nodes, edges, {
+        selectedIds: selectedNodes.map((n) => n.id),
+        statusByNodeId,
+        maxText: 60,
+    });
+    const attachmentLines =
+        attachments.length > 0
+            ? `\nattachments:\n${attachments
+                  .map(
+                      (a) =>
+                          `  #${a.index} ${a.modality} "${a.name}" (${a.mime})`,
+                  )
+                  .join("\n")}`
+            : "";
+    return `${CANVAS_DIGEST_OPEN}${canvas}${attachmentLines}${CANVAS_DIGEST_CLOSE}`;
+}
+
+/** Trim old messages, keeping user/assistant turns over bulky tool results. */
+function boundedWire(wire: AgentWireMessage[]): AgentWireMessage[] {
+    if (wire.length <= MAX_WIRE_MESSAGES) return wire;
+    const overflow = wire.length - MAX_WIRE_MESSAGES;
+    // Never split an assistant(tool_calls) from its tool results: drop whole
+    // leading spans until under budget.
+    let cut = 0;
+    let dropped = 0;
+    while (dropped < overflow && cut < wire.length) {
+        const msg = wire[cut];
+        cut++;
+        dropped++;
+        if (msg.role === "assistant" && msg.tool_calls?.length) {
+            while (cut < wire.length && wire[cut].role === "tool") {
+                cut++;
+                dropped++;
+            }
+        }
+    }
+    return wire.slice(cut);
+}
+
+async function* readSse(response: Response): AsyncGenerator<AgentStreamEvent> {
+    const reader = response.body?.getReader();
+    if (!reader) return;
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let sep = buffer.indexOf("\n\n");
+        while (sep >= 0) {
+            const frame = buffer.slice(0, sep);
+            buffer = buffer.slice(sep + 2);
+            sep = buffer.indexOf("\n\n");
+            const data = frame
+                .split("\n")
+                .filter((l) => l.startsWith("data: "))
+                .map((l) => l.slice("data: ".length))
+                .join("");
+            if (!data) continue;
+            try {
+                yield JSON.parse(data) as AgentStreamEvent;
+            } catch {
+                logger.warn("[agent] bad SSE frame:", data.slice(0, 200));
+            }
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Store                                                               */
+/* ------------------------------------------------------------------ */
+
+export const useAgentChat = create<AgentChatState>((set, get) => ({
+    open: false,
+    status: "idle",
+    entries: [],
+    wire: [],
+    attachments: [],
+    pluginId: "",
+    model: "",
+    missingEnvKey: null,
+
+    toggle: () => set((s) => ({ open: !s.open })),
+
+    setProvider: (pluginId, model) =>
+        set({ pluginId, model, missingEnvKey: null }),
+
+    addAttachments: (files) =>
+        set((s) => {
+            const base = s.attachments.length;
+            const withIndex = files.map((f, i) => ({
+                ...f,
+                index: base + i + 1,
+            }));
+            return { attachments: [...s.attachments, ...withIndex] };
+        }),
+
+    removeAttachment: (index) =>
+        set((s) => ({
+            attachments: s.attachments
+                .filter((a) => a.index !== index)
+                .map((a, i) => ({ ...a, index: i + 1 })),
+        })),
+
+    stop: () => {
+        abortController?.abort();
+        abortController = null;
+        set((s) => ({
+            status: "idle",
+            entries: s.entries.map((e) =>
+                e.kind === "assistant" ? { ...e, streaming: false } : e,
+            ),
+        }));
+    },
+
+    clear: () => {
+        abortController?.abort();
+        abortController = null;
+        set({
+            entries: [],
+            wire: [],
+            attachments: [],
+            status: "idle",
+            missingEnvKey: null,
+        });
+    },
+
+    send: async (text) => {
+        const state = get();
+        if (state.status !== "idle" || !text.trim()) return;
+        if (!state.pluginId) {
+            set({ missingEnvKey: "" });
+            return;
+        }
+
+        const turnId = crypto.randomUUID().slice(0, 8);
+        const attachments = state.attachments;
+
+        // Strip stale digests from history, attach a fresh one to this turn.
+        const history = state.wire.map((m) =>
+            m.role === "user" ? { ...m, content: stripDigest(m.content) } : m,
+        );
+        let wire: AgentWireMessage[] = boundedWire([
+            ...history,
+            { role: "user", content: text + buildDigest(attachments) },
+        ]);
+
+        set((s) => ({
+            status: "streaming",
+            missingEnvKey: null,
+            entries: [
+                ...s.entries,
+                {
+                    kind: "user",
+                    text,
+                    ...(attachments.length > 0 ? { attachments } : {}),
+                },
+            ],
+        }));
+
+        abortController = new AbortController();
+
+        try {
+            for (let turn = 0; turn < MAX_AGENT_TURNS; turn++) {
+                const { pluginId, model } = get();
+                const response = await fetch("/api/agent/chat", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    signal: abortController.signal,
+                    body: JSON.stringify({
+                        messages: wire,
+                        pluginId,
+                        model,
+                        locale: document.documentElement.lang || undefined,
+                    }),
+                });
+
+                if (!response.ok) {
+                    const err = (await response.json().catch(() => ({}))) as {
+                        error?: string;
+                        envKey?: string;
+                        message?: string;
+                    };
+                    if (response.status === 428) {
+                        set({ missingEnvKey: err.envKey ?? "" });
+                    } else {
+                        set((s) => ({
+                            entries: [
+                                ...s.entries,
+                                {
+                                    kind: "error",
+                                    code: err.error,
+                                    message:
+                                        err.message ??
+                                        `HTTP ${response.status}`,
+                                },
+                            ],
+                        }));
+                    }
+                    return;
+                }
+
+                // Stream this round.
+                let assistantText = "";
+                const toolCalls: {
+                    id: string;
+                    name: string;
+                    args: Record<string, unknown>;
+                }[] = [];
+                set((s) => ({
+                    entries: [
+                        ...s.entries,
+                        { kind: "assistant", text: "", streaming: true },
+                    ],
+                }));
+                const patchAssistant = (
+                    updater: (
+                        e: Extract<AgentUiEntry, { kind: "assistant" }>,
+                    ) => AgentUiEntry,
+                ) =>
+                    set((s) => {
+                        const entries = [...s.entries];
+                        for (let i = entries.length - 1; i >= 0; i--) {
+                            const e = entries[i];
+                            if (e.kind === "assistant") {
+                                entries[i] = updater(e);
+                                break;
+                            }
+                        }
+                        return { entries };
+                    });
+
+                let streamError: string | null = null;
+                for await (const event of readSse(response)) {
+                    if (event.type === "text_delta") {
+                        assistantText += event.text;
+                        patchAssistant((e) => ({
+                            ...e,
+                            text: assistantText,
+                        }));
+                    } else if (event.type === "tool_call") {
+                        toolCalls.push({
+                            id: event.id,
+                            name: event.name,
+                            args: event.arguments,
+                        });
+                    } else if (event.type === "error") {
+                        streamError = event.message;
+                    }
+                }
+                patchAssistant((e) => ({ ...e, streaming: false }));
+
+                if (streamError) {
+                    set((s) => ({
+                        entries: [
+                            ...s.entries,
+                            { kind: "error", message: streamError },
+                        ],
+                    }));
+                    return;
+                }
+
+                const wireCalls: AgentToolCall[] = toolCalls.map((c) => ({
+                    id: c.id,
+                    type: "function",
+                    function: {
+                        name: c.name,
+                        arguments: JSON.stringify(c.args),
+                    },
+                }));
+                wire = [
+                    ...wire,
+                    {
+                        role: "assistant",
+                        content: assistantText || null,
+                        ...(wireCalls.length > 0
+                            ? { tool_calls: wireCalls }
+                            : {}),
+                    },
+                ];
+
+                if (toolCalls.length === 0) return; // model is done
+
+                // Execute sequentially so the canvas grows step by step.
+                set({ status: "executing" });
+                for (const call of toolCalls) {
+                    set((s) => ({
+                        entries: [
+                            ...s.entries,
+                            { kind: "tool", name: call.name, args: call.args },
+                        ],
+                    }));
+                    const result = await executeAgentTool(
+                        call.name,
+                        call.args,
+                        {
+                            attachments: get().attachments,
+                            turnId,
+                        },
+                    );
+                    set((s) => {
+                        const entries = [...s.entries];
+                        for (let i = entries.length - 1; i >= 0; i--) {
+                            const e = entries[i];
+                            if (e.kind === "tool" && !e.result) {
+                                entries[i] = { ...e, result };
+                                break;
+                            }
+                        }
+                        return { entries };
+                    });
+                    wire = [
+                        ...wire,
+                        {
+                            role: "tool",
+                            tool_call_id: call.id,
+                            content: JSON.stringify(result),
+                        },
+                    ];
+                }
+                set({ status: "streaming" });
+                wire = boundedWire(wire);
+            }
+
+            set((s) => ({
+                entries: [
+                    ...s.entries,
+                    {
+                        kind: "error",
+                        code: "turn_limit",
+                        message: `stopped after ${MAX_AGENT_TURNS} rounds`,
+                    },
+                ],
+            }));
+        } catch (e) {
+            if ((e as Error).name !== "AbortError") {
+                logger.error("[agent] loop failed:", e);
+                set((s) => ({
+                    entries: [
+                        ...s.entries,
+                        { kind: "error", message: String(e) },
+                    ],
+                }));
+            }
+        } finally {
+            abortController = null;
+            // Attachments were consumed by this turn (referenced or not).
+            set({ status: "idle", wire, attachments: [] });
+        }
+    },
+}));

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1269,5 +1269,39 @@
         "retry": "Retry",
         "operationFailed": "Operation failed, please try again",
         "fetchFailed": "Failed to load portfolio, please retry"
+    },
+    "Agent": {
+        "title": "Agent",
+        "close": "Close",
+        "clear": "Clear conversation",
+        "stop": "Stop",
+        "send": "Send",
+        "attach": "Attach files",
+        "placeholder": "Describe the workflow you want…",
+        "emptyHint": "I can build and edit workflows on the canvas, and answer questions about TongFlow.",
+        "example1": "Generate a cat picture, then turn it into a video",
+        "example2": "Merge my two photos into one image",
+        "example3": "What's the difference between Create and Execute mode?",
+        "selectPlugin": "Plugin",
+        "selectModel": "Model",
+        "noLlmPlugin": "No LLM plugin installed",
+        "missingKeyTitle": "Provider key required",
+        "missingKeyBody": "Add {envKey} in Settings → Connect, then try again.",
+        "noProviderBody": "Select an LLM plugin above, or install one (e.g. OpenRouter) in Settings → Plugins.",
+        "turnLimit": "Stopped: too many steps in one request. Send a follow-up to continue.",
+        "tools": {
+            "patch": "Editing canvas",
+            "addNodes": "Adding {count} node(s)",
+            "addEdges": "Connecting {count} edge(s)",
+            "updateNodes": "Updating {count} node(s)",
+            "removeNodes": "Removing {count} node(s)",
+            "readCanvas": "Reading canvas",
+            "validate": "Validating workflow",
+            "describe": "Inspecting {type}",
+            "searchDocs": "Searching docs: {query}",
+            "listWorkflows": "Listing workflows",
+            "loadWorkflow": "Loading workflow",
+            "saveWorkflow": "Saving workflow"
+        }
     }
 }

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1183,5 +1183,39 @@
         "retry": "再試行",
         "operationFailed": "操作に失敗しました。もう一度お試しください",
         "fetchFailed": "ポートフォリオの取得に失敗しました。再試行してください"
+    },
+    "Agent": {
+        "title": "エージェント",
+        "close": "閉じる",
+        "clear": "会話をクリア",
+        "stop": "停止",
+        "send": "送信",
+        "attach": "ファイルを添付",
+        "placeholder": "作りたいワークフローを説明してください…",
+        "emptyHint": "キャンバス上でワークフローの構築・編集ができ、TongFlow の使い方にもお答えします。",
+        "example1": "猫の画像を生成して、動画に変換して",
+        "example2": "2枚の写真を1枚に融合して",
+        "example3": "作成モードと実行モードの違いは？",
+        "selectPlugin": "プラグイン",
+        "selectModel": "モデル",
+        "noLlmPlugin": "LLM プラグイン未インストール",
+        "missingKeyTitle": "プロバイダーキーが必要です",
+        "missingKeyBody": "設定 → 接続 で {envKey} を追加してから再試行してください。",
+        "noProviderBody": "上で LLM プラグインを選択するか、設定 → プラグイン でインストールしてください（例:OpenRouter）。",
+        "turnLimit": "停止しました:1回のリクエストでステップが多すぎます。続けるにはメッセージを送ってください。",
+        "tools": {
+            "patch": "キャンバスを編集中",
+            "addNodes": "ノードを {count} 個追加",
+            "addEdges": "エッジを {count} 本接続",
+            "updateNodes": "ノードを {count} 個更新",
+            "removeNodes": "ノードを {count} 個削除",
+            "readCanvas": "キャンバスを読み取り",
+            "validate": "ワークフローを検証",
+            "describe": "{type} を確認",
+            "searchDocs": "ドキュメント検索:{query}",
+            "listWorkflows": "ワークフロー一覧",
+            "loadWorkflow": "ワークフローを読み込み",
+            "saveWorkflow": "ワークフローを保存"
+        }
     }
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1269,5 +1269,39 @@
         "retry": "다시 시도",
         "operationFailed": "작업에 실패했습니다. 다시 시도해 주세요",
         "fetchFailed": "포트폴리오를 불러오지 못했습니다. 다시 시도해 주세요"
+    },
+    "Agent": {
+        "title": "에이전트",
+        "close": "닫기",
+        "clear": "대화 지우기",
+        "stop": "중지",
+        "send": "보내기",
+        "attach": "파일 첨부",
+        "placeholder": "원하는 워크플로를 설명해 주세요…",
+        "emptyHint": "캔버스에서 워크플로를 만들고 수정할 수 있으며, TongFlow 사용법 질문에도 답합니다.",
+        "example1": "고양이 그림을 생성한 뒤 영상으로 만들어 줘",
+        "example2": "사진 두 장을 한 장으로 합성해 줘",
+        "example3": "생성 모드와 실행 모드의 차이는?",
+        "selectPlugin": "플러그인",
+        "selectModel": "모델",
+        "noLlmPlugin": "설치된 LLM 플러그인 없음",
+        "missingKeyTitle": "프로바이더 키 필요",
+        "missingKeyBody": "설정 → 연결에서 {envKey} 를 추가한 뒤 다시 시도하세요.",
+        "noProviderBody": "위에서 LLM 플러그인을 선택하거나 설정 → 플러그인에서 설치하세요 (예: OpenRouter).",
+        "turnLimit": "중지됨: 한 요청에 단계가 너무 많습니다. 이어서 하려면 메시지를 보내세요.",
+        "tools": {
+            "patch": "캔버스 편집 중",
+            "addNodes": "노드 {count}개 추가",
+            "addEdges": "엣지 {count}개 연결",
+            "updateNodes": "노드 {count}개 업데이트",
+            "removeNodes": "노드 {count}개 삭제",
+            "readCanvas": "캔버스 읽는 중",
+            "validate": "워크플로 검증",
+            "describe": "{type} 확인",
+            "searchDocs": "문서 검색: {query}",
+            "listWorkflows": "워크플로 목록",
+            "loadWorkflow": "워크플로 불러오기",
+            "saveWorkflow": "워크플로 저장"
+        }
     }
 }

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1269,5 +1269,39 @@
         "retry": "重试",
         "operationFailed": "操作失败，请重试",
         "fetchFailed": "获取作品集失败，请重试"
+    },
+    "Agent": {
+        "title": "智能体",
+        "close": "关闭",
+        "clear": "清空对话",
+        "stop": "停止",
+        "send": "发送",
+        "attach": "添加附件",
+        "placeholder": "描述你想要的工作流…",
+        "emptyHint": "我可以在画布上搭建和修改工作流，也能回答 TongFlow 使用问题。",
+        "example1": "生成一张猫的图片，再转成视频",
+        "example2": "把我的两张照片融合成一张",
+        "example3": "创建模式和执行模式有什么区别？",
+        "selectPlugin": "插件",
+        "selectModel": "模型",
+        "noLlmPlugin": "未安装 LLM 插件",
+        "missingKeyTitle": "需要配置密钥",
+        "missingKeyBody": "请在 设置 → 连接 中填入 {envKey} 后重试。",
+        "noProviderBody": "请在上方选择 LLM 插件，或先在 设置 → 插件 中安装一个（如 OpenRouter）。",
+        "turnLimit": "已停止：单次请求步骤过多，发送后续消息可继续。",
+        "tools": {
+            "patch": "正在编辑画布",
+            "addNodes": "添加 {count} 个节点",
+            "addEdges": "连接 {count} 条边",
+            "updateNodes": "更新 {count} 个节点",
+            "removeNodes": "删除 {count} 个节点",
+            "readCanvas": "读取画布",
+            "validate": "体检工作流",
+            "describe": "查看 {type}",
+            "searchDocs": "检索文档：{query}",
+            "listWorkflows": "列出工作流",
+            "loadWorkflow": "载入工作流",
+            "saveWorkflow": "保存工作流"
+        }
     }
 }

--- a/src/lib/agent/catalog.server.ts
+++ b/src/lib/agent/catalog.server.ts
@@ -139,10 +139,11 @@ function renderExecutableLine(
 }
 
 const MODALITY_SECTION = `## Data (modality) nodes — carry assets, never execute
+The graph strictly alternates: add node → data node → executable → data node → executable → … → data node. Executables never wire directly to executables — every executable output gets an empty downstream data node of the output's modality, created at build time and filled at run time.
 textNode — data:{texts:[string,…]}. Multiple texts on one node = one batch (fans out downstream).
-imageNode / videoNode / audioNode / modelNode / fileNode — data:{fileKeys:[…]}. Never write fileKeys yourself; reference chat uploads via fromAttachment.
+imageNode / videoNode / audioNode / modelNode / fileNode — data:{fileKeys:[…]}. Never write fileKeys yourself; reference chat uploads via fromAttachment. Result data nodes are created with empty data.
 linkNode — data:{texts:[url,…]}.
-Add nodes (addTextNode, addImageNode, addVideoNode, addAudioNode, addFileNode, addModelNode, addLinkNode) — user-facing input widgets. Create one (with fromAttachment for uploads) feeding its modality node when the asset is user-supplied input; the pair makes the workflow reusable in App Mode. For prompt text you author yourself, a bare textNode is enough.`;
+Add nodes (addTextNode {manualValue}, addImageNode, addVideoNode, addAudioNode, addFileNode, addModelNode, addLinkNode) — user-facing input widgets that start every chain, feeding their data node (use fromAttachment for uploads). The add-node pair is what makes an input replaceable in App Mode.`;
 
 let cachedCatalog: { generatedAt: string; text: string } | null = null;
 

--- a/src/lib/agent/catalog.server.ts
+++ b/src/lib/agent/catalog.server.ts
@@ -1,0 +1,189 @@
+import "server-only";
+
+/**
+ * Derived node catalog for the agent's system prompt.
+ *
+ * Generated from the same registries the canvas itself runs on
+ * (NODE_TYPE_TO_ABI_FEATURE + ABI topology + sourceSpec overrides + the live
+ * plugins registry), so unlike the hand-maintained READMEs it cannot drift.
+ * One compact line per node type; the full per-field schema stays behind the
+ * `describe_node_type` tool.
+ */
+
+import type { JSONSchema7 } from "json-schema";
+import enMessages from "@/i18n/messages/en.json";
+import { getAbiTopology } from "@/lib/abi/handle-introspect";
+import {
+    NODE_TYPE_SOURCE_SPEC,
+    NODE_TYPE_TO_ABI_FEATURE,
+} from "@/lib/abi/node-feature-registry";
+import { type ResolvedField, resolveSpec } from "@/lib/abi/resolve";
+import { loadPluginsRegistry } from "@/lib/plugins/plugins-registry.server";
+
+/* ------------------------------------------------------------------ */
+/* Labels                                                              */
+/* ------------------------------------------------------------------ */
+
+/** Node types whose i18n title key is not simply `type` minus "Node". */
+const TITLE_KEY_EXCEPTIONS: Record<string, string> = {
+    genTextNode: "textGenText",
+    textsGenTextNode: "combineText",
+    videoGenTextSpeechRecognizeNode: "speechRecognize",
+    audioGenTextSpeechRecognizeNode: "speechRecognize",
+    imageGenImageUpscaleNode: "imageUpscale",
+    removeVideoSubtitleNode: "removeSubtitle",
+    denoiseAudioSubtitleNode: "denoiseAudio",
+    separateAudioTrackNode: "separateTrack",
+    extractAudioNode: "extractAudioTrack",
+    videoImageGenVideoMixNode: "videoImageMix",
+    videoImageGenVideoMoveNode: "videoImageMove",
+    concatVideoComposeNode: "concatVideo",
+};
+
+const NODE_TITLES: Record<string, string> = enMessages.Workspace.nodes
+    .titles as Record<string, string>;
+
+function labelForNodeType(nodeType: string): string {
+    const key = TITLE_KEY_EXCEPTIONS[nodeType] ?? nodeType.replace(/Node$/, "");
+    const title = NODE_TITLES?.[key];
+    if (title) return title;
+    // Fall back to a spaced form of the type name.
+    return key.replace(/([a-z])([A-Z])/g, "$1 $2").toLowerCase();
+}
+
+/* ------------------------------------------------------------------ */
+/* Field rendering                                                     */
+/* ------------------------------------------------------------------ */
+
+function schemaSummary(schema: JSONSchema7 | undefined): string {
+    if (!schema) return "any";
+    if (Array.isArray(schema.enum)) {
+        return schema.enum.map((v) => JSON.stringify(v)).join("|");
+    }
+    if (schema.type === "array") return "array";
+    return typeof schema.type === "string" ? schema.type : "any";
+}
+
+function renderField(
+    name: string,
+    field: ResolvedField,
+    configSchema: JSONSchema7 | undefined,
+): string | undefined {
+    const req = field.required ? "*" : "";
+    switch (field.kind) {
+        case "handle": {
+            const mode = field.batch
+                ? ",batch"
+                : field.collect
+                  ? ",collect-many"
+                  : "";
+            const manual = field.manual ? ",or-config" : "";
+            return `${name}${req}=wire(${field.nodeType}${mode}${manual})`;
+        }
+        case "config":
+            return `${name}${req}:${schemaSummary(configSchema)}`;
+        case "static":
+        case "input":
+            // Pinned or workflow-input fields are not the agent's to set.
+            return undefined;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Catalog                                                             */
+/* ------------------------------------------------------------------ */
+
+function renderExecutableLine(
+    nodeType: string,
+    pluginsBySlot: Record<string, string[]>,
+    modelsFor: (pluginId: string, slot: string) => string[],
+): string | undefined {
+    const feature = NODE_TYPE_TO_ABI_FEATURE[nodeType];
+    const plugins = pluginsBySlot[feature] ?? [];
+    // Nodes with no installed plugin are listed separately so the agent can
+    // warn instead of silently building a dead graph.
+    const spec = resolveSpec(feature, NODE_TYPE_SOURCE_SPEC[nodeType]);
+    const topology = getAbiTopology(feature);
+
+    // Config schemas live on the raw topology classification.
+    const inputProps: Record<string, JSONSchema7> = {};
+    for (const [f, cls] of Object.entries(topology.inputs)) {
+        if (cls.kind === "config") inputProps[f] = cls.schema;
+    }
+
+    const fields = topology.inputOrder
+        .map((f) => renderField(f, spec.fields[f], inputProps[f]))
+        .filter(Boolean);
+
+    const outputs = topology.outputs
+        .map(
+            (o) => `${o.field}→${o.nodeType}${o.expandEach ? "(fan-out)" : ""}`,
+        )
+        .join(", ");
+
+    const pluginParts = plugins.map((p) => {
+        const models = modelsFor(p, feature);
+        return models.length > 0
+            ? `${p}[${models.slice(0, 8).join(",")}${models.length > 8 ? ",…" : ""}]`
+            : p;
+    });
+
+    const pluginInfo =
+        pluginParts.length > 0
+            ? ` plugins: ${pluginParts.join("; ")}`
+            : " plugins: NONE-INSTALLED";
+
+    return `${nodeType} "${labelForNodeType(nodeType)}" — in: ${
+        fields.join(", ") || "(none)"
+    }. out: ${outputs || "(none)"}.${pluginInfo}`;
+}
+
+const MODALITY_SECTION = `## Data (modality) nodes — carry assets, never execute
+textNode — data:{texts:[string,…]}. Multiple texts on one node = one batch (fans out downstream).
+imageNode / videoNode / audioNode / modelNode / fileNode — data:{fileKeys:[…]}. Never write fileKeys yourself; reference chat uploads via fromAttachment.
+linkNode — data:{texts:[url,…]}.
+Add nodes (addTextNode, addImageNode, addVideoNode, addAudioNode, addFileNode, addModelNode, addLinkNode) — user-facing input widgets. Create one (with fromAttachment for uploads) feeding its modality node when the asset is user-supplied input; the pair makes the workflow reusable in App Mode. For prompt text you author yourself, a bare textNode is enough.`;
+
+let cachedCatalog: { generatedAt: string; text: string } | null = null;
+
+export function buildAgentCatalog(): string {
+    const registry = loadPluginsRegistry();
+    if (cachedCatalog && cachedCatalog.generatedAt === registry.generatedAt) {
+        return cachedCatalog.text;
+    }
+
+    const modelsFor = (pluginId: string, slot: string): string[] =>
+        registry.plugins[pluginId]?.methodsByNodeSlot?.[slot]?.models ?? [];
+
+    const available: string[] = [];
+    const uninstalled: string[] = [];
+
+    for (const nodeType of Object.keys(NODE_TYPE_TO_ABI_FEATURE)) {
+        const line = renderExecutableLine(
+            nodeType,
+            registry.nodePluginMap,
+            modelsFor,
+        );
+        if (!line) continue;
+        if (line.endsWith("NONE-INSTALLED")) uninstalled.push(line);
+        else available.push(line);
+    }
+
+    const sections = [
+        MODALITY_SECTION,
+        `## Executable nodes (${available.length} with installed plugins)
+Legend: field*=required. wire(x) = fed by an edge from an upstream node of type x; "batch" fans out one task per element; "collect-many" merges several edges into one array; "or-config" = wire optional, config value used as fallback. Other fields are config — set them via data in the patch. First listed plugin is the default.
+${available.join("\n")}`,
+    ];
+
+    if (uninstalled.length > 0) {
+        sections.push(
+            `## Nodes with NO installed plugin — these will not run; warn the user and suggest alternatives instead of using them
+${uninstalled.map((l) => l.replace(" plugins: NONE-INSTALLED", "")).join("\n")}`,
+        );
+    }
+
+    const text = sections.join("\n\n");
+    cachedCatalog = { generatedAt: registry.generatedAt, text };
+    return text;
+}

--- a/src/lib/agent/chat-adapters.ts
+++ b/src/lib/agent/chat-adapters.ts
@@ -1,0 +1,87 @@
+/**
+ * Maps the panel's plugin selection to an OpenAI-compatible chat endpoint.
+ *
+ * The pickable list is the intersection of gen-text-slot plugins (what the
+ * scanner found installed) and this adapter map (which of those expose a
+ * streaming tool-use chat API). Modal-deployed LLM plugins run as tasks and
+ * have no such endpoint, so they are deliberately absent.
+ *
+ * Isomorphic on purpose: the panel filters its picker on the id set, the
+ * route resolves keys. Nothing here is secret — base URLs and env-var NAMES
+ * only; values stay in the server env store.
+ */
+
+export interface ChatAdapter {
+    baseURL: string;
+    envKey: string;
+    /** Fallback env keys some plugins also accept. */
+    altEnvKeys?: string[];
+}
+
+export const CHAT_ADAPTERS: Record<string, ChatAdapter> = {
+    "tongflow-router-openrouter": {
+        baseURL: "https://openrouter.ai/api/v1",
+        envKey: "OPENROUTER_API_KEY",
+    },
+    "tongflow-api-openai": {
+        baseURL: "https://api.openai.com/v1",
+        envKey: "OPENAI_API_KEY",
+    },
+    "tongflow-api-gemini": {
+        // Gemini's OpenAI-compatibility endpoint.
+        baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+        envKey: "GEMINI_API_KEY",
+        altEnvKeys: ["GOOGLE_API_KEY"],
+    },
+    "tongflow-api-deepseek": {
+        baseURL: "https://api.deepseek.com/v1",
+        envKey: "DEEPSEEK_API_KEY",
+    },
+    "tongflow-api-xai": {
+        baseURL: "https://api.x.ai/v1",
+        envKey: "XAI_API_KEY",
+        altEnvKeys: ["GROK_API_KEY"],
+    },
+    "tongflow-api-bytedance": {
+        baseURL: "https://ark.cn-beijing.volces.com/api/v3",
+        envKey: "ARK_API_KEY",
+    },
+    "tongflow-router-apimart": {
+        baseURL: "https://api.apimart.ai/v1",
+        envKey: "APIMART_API_KEY",
+    },
+    "tongflow-api-agnes": {
+        baseURL: "https://apihub.agnes-ai.com/v1",
+        envKey: "AGNES_API_KEY",
+    },
+};
+
+export function isChatCapablePlugin(pluginId: string): boolean {
+    return pluginId in CHAT_ADAPTERS;
+}
+
+export interface ResolvedAgentProvider {
+    baseURL: string;
+    apiKey: string;
+}
+
+export type ProviderError = "unsupported_plugin" | "missing_key";
+
+export function resolveAgentProvider(
+    pluginId: string,
+    env: Record<string, string>,
+):
+    | { ok: true; provider: ResolvedAgentProvider }
+    | { ok: false; error: ProviderError; envKey?: string } {
+    const adapter = CHAT_ADAPTERS[pluginId];
+    if (!adapter) return { ok: false, error: "unsupported_plugin" };
+
+    const apiKey =
+        env[adapter.envKey] ??
+        adapter.altEnvKeys?.map((k) => env[k]).find(Boolean);
+    if (!apiKey) {
+        return { ok: false, error: "missing_key", envKey: adapter.envKey };
+    }
+
+    return { ok: true, provider: { baseURL: adapter.baseURL, apiKey } };
+}

--- a/src/lib/agent/docs-search.ts
+++ b/src/lib/agent/docs-search.ts
@@ -1,0 +1,106 @@
+"use client";
+
+/**
+ * Keyword search over the generated docs corpus (src/generated/agent-docs).
+ *
+ * The corpus is a few dozen kilobytes per locale, dynamically imported on the
+ * first product question so it never loads for users who only build. Plain
+ * term scoring is enough at this size — deliberately no vector store.
+ */
+
+import type { ToolResult } from "./types";
+
+interface DocChunk {
+    source: string;
+    heading: string;
+    body: string;
+}
+
+const SUPPORTED_LOCALES = ["en", "zh", "ja"] as const;
+type DocsLocale = (typeof SUPPORTED_LOCALES)[number];
+
+const corpusCache = new Map<DocsLocale, DocChunk[]>();
+
+function currentLocale(): DocsLocale {
+    // next-intl stamps the locale on <html lang>. Korean has no localized
+    // README — fall back to English and let the model answer in Korean.
+    const lang =
+        typeof document !== "undefined"
+            ? document.documentElement.lang.slice(0, 2)
+            : "en";
+    return (SUPPORTED_LOCALES as readonly string[]).includes(lang)
+        ? (lang as DocsLocale)
+        : "en";
+}
+
+async function loadCorpus(locale: DocsLocale): Promise<DocChunk[]> {
+    const cached = corpusCache.get(locale);
+    if (cached) return cached;
+    const mod = await import(`@/generated/agent-docs/${locale}.json`);
+    const chunks = (mod.default ?? mod).chunks as DocChunk[];
+    corpusCache.set(locale, chunks);
+    return chunks;
+}
+
+function tokenize(text: string): string[] {
+    // Latin terms plus CJK bigrams — good enough for three READMEs.
+    const lower = text.toLowerCase();
+    const latin = lower.match(/[a-z0-9]{2,}/g) ?? [];
+    const cjk = lower.match(/[぀-ヿ一-鿿]/g) ?? [];
+    const bigrams: string[] = [];
+    for (let i = 0; i + 1 < cjk.length; i++) {
+        bigrams.push(cjk[i] + cjk[i + 1]);
+    }
+    return [...latin, ...cjk, ...bigrams];
+}
+
+export async function searchDocs(query: string): Promise<ToolResult> {
+    if (!query.trim()) return { ok: false, error: "empty query" };
+
+    const locale = currentLocale();
+    let corpus: DocChunk[];
+    try {
+        corpus = await loadCorpus(locale);
+        // English docs cover topics the localized READMEs may lack.
+        if (locale !== "en") corpus = [...corpus, ...(await loadCorpus("en"))];
+    } catch (e) {
+        return { ok: false, error: `docs corpus unavailable: ${String(e)}` };
+    }
+
+    const terms = new Set(tokenize(query));
+    if (terms.size === 0) return { ok: false, error: "unrecognized query" };
+
+    const scored = corpus
+        .map((chunk) => {
+            const hay = tokenize(`${chunk.heading} ${chunk.body}`);
+            const counts = new Map<string, number>();
+            for (const t of hay) counts.set(t, (counts.get(t) ?? 0) + 1);
+            let score = 0;
+            for (const term of terms) {
+                const c = counts.get(term) ?? 0;
+                if (c > 0) score += 1 + Math.log(c);
+                if (tokenize(chunk.heading).includes(term)) score += 2;
+            }
+            return { chunk, score };
+        })
+        .filter((s) => s.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 4);
+
+    if (scored.length === 0) {
+        return {
+            ok: true,
+            results: [],
+            note: "no documentation matched; tell the user the docs do not cover this and point to the project's GitHub / Discord",
+        };
+    }
+
+    return {
+        ok: true,
+        results: scored.map(({ chunk }) => ({
+            source: chunk.source,
+            heading: chunk.heading,
+            body: chunk.body,
+        })),
+    };
+}

--- a/src/lib/agent/executor.test.ts
+++ b/src/lib/agent/executor.test.ts
@@ -30,8 +30,8 @@ vi.mock("@/lib/api/task", () => ({
 }));
 
 import useFlow from "@/hooks/use-flow";
-import type { AgentAttachment } from "./types";
 import { applyGraphPatch } from "./executor";
+import type { AgentAttachment } from "./types";
 
 const ATTACHMENTS: AgentAttachment[] = [
     {
@@ -64,27 +64,31 @@ describe("applyGraphPatch", () => {
             "t1",
         );
         expect(result.ok).toBe(false);
-        const steps = (result as { steps: { hint?: string }[] }).steps;
+        const steps = (result as unknown as { steps: { hint?: string }[] })
+            .steps;
         expect(steps[0].hint).toContain("textGenImageNode");
         expect(useFlow.getState().nodes).toHaveLength(0);
     });
 
-    it("builds a chain with ABI handles via expands", async () => {
+    it("builds a fully alternating chain with ABI handles via expands", async () => {
+        // add → data → executable → data → executable → data
         const result = await applyGraphPatch(
             {
                 add_nodes: [
+                    { alias: "add1", type: "addImageNode", fromAttachment: 1 },
+                    { alias: "src", type: "imageNode", fromAttachment: 1 },
                     {
-                        alias: "src",
-                        type: "imageNode",
-                        fromAttachment: 1,
-                    },
-                    {
-                        alias: "vid",
+                        alias: "genVid",
                         type: "imageGenVideoNode",
                         data: { text: "walking", duration: 5 },
                     },
+                    { alias: "vid", type: "videoNode" },
                 ],
-                add_edges: [{ from: "src", to: "vid" }],
+                add_edges: [
+                    { from: "add1", to: "src" },
+                    { from: "src", to: "genVid" },
+                    { from: "genVid", to: "vid" },
+                ],
             },
             ATTACHMENTS,
             "t2",
@@ -92,10 +96,42 @@ describe("applyGraphPatch", () => {
         expect(result.ok).toBe(true);
 
         const { nodes, edges } = useFlow.getState();
-        expect(nodes).toHaveLength(2);
-        expect(edges).toHaveLength(1);
-        expect(edges[0].sourceHandle).toBe("out:imageNode");
-        expect(edges[0].targetHandle).toBe("in:image");
+        expect(nodes).toHaveLength(4);
+        expect(edges).toHaveLength(3);
+        const intoExec = edges.find((e) => e.targetHandle === "in:image");
+        expect(intoExec?.sourceHandle).toBe("out:imageNode");
+        // Executable output flows into the pre-created empty result node.
+        const outOfExec = edges.find((e) => e.targetHandle === "in:videoNode");
+        expect(outOfExec?.sourceHandle).toBe("out:video");
+    });
+
+    it("rejects executable→executable edges with a repair hint", async () => {
+        const result = await applyGraphPatch(
+            {
+                add_nodes: [
+                    { alias: "genImg", type: "textGenImageNode" },
+                    {
+                        alias: "genVid",
+                        type: "imageGenVideoNode",
+                        data: { text: "walking" },
+                    },
+                ],
+                add_edges: [{ from: "genImg", to: "genVid" }],
+            },
+            [],
+            "t2c",
+        );
+        expect(result.ok).toBe(false);
+        const steps = (
+            result as unknown as {
+                steps: { op: string; ok: boolean; error?: string }[];
+            }
+        ).steps;
+        const edgeStep = steps.find((s) => s.op === "add_edge");
+        expect(edgeStep?.ok).toBe(false);
+        expect(edgeStep?.error).toContain("insert an empty imageNode");
+        // The invalid edge must not be created.
+        expect(useFlow.getState().edges).toHaveLength(0);
     });
 
     it("wires sourceSpec-only handles pending the post-mount heal", async () => {
@@ -144,9 +180,7 @@ describe("applyGraphPatch", () => {
         expect(result.ok).toBe(true);
 
         const { edges } = useFlow.getState();
-        const fuseEdges = edges.filter(
-            (e) => e.targetHandle === "in:images",
-        );
+        const fuseEdges = edges.filter((e) => e.targetHandle === "in:images");
         expect(fuseEdges).toHaveLength(2);
     });
 

--- a/src/lib/agent/executor.test.ts
+++ b/src/lib/agent/executor.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Patch-applier semantics that must not regress:
+ *  - unknown node types fail with suggestions (hallucination guard)
+ *  - alias edges route through `expands` and land ABI handles
+ *  - collect-many handles accept several edges on the same target handle
+ *  - update_nodes merges into node.data (updates() replaces wholesale)
+ *  - `prompt` stays agent-unwritable; attachments substitute real fileKeys
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The flow store persists to localStorage on every mutation.
+const storage = new Map<string, string>();
+vi.stubGlobal("localStorage", {
+    getItem: (k: string) => storage.get(k) ?? null,
+    setItem: (k: string, v: string) => void storage.set(k, v),
+    removeItem: (k: string) => void storage.delete(k),
+});
+
+// The workspace API client transitively imports .tsx UI (toast); vitest runs
+// without JSX transform, and these tests never touch the network anyway.
+vi.mock("@/lib/api/workspace", () => ({
+    getWorkflow: vi.fn(),
+    listWorkflows: vi.fn(),
+    saveWorkflow: vi.fn(),
+}));
+vi.mock("@/lib/api/task", () => ({
+    createTask: vi.fn(),
+    updateTaskStatus: vi.fn(),
+}));
+
+import useFlow from "@/hooks/use-flow";
+import type { AgentAttachment } from "./types";
+import { applyGraphPatch } from "./executor";
+
+const ATTACHMENTS: AgentAttachment[] = [
+    {
+        index: 1,
+        fileKey: "tasks/upload/cat.png",
+        url: "https://example.test/cat.png",
+        name: "cat.png",
+        mime: "image/png",
+        modality: "imageNode",
+        addNodeType: "addImageNode",
+    },
+];
+
+function reset() {
+    useFlow.setState({
+        nodes: [],
+        edges: [],
+        historyPast: [],
+        historyFuture: [],
+    });
+}
+
+describe("applyGraphPatch", () => {
+    beforeEach(reset);
+
+    it("rejects unknown node types with close suggestions", async () => {
+        const result = await applyGraphPatch(
+            { add_nodes: [{ alias: "x", type: "textToImageNode" }] },
+            [],
+            "t1",
+        );
+        expect(result.ok).toBe(false);
+        const steps = (result as { steps: { hint?: string }[] }).steps;
+        expect(steps[0].hint).toContain("textGenImageNode");
+        expect(useFlow.getState().nodes).toHaveLength(0);
+    });
+
+    it("builds a chain with ABI handles via expands", async () => {
+        const result = await applyGraphPatch(
+            {
+                add_nodes: [
+                    {
+                        alias: "src",
+                        type: "imageNode",
+                        fromAttachment: 1,
+                    },
+                    {
+                        alias: "vid",
+                        type: "imageGenVideoNode",
+                        data: { text: "walking", duration: 5 },
+                    },
+                ],
+                add_edges: [{ from: "src", to: "vid" }],
+            },
+            ATTACHMENTS,
+            "t2",
+        );
+        expect(result.ok).toBe(true);
+
+        const { nodes, edges } = useFlow.getState();
+        expect(nodes).toHaveLength(2);
+        expect(edges).toHaveLength(1);
+        expect(edges[0].sourceHandle).toBe("out:imageNode");
+        expect(edges[0].targetHandle).toBe("in:image");
+    });
+
+    it("wires sourceSpec-only handles pending the post-mount heal", async () => {
+        // textGenImageNode's `text: batchOn` lives only in the component's
+        // sourceSpec (not NODE_TYPE_SOURCE_SPEC), so before the node mounts
+        // the target handle cannot be derived — useAbiExecution's heal fills
+        // it in on mount. The edge itself must still be created.
+        const result = await applyGraphPatch(
+            {
+                add_nodes: [
+                    {
+                        alias: "t1",
+                        type: "textNode",
+                        data: { texts: ["a cat"] },
+                    },
+                    { alias: "img", type: "textGenImageNode" },
+                ],
+                add_edges: [{ from: "t1", to: "img" }],
+            },
+            [],
+            "t2b",
+        );
+        expect(result.ok).toBe(true);
+
+        const { edges } = useFlow.getState();
+        expect(edges).toHaveLength(1);
+        expect(edges[0].sourceHandle).toBe("out:textNode");
+    });
+
+    it("routes several sources onto a collect-many handle", async () => {
+        const result = await applyGraphPatch(
+            {
+                add_nodes: [
+                    { alias: "a", type: "imageNode", fromAttachment: 1 },
+                    { alias: "b", type: "imageNode", fromAttachment: 1 },
+                    { alias: "fuse", type: "imageFusionNode" },
+                ],
+                add_edges: [
+                    { from: "a", to: "fuse" },
+                    { from: "b", to: "fuse" },
+                ],
+            },
+            ATTACHMENTS,
+            "t3",
+        );
+        expect(result.ok).toBe(true);
+
+        const { edges } = useFlow.getState();
+        const fuseEdges = edges.filter(
+            (e) => e.targetHandle === "in:images",
+        );
+        expect(fuseEdges).toHaveLength(2);
+    });
+
+    it("merges update_nodes into existing data", async () => {
+        await applyGraphPatch(
+            {
+                add_nodes: [
+                    {
+                        alias: "vid",
+                        type: "imageGenVideoNode",
+                        data: { text: "drinking", duration: 5 },
+                    },
+                ],
+            },
+            [],
+            "t4",
+        );
+        const id = useFlow.getState().nodes[0].id;
+
+        const result = await applyGraphPatch(
+            { update_nodes: [{ id: id.slice(0, 8), data: { duration: 10 } }] },
+            [],
+            "t5",
+        );
+        expect(result.ok).toBe(true);
+
+        const data = useFlow.getState().nodes[0].data as Record<
+            string,
+            unknown
+        >;
+        // Changed key updated, untouched key preserved (merge, not replace).
+        expect(data.duration).toBe(10);
+        expect(data.text).toBe("drinking");
+    });
+
+    it("refuses to write the derived prompt field", async () => {
+        await applyGraphPatch(
+            { add_nodes: [{ alias: "n", type: "textGenImageNode" }] },
+            [],
+            "t6",
+        );
+        const id = useFlow.getState().nodes[0].id;
+        const result = await applyGraphPatch(
+            { update_nodes: [{ id, data: { prompt: { text: "x" } } }] },
+            [],
+            "t7",
+        );
+        expect(result.ok).toBe(false);
+    });
+
+    it("substitutes attachment fileKeys and rejects bad indices", async () => {
+        const ok = await applyGraphPatch(
+            {
+                add_nodes: [
+                    { alias: "src", type: "addImageNode", fromAttachment: 1 },
+                ],
+            },
+            ATTACHMENTS,
+            "t8",
+        );
+        expect(ok.ok).toBe(true);
+        const data = useFlow.getState().nodes[0].data as Record<
+            string,
+            unknown
+        >;
+        expect(data.fileKeys).toEqual(["tasks/upload/cat.png"]);
+
+        const bad = await applyGraphPatch(
+            {
+                add_nodes: [
+                    { alias: "x", type: "addImageNode", fromAttachment: 9 },
+                ],
+            },
+            ATTACHMENTS,
+            "t9",
+        );
+        expect(bad.ok).toBe(false);
+    });
+
+    it("resolves references against existing canvas nodes", async () => {
+        await applyGraphPatch(
+            {
+                add_nodes: [
+                    {
+                        alias: "t1",
+                        type: "textNode",
+                        data: { texts: ["hello"] },
+                    },
+                ],
+            },
+            [],
+            "t10",
+        );
+        const existingId = useFlow.getState().nodes[0].id;
+
+        // Second patch references the first patch's node by short id.
+        const result = await applyGraphPatch(
+            {
+                add_nodes: [{ alias: "img", type: "textGenImageNode" }],
+                add_edges: [{ from: existingId.slice(0, 8), to: "img" }],
+            },
+            [],
+            "t11",
+        );
+        expect(result.ok).toBe(true);
+        expect(useFlow.getState().edges).toHaveLength(1);
+    });
+});

--- a/src/lib/agent/executor.ts
+++ b/src/lib/agent/executor.ts
@@ -1,0 +1,675 @@
+"use client";
+
+/**
+ * Client-side agent tool dispatch.
+ *
+ * All canvas mutations go through the same `useFlow` store actions the UI
+ * uses, so agent-built nodes get automatic layout, ABI handle resolution,
+ * camera-follow and undo for free. The patch applier paces its steps so the
+ * user watches the workflow grow instead of it popping in at once.
+ */
+
+import type { Edge, Node } from "@xyflow/react";
+import { v4 } from "uuid";
+import { MODALITY_NODE_TYPES } from "@/constants/modality-nodes";
+import useFlow from "@/hooks/use-flow";
+import { usePluginsRegistryStore } from "@/hooks/use-plugins-registry";
+import { useTaskStore } from "@/hooks/use-task";
+import { getAbiTopology } from "@/lib/abi/handle-introspect";
+import {
+    NODE_TYPE_SOURCE_SPEC,
+    NODE_TYPE_TO_ABI_FEATURE,
+    resolvedSpecForNodeType,
+    resolveEdgeHandles,
+} from "@/lib/abi/node-feature-registry";
+import { resolveSpec } from "@/lib/abi/resolve";
+import { getWorkflow, listWorkflows, saveWorkflow } from "@/lib/api/workspace";
+import { logger } from "@/lib/logger";
+import { isValidFlowConnection } from "@/lib/workflow/connection-rules";
+import {
+    exportWorkflow,
+    parseWorkflowImportJson,
+} from "@/lib/workflow/exporter";
+import { isWorkflowValid } from "@/lib/workflow/parser";
+import { searchDocs } from "./docs-search";
+import { neighborhood, renderCanvas, resolveNodeRef } from "./serialize";
+import type {
+    AgentAttachment,
+    GraphPatch,
+    GraphPatchAddNode,
+    PatchStepResult,
+    ToolResult,
+} from "./types";
+
+/** Known add-node types (user-input widgets) accepted in patches. */
+const ADD_NODE_TYPES = new Set([
+    "addTextNode",
+    "addImageNode",
+    "addVideoNode",
+    "addAudioNode",
+    "addFileNode",
+    "addModelNode",
+    "addLinkNode",
+]);
+
+const KNOWN_NODE_TYPES: string[] = [
+    ...Object.keys(NODE_TYPE_TO_ABI_FEATURE),
+    ...MODALITY_NODE_TYPES,
+    ...ADD_NODE_TYPES,
+];
+
+/** Delay between patch steps so the build reads as a sequence, not a pop. */
+const STEP_PACING_MS = 250;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function closestTypes(input: string, count = 3): string[] {
+    const lower = input.toLowerCase();
+    const scored = KNOWN_NODE_TYPES.map((t) => {
+        const tl = t.toLowerCase();
+        let score = 0;
+        if (tl.includes(lower) || lower.includes(tl.replace(/node$/, ""))) {
+            score += 10;
+        }
+        // Shared 4-grams as a cheap similarity signal.
+        for (let i = 0; i + 4 <= lower.length; i++) {
+            if (tl.includes(lower.slice(i, i + 4))) score++;
+        }
+        return { t, score };
+    });
+    return scored
+        .sort((a, b) => b.score - a.score)
+        .slice(0, count)
+        .map((s) => s.t);
+}
+
+function isKnownType(type: string): boolean {
+    return KNOWN_NODE_TYPES.includes(type);
+}
+
+/**
+ * `updates()` replaces node.data wholesale — every agent write must merge
+ * with the node's current data or it would wipe params and file keys.
+ */
+function mergeNodeData(nodeId: string, patch: Record<string, unknown>): void {
+    const flow = useFlow.getState();
+    const node = flow.nodes.find((n) => n.id === nodeId);
+    if (!node) return;
+    // The turn-level commit already snapshotted history; skip per-update
+    // commits so one Cmd+Z reverts the whole agent turn.
+    flow.updates(nodeId, { ...node.data, ...patch }, { history: false });
+}
+
+function attachmentData(
+    node: GraphPatchAddNode,
+    attachments: AgentAttachment[],
+): { data?: Record<string, unknown>; error?: string } {
+    if (node.fromAttachment === undefined) return { data: node.data };
+    const att = attachments.find((a) => a.index === node.fromAttachment);
+    if (!att) {
+        return {
+            error: `attachment #${node.fromAttachment} does not exist (have ${attachments.length})`,
+        };
+    }
+    if (node.type === "addTextNode" || node.type === "textNode") {
+        return { error: "attachments carry files; use fileKeys-based nodes" };
+    }
+    return {
+        data: {
+            ...node.data,
+            fileKeys: [att.fileKey],
+            ...(ADD_NODE_TYPES.has(node.type) ? { activeTab: "upload" } : {}),
+        },
+    };
+}
+
+/* ------------------------------------------------------------------ */
+/* apply_graph_patch                                                   */
+/* ------------------------------------------------------------------ */
+
+export async function applyGraphPatch(
+    patch: GraphPatch,
+    attachments: AgentAttachment[],
+    turnId: string,
+): Promise<ToolResult> {
+    const results: PatchStepResult[] = [];
+    const aliases = new Map<string, string>();
+    // Edges already claimed per target within this patch, so several sources
+    // land on distinct handles (mirrors compose()'s usedTargetHandles).
+    const usedTargetHandles = new Map<string, Set<string>>();
+
+    const flow = useFlow.getState();
+    const hasSteps =
+        (patch.add_nodes?.length ?? 0) +
+            (patch.add_edges?.length ?? 0) +
+            (patch.update_nodes?.length ?? 0) +
+            (patch.remove_nodes?.length ?? 0) >
+        0;
+    if (!hasSteps) {
+        return { ok: false, error: "empty patch" };
+    }
+
+    // One history snapshot per agent turn → one Cmd+Z undoes it all.
+    flow.commitHistory(`agent:${turnId}`);
+
+    const pendingNodes = [...(patch.add_nodes ?? [])];
+    const pendingEdges = [...(patch.add_edges ?? [])];
+
+    /* ---- add_nodes + their first incoming edge (via expands) -------- */
+
+    for (const spec of pendingNodes) {
+        if (!isKnownType(spec.type)) {
+            results.push({
+                op: "add_node",
+                ref: spec.alias,
+                ok: false,
+                error: `unknown node type "${spec.type}"`,
+                hint: `closest known types: ${closestTypes(spec.type).join(", ")}`,
+            });
+            continue;
+        }
+        const { data, error } = attachmentData(spec, attachments);
+        if (error) {
+            results.push({ op: "add_node", ref: spec.alias, ok: false, error });
+            continue;
+        }
+
+        const nodeData: Record<string, unknown> = { ...data };
+        if (spec.pluginId) nodeData.pluginId = spec.pluginId;
+        if (spec.pluginModel) nodeData.pluginModel = spec.pluginModel;
+
+        // If this node's first incoming edge originates from an
+        // already-materialized node, create node+edge in one `expands` call:
+        // it derives handles, lays out the child and fires camera-follow.
+        const edgeIdx = pendingEdges.findIndex((e) => {
+            if (e.to !== spec.alias) return false;
+            const from = resolveNodeRef(
+                e.from,
+                useFlow.getState().nodes,
+                aliases,
+            );
+            return !!from.id;
+        });
+
+        let newId: string | undefined;
+        let reused = false;
+
+        if (edgeIdx >= 0) {
+            const edge = pendingEdges[edgeIdx];
+            const from = resolveNodeRef(
+                edge.from,
+                useFlow.getState().nodes,
+                aliases,
+            );
+            const before = new Set(useFlow.getState().nodes.map((n) => n.id));
+            const ids = useFlow
+                .getState()
+                .expands(from.id ?? null, [
+                    { type: spec.type, data: nodeData },
+                ]);
+            newId = ids[0];
+            reused = newId !== undefined && before.has(newId);
+            if (newId) {
+                pendingEdges.splice(edgeIdx, 1);
+                const targetHandle = useFlow
+                    .getState()
+                    .edges.find(
+                        (e) => e.source === from.id && e.target === newId,
+                    )?.targetHandle;
+                if (targetHandle) {
+                    const used =
+                        usedTargetHandles.get(newId) ?? new Set<string>();
+                    used.add(targetHandle);
+                    usedTargetHandles.set(newId, used);
+                }
+            }
+        } else {
+            newId = useFlow.getState().addNode({
+                type: spec.type,
+                data: nodeData,
+            });
+        }
+
+        if (!newId) {
+            results.push({
+                op: "add_node",
+                ref: spec.alias,
+                ok: false,
+                error: "node creation failed",
+            });
+            continue;
+        }
+
+        aliases.set(spec.alias, newId);
+        results.push({
+            op: "add_node",
+            ref: spec.alias,
+            ok: true,
+            nodeId: newId,
+            ...(reused ? { reused: true } : {}),
+        });
+        await sleep(STEP_PACING_MS);
+    }
+
+    /* ---- remaining edges (cross-links, fan-ins) --------------------- */
+
+    for (const spec of pendingEdges) {
+        const state = useFlow.getState();
+        const from = resolveNodeRef(spec.from, state.nodes, aliases);
+        const to = resolveNodeRef(spec.to, state.nodes, aliases);
+        const refLabel = `${spec.from}→${spec.to}`;
+
+        const missing = !from.id ? spec.from : !to.id ? spec.to : undefined;
+        if (missing) {
+            results.push({
+                op: "add_edge",
+                ref: refLabel,
+                ok: false,
+                error:
+                    from.ambiguous || to.ambiguous
+                        ? `reference "${missing}" is ambiguous`
+                        : `reference "${missing}" not found`,
+                hint: "use an alias from this patch or a short id from the canvas listing",
+            });
+            continue;
+        }
+
+        const fromNode = state.nodes.find((n) => n.id === from.id) as Node;
+        const toNode = state.nodes.find((n) => n.id === to.id) as Node;
+
+        const used = usedTargetHandles.get(toNode.id) ?? new Set<string>();
+        for (const e of state.edges) {
+            if (e.target === toNode.id && e.targetHandle) {
+                // Existing single-value edges also occupy their handle;
+                // batch/collect handles accept repeats and are re-picked by
+                // resolveEdgeHandles anyway.
+                used.add(e.targetHandle);
+            }
+        }
+
+        const derived = resolveEdgeHandles({
+            sourceType: fromNode.type,
+            targetType: toNode.type,
+            usedTargetHandles: used,
+            targetSpec: resolvedSpecForNodeType(toNode.type),
+        });
+        const sourceHandle = spec.fromHandle ?? derived.sourceHandle;
+        const targetHandle = spec.toHandle ?? derived.targetHandle;
+
+        const connection = {
+            source: fromNode.id,
+            target: toNode.id,
+            sourceHandle: sourceHandle ?? null,
+            targetHandle: targetHandle ?? null,
+        };
+
+        if (!isValidFlowConnection(connection, state.nodes, state.edges)) {
+            results.push({
+                op: "add_edge",
+                ref: refLabel,
+                ok: false,
+                error: `connection rejected (${fromNode.type} → ${toNode.type}${targetHandle ? ` on ${targetHandle}` : ""})`,
+                hint: "check the catalog: the target field's modality must match the source output, and single-value inputs accept only one edge",
+            });
+            continue;
+        }
+
+        const edge: Edge = {
+            id: v4(),
+            source: fromNode.id,
+            target: toNode.id,
+            type: "custom-edge",
+            ...(sourceHandle ? { sourceHandle } : {}),
+            ...(targetHandle ? { targetHandle } : {}),
+        };
+        useFlow.getState().setEdges([...useFlow.getState().edges, edge]);
+        if (targetHandle) {
+            used.add(targetHandle);
+            usedTargetHandles.set(toNode.id, used);
+        }
+
+        results.push({ op: "add_edge", ref: refLabel, ok: true });
+        await sleep(STEP_PACING_MS);
+    }
+
+    /* ---- update_nodes ---------------------------------------------- */
+
+    for (const spec of patch.update_nodes ?? []) {
+        const state = useFlow.getState();
+        const ref = resolveNodeRef(spec.id, state.nodes, aliases);
+        if (!ref.id) {
+            results.push({
+                op: "update_node",
+                ref: spec.id,
+                ok: false,
+                error: ref.ambiguous
+                    ? `reference "${spec.id}" is ambiguous`
+                    : `node "${spec.id}" not found`,
+                hint: "re-read the canvas; the node may have been removed",
+            });
+            continue;
+        }
+        if ("prompt" in spec.data) {
+            results.push({
+                op: "update_node",
+                ref: spec.id,
+                ok: false,
+                error: "'prompt' is derived at run time and cannot be set",
+                hint: "set the node's own fields (e.g. text, duration) instead",
+            });
+            continue;
+        }
+        mergeNodeData(ref.id, spec.data);
+        results.push({ op: "update_node", ref: spec.id, ok: true });
+        await sleep(STEP_PACING_MS);
+    }
+
+    /* ---- remove_nodes ----------------------------------------------- */
+
+    for (const refStr of patch.remove_nodes ?? []) {
+        const state = useFlow.getState();
+        const ref = resolveNodeRef(refStr, state.nodes, aliases);
+        if (!ref.id) {
+            results.push({
+                op: "remove_node",
+                ref: refStr,
+                ok: false,
+                error: ref.ambiguous
+                    ? `reference "${refStr}" is ambiguous`
+                    : `node "${refStr}" not found`,
+            });
+            continue;
+        }
+        useFlow.getState().removeNode(ref.id);
+        results.push({ op: "remove_node", ref: refStr, ok: true });
+        await sleep(STEP_PACING_MS);
+    }
+
+    const failed = results.filter((r) => !r.ok);
+    return {
+        ok: failed.length === 0,
+        ...(failed.length > 0
+            ? {
+                  error: `${failed.length}/${results.length} step(s) failed`,
+              }
+            : {}),
+        steps: results,
+    } as ToolResult;
+}
+
+/* ------------------------------------------------------------------ */
+/* read_canvas                                                         */
+/* ------------------------------------------------------------------ */
+
+function readCanvas(scope?: string): ToolResult {
+    const { nodes, edges, selectedNodes } = useFlow.getState();
+    const statusByNodeId = useTaskStore.getState().nodeExecutionStatusMap;
+
+    let only: Set<string> | undefined;
+    if (scope === "selection") {
+        only = new Set(selectedNodes.map((n) => n.id));
+        if (only.size === 0) {
+            return { ok: false, error: "nothing is selected" };
+        }
+    } else if (scope?.startsWith("around:")) {
+        const ref = resolveNodeRef(scope.slice("around:".length), nodes);
+        if (!ref.id) {
+            return { ok: false, error: `node "${scope}" not found` };
+        }
+        only = neighborhood(ref.id, edges);
+    }
+
+    return {
+        ok: true,
+        canvas: renderCanvas(nodes, edges, {
+            selectedIds: selectedNodes.map((n) => n.id),
+            statusByNodeId,
+            maxText: 200,
+            only,
+        }),
+    };
+}
+
+/* ------------------------------------------------------------------ */
+/* validate_workflow                                                   */
+/* ------------------------------------------------------------------ */
+
+function validateWorkflow(): ToolResult {
+    const { nodes, edges } = useFlow.getState();
+    const registry = usePluginsRegistryStore.getState().registry;
+    const problems: string[] = [];
+
+    if (nodes.length === 0) return { ok: true, problems: ["canvas is empty"] };
+    if (!isWorkflowValid({ nodes, edges })) {
+        problems.push("the graph contains a cycle");
+    }
+
+    for (const node of nodes) {
+        const feature = NODE_TYPE_TO_ABI_FEATURE[node.type ?? ""];
+        if (!feature) continue;
+        const short = `#${node.id.slice(0, 8)} ${node.type}`;
+        const spec = resolveSpec(
+            feature,
+            NODE_TYPE_SOURCE_SPEC[node.type ?? ""],
+        );
+        const data = (node.data ?? {}) as Record<string, unknown>;
+
+        for (const [field, resolved] of Object.entries(spec.fields)) {
+            if (!resolved.required) continue;
+            if (resolved.kind === "handle") {
+                const wired = edges.some(
+                    (e) =>
+                        e.target === node.id &&
+                        (!e.targetHandle || e.targetHandle === `in:${field}`),
+                );
+                const manualValue =
+                    resolved.manual &&
+                    data[field] !== undefined &&
+                    data[field] !== "";
+                if (!wired && !manualValue) {
+                    problems.push(
+                        `${short}: required input "${field}" is not connected`,
+                    );
+                }
+            } else if (resolved.kind === "config") {
+                if (data[field] === undefined || data[field] === "") {
+                    problems.push(
+                        `${short}: required config "${field}" is empty`,
+                    );
+                }
+            }
+        }
+
+        const installed = registry?.nodePluginMap?.[feature] ?? [];
+        if (installed.length === 0) {
+            problems.push(`${short}: no plugin installed for "${feature}"`);
+        } else if (
+            typeof data.pluginId === "string" &&
+            data.pluginId &&
+            !installed.includes(data.pluginId)
+        ) {
+            problems.push(
+                `${short}: plugin "${data.pluginId}" is not installed (available: ${installed.join(", ")})`,
+            );
+        }
+    }
+
+    return { ok: true, valid: problems.length === 0, problems };
+}
+
+/* ------------------------------------------------------------------ */
+/* describe_node_type                                                  */
+/* ------------------------------------------------------------------ */
+
+function describeNodeType(type: string): ToolResult {
+    if (!isKnownType(type)) {
+        return {
+            ok: false,
+            error: `unknown node type "${type}"`,
+            hint: `closest known types: ${closestTypes(type).join(", ")}`,
+        };
+    }
+    const feature = NODE_TYPE_TO_ABI_FEATURE[type];
+    if (!feature) {
+        return {
+            ok: true,
+            type,
+            kind: "data-node",
+            note: "carries assets; data keys are texts (textNode/linkNode) or fileKeys (other modalities)",
+        };
+    }
+    const topology = getAbiTopology(feature);
+    const spec = resolveSpec(feature, NODE_TYPE_SOURCE_SPEC[type]);
+    const fields: Record<string, unknown> = {};
+    for (const field of topology.inputOrder) {
+        const resolved = spec.fields[field];
+        const cls = topology.inputs[field];
+        fields[field] =
+            resolved.kind === "handle"
+                ? {
+                      kind: "wire",
+                      from: resolved.nodeType,
+                      batch: resolved.batch ?? false,
+                      collect: resolved.collect ?? false,
+                      configFallback: resolved.manual ?? false,
+                      required: resolved.required,
+                  }
+                : {
+                      kind: resolved.kind,
+                      required: resolved.required,
+                      schema: cls.kind === "config" ? cls.schema : undefined,
+                  };
+    }
+    return {
+        ok: true,
+        type,
+        feature,
+        fields,
+        outputs: topology.outputs,
+    };
+}
+
+/* ------------------------------------------------------------------ */
+/* Workflow persistence tools                                          */
+/* ------------------------------------------------------------------ */
+
+async function toolListWorkflows(): Promise<ToolResult> {
+    try {
+        const res = await listWorkflows();
+        return {
+            ok: true,
+            workflows: (res.workflows ?? []).map((w) => ({
+                id: w.id,
+                name: w.name,
+                description: w.description ?? undefined,
+            })),
+        };
+    } catch (e) {
+        return { ok: false, error: String(e) };
+    }
+}
+
+async function toolLoadWorkflow(id: number): Promise<ToolResult> {
+    try {
+        const res = await getWorkflow(id);
+        // `flow` is stored as a JSON string; the import parser tolerates both
+        // encodings and the {flow:...} envelope.
+        const parsed = parseWorkflowImportJson({ flow: res.workflow.flow });
+        const flow = useFlow.getState();
+        flow.commitHistory("agent:load-workflow");
+        flow.setNodes(parsed.nodes);
+        flow.setEdges(parsed.edges);
+        flow.setWorkflowId(res.workflow.id);
+        flow.setWorkflowName(res.workflow.name ?? "");
+        flow.setWorkflowDescription(res.workflow.description ?? "");
+        return {
+            ok: true,
+            loaded: res.workflow.name,
+            nodes: parsed.nodes.length,
+        };
+    } catch (e) {
+        return { ok: false, error: String(e) };
+    }
+}
+
+async function toolSaveWorkflow(args: {
+    name?: string;
+    description?: string;
+}): Promise<ToolResult> {
+    try {
+        const state = useFlow.getState();
+        if (state.nodes.length === 0) {
+            return { ok: false, error: "canvas is empty; nothing to save" };
+        }
+        const name = args.name || state.workflowName || "Agent workflow";
+        const description = args.description ?? state.workflowDescription;
+        const executable = exportWorkflow(state.nodes, state.edges, {
+            name,
+            description,
+            includeOriginalFlow: true,
+        });
+        const res = await saveWorkflow({
+            workflowId: state.workflowId ?? undefined,
+            name,
+            description,
+            flow: { nodes: state.nodes, edges: state.edges },
+            executable,
+        });
+        if (res.workflowId !== undefined && res.workflowId !== null) {
+            state.setWorkflowId(res.workflowId);
+        }
+        state.setWorkflowName(name);
+        if (description) state.setWorkflowDescription(description);
+        return { ok: true, workflowId: res.workflowId, name };
+    } catch (e) {
+        return { ok: false, error: String(e) };
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Dispatch                                                            */
+/* ------------------------------------------------------------------ */
+
+export async function executeAgentTool(
+    name: string,
+    args: Record<string, unknown>,
+    context: { attachments: AgentAttachment[]; turnId: string },
+): Promise<ToolResult> {
+    try {
+        switch (name) {
+            case "apply_graph_patch":
+                return await applyGraphPatch(
+                    args as GraphPatch,
+                    context.attachments,
+                    context.turnId,
+                );
+            case "read_canvas":
+                return readCanvas(
+                    typeof args.scope === "string" ? args.scope : undefined,
+                );
+            case "validate_workflow":
+                return validateWorkflow();
+            case "describe_node_type":
+                return describeNodeType(String(args.type ?? ""));
+            case "search_docs":
+                return await searchDocs(String(args.query ?? ""));
+            case "list_workflows":
+                return await toolListWorkflows();
+            case "load_workflow":
+                return await toolLoadWorkflow(Number(args.id));
+            case "save_workflow":
+                return await toolSaveWorkflow(
+                    args as { name?: string; description?: string },
+                );
+            default:
+                return { ok: false, error: `unknown tool "${name}"` };
+        }
+    } catch (e) {
+        logger.error("[agent] tool failed:", name, e);
+        return { ok: false, error: String(e) };
+    }
+}

--- a/src/lib/agent/executor.ts
+++ b/src/lib/agent/executor.ts
@@ -104,6 +104,53 @@ function mergeNodeData(nodeId: string, patch: Record<string, unknown>): void {
     flow.updates(nodeId, { ...node.data, ...patch }, { history: false });
 }
 
+type NodeKind = "add" | "data" | "executable";
+
+function nodeKind(type: string | undefined): NodeKind | undefined {
+    if (!type) return undefined;
+    if (ADD_NODE_TYPES.has(type)) return "add";
+    if ((MODALITY_NODE_TYPES as readonly string[]).includes(type)) {
+        return "data";
+    }
+    if (type in NODE_TYPE_TO_ABI_FEATURE) return "executable";
+    return undefined;
+}
+
+/**
+ * Enforce the canonical alternation `add → data → executable → data → …`.
+ * Executables must never wire directly to each other: at run time a consumer
+ * reads its input from the upstream node's data, and an executable's results
+ * land on its downstream data node — a direct edge would read nothing.
+ */
+function edgeShapeError(
+    sourceType: string | undefined,
+    targetType: string | undefined,
+): string | undefined {
+    const s = nodeKind(sourceType);
+    const t = nodeKind(targetType);
+    if (!s || !t) return undefined;
+
+    if (s === "executable" && t === "executable") {
+        const feature = NODE_TYPE_TO_ABI_FEATURE[sourceType ?? ""];
+        const outType = feature
+            ? getAbiTopology(feature).outputs[0]?.nodeType
+            : undefined;
+        return `executables never connect directly — insert an empty ${
+            outType ?? "data"
+        } node between ${sourceType} and ${targetType} (results land on the data node; the next executable reads from it)`;
+    }
+    if (s === "data" && t === "data") {
+        return "data nodes never connect to each other";
+    }
+    if (s === "add" && t !== "data") {
+        return `an add node feeds its data node first (${sourceType} → data node → ${targetType})`;
+    }
+    if (t === "add") {
+        return "add nodes are workflow inputs and take no incoming edges";
+    }
+    return undefined;
+}
+
 function attachmentData(
     node: GraphPatchAddNode,
     attachments: AgentAttachment[],
@@ -157,7 +204,34 @@ export async function applyGraphPatch(
     flow.commitHistory(`agent:${turnId}`);
 
     const pendingNodes = [...(patch.add_nodes ?? [])];
-    const pendingEdges = [...(patch.add_edges ?? [])];
+    let pendingEdges = [...(patch.add_edges ?? [])];
+
+    /* ---- structural pre-pass: reject shape-invalid edges ------------ */
+
+    // Node types are known before anything materializes (aliases from this
+    // patch, existing nodes from the canvas), so alternation violations fail
+    // fast with a repair hint instead of half-applying.
+    const typeByAlias = new Map(pendingNodes.map((n) => [n.alias, n.type]));
+    const refType = (ref: string): string | undefined => {
+        const aliased = typeByAlias.get(ref);
+        if (aliased) return aliased;
+        const resolved = resolveNodeRef(ref, useFlow.getState().nodes);
+        return resolved.id
+            ? useFlow.getState().nodes.find((n) => n.id === resolved.id)?.type
+            : undefined;
+    };
+    pendingEdges = pendingEdges.filter((e) => {
+        const error = edgeShapeError(refType(e.from), refType(e.to));
+        if (!error) return true;
+        results.push({
+            op: "add_edge",
+            ref: `${e.from}→${e.to}`,
+            ok: false,
+            error,
+            hint: "the graph must alternate: add node → data node → executable → data node → …",
+        });
+        return false;
+    });
 
     /* ---- add_nodes + their first incoming edge (via expands) -------- */
 
@@ -446,6 +520,22 @@ function validateWorkflow(): ToolResult {
     if (nodes.length === 0) return { ok: true, problems: ["canvas is empty"] };
     if (!isWorkflowValid({ nodes, edges })) {
         problems.push("the graph contains a cycle");
+    }
+
+    // Alternation invariant: an executable's results land on its downstream
+    // data node, so a direct executable→executable edge reads nothing at
+    // run time.
+    const typeById = new Map(nodes.map((n) => [n.id, n.type]));
+    for (const e of edges) {
+        const error = edgeShapeError(
+            typeById.get(e.source),
+            typeById.get(e.target),
+        );
+        if (error) {
+            problems.push(
+                `edge #${e.source.slice(0, 8)}→#${e.target.slice(0, 8)}: ${error}`,
+            );
+        }
     }
 
     for (const node of nodes) {

--- a/src/lib/agent/prompt.server.ts
+++ b/src/lib/agent/prompt.server.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+/**
+ * System prompt assembly: hand-written manual + code-derived catalog.
+ *
+ * The manual (docs/agent-workflow-manual.md) holds rules, examples and the
+ * product FAQ; the catalog is regenerated from the registries whenever the
+ * plugins registry changes. Keeping the two sources separate is what stops
+ * the prompt from drifting the way hand-maintained node lists do.
+ */
+
+import manual from "../../../docs/agent-workflow-manual.md";
+import { buildAgentCatalog } from "./catalog.server";
+
+const PREAMBLE = `You are the TongFlow workspace agent. You build and edit
+multi-modal AI workflows on the user's canvas through the tools provided, and
+you answer questions about using TongFlow. Distinguish questions from build
+requests: answer questions directly without touching the canvas. Respond in
+the language the user writes in.`;
+
+export function buildSystemPrompt(locale?: string): string {
+    const localeHint = locale
+        ? `\nThe user's interface language is "${locale}".`
+        : "";
+    return [
+        PREAMBLE + localeHint,
+        manual,
+        "# Node catalog (generated from the live installation)",
+        buildAgentCatalog(),
+    ].join("\n\n");
+}

--- a/src/lib/agent/serialize.test.ts
+++ b/src/lib/agent/serialize.test.ts
@@ -1,0 +1,103 @@
+import type { Edge, Node } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+import { neighborhood, renderCanvas, resolveNodeRef } from "./serialize";
+
+const node = (id: string, type: string, data: Record<string, unknown> = {}) =>
+    ({ id, type, position: { x: 0, y: 0 }, data }) as Node;
+
+const edge = (
+    source: string,
+    target: string,
+    handles: { sourceHandle?: string; targetHandle?: string } = {},
+) => ({ id: `${source}-${target}`, source, target, ...handles }) as Edge;
+
+describe("renderCanvas", () => {
+    it("hides derived keys and summarizes file keys", () => {
+        const out = renderCanvas(
+            [
+                node("aaaa1111-x", "textGenImageNode", {
+                    texts: ["a cat"],
+                    prompt: { text: "a cat" },
+                    feature: "image-gen",
+                    width: 1024,
+                }),
+                node("bbbb2222-x", "imageNode", {
+                    fileKeys: ["tasks/abc/def.png", "tasks/abc/ghi.png"],
+                }),
+            ],
+            [],
+        );
+        expect(out).toContain("width=1024");
+        expect(out).not.toContain("prompt");
+        expect(out).not.toContain("feature");
+        // Storage keys never appear verbatim.
+        expect(out).not.toContain("tasks/abc/def.png");
+        expect(out).toContain("files=2×png");
+    });
+
+    it("truncates long text to the digest budget", () => {
+        const long = "x".repeat(500);
+        const out = renderCanvas(
+            [node("aaaa1111-x", "textNode", { texts: [long] })],
+            [],
+            { maxText: 60 },
+        );
+        expect(out).not.toContain(long);
+        expect(out).toContain(`${"x".repeat(60)}…`);
+    });
+
+    it("marks selection and execution status", () => {
+        const out = renderCanvas(
+            [node("aaaa1111-x", "textNode", { texts: ["hi"] })],
+            [],
+            {
+                selectedIds: ["aaaa1111-x"],
+                statusByNodeId: new Map([["aaaa1111-x", "running"]]),
+            },
+        );
+        expect(out).toContain("[running]");
+        expect(out).toContain("user-selected: aaaa1111");
+    });
+});
+
+describe("resolveNodeRef", () => {
+    const nodes = [
+        node("aaaa1111-2222-3333", "textNode"),
+        node("aaaa9999-8888-7777", "imageNode"),
+        node("bbbb0000-1111-2222", "videoNode"),
+    ];
+
+    it("resolves aliases first, then exact ids, then short ids", () => {
+        const aliases = new Map([["t1", "bbbb0000-1111-2222"]]);
+        expect(resolveNodeRef("t1", nodes, aliases).id).toBe(
+            "bbbb0000-1111-2222",
+        );
+        expect(resolveNodeRef("aaaa1111-2222-3333", nodes).id).toBe(
+            "aaaa1111-2222-3333",
+        );
+        expect(resolveNodeRef("bbbb0000", nodes).id).toBe(
+            "bbbb0000-1111-2222",
+        );
+    });
+
+    it("flags ambiguous short ids instead of guessing", () => {
+        expect(resolveNodeRef("aaaa", nodes)).toEqual({ ambiguous: true });
+        expect(resolveNodeRef("cccc", nodes)).toEqual({});
+    });
+});
+
+describe("neighborhood", () => {
+    it("walks both directions up to the hop limit", () => {
+        const edges = [
+            edge("a", "b"),
+            edge("b", "c"),
+            edge("c", "d"),
+            edge("x", "a"),
+        ];
+        const around = neighborhood("b", edges, 1);
+        expect([...around].sort()).toEqual(["a", "b", "c"]);
+        const wider = neighborhood("b", edges, 2);
+        expect(wider.has("d")).toBe(true);
+        expect(wider.has("x")).toBe(true);
+    });
+});

--- a/src/lib/agent/serialize.test.ts
+++ b/src/lib/agent/serialize.test.ts
@@ -75,9 +75,7 @@ describe("resolveNodeRef", () => {
         expect(resolveNodeRef("aaaa1111-2222-3333", nodes).id).toBe(
             "aaaa1111-2222-3333",
         );
-        expect(resolveNodeRef("bbbb0000", nodes).id).toBe(
-            "bbbb0000-1111-2222",
-        );
+        expect(resolveNodeRef("bbbb0000", nodes).id).toBe("bbbb0000-1111-2222");
     });
 
     it("flags ambiguous short ids instead of guessing", () => {

--- a/src/lib/agent/serialize.ts
+++ b/src/lib/agent/serialize.ts
@@ -1,0 +1,199 @@
+/**
+ * Compact canvas rendering for the agent.
+ *
+ * This text re-enters the prompt on every turn (as the auto-injected digest)
+ * and on every `read_canvas` call, so compactness is a feature, not a polish
+ * item. Node ids are shortened to 8 characters — `resolveNodeRef` accepts the
+ * short form, the full uuid, or a patch-local alias.
+ */
+
+import type { Edge, Node } from "@xyflow/react";
+
+/** Derived or mirrored keys the agent must never see or author. */
+const HIDDEN_DATA_KEYS = new Set([
+    "prompt", // built by buildPrompts() at run time
+    "feature", // mirrored from the registry on mount
+    "activeTab", // pure UI state
+    "locked",
+    "ids",
+]);
+
+/** Keys holding storage keys — rendered as a count, never verbatim. */
+const FILE_KEYS = new Set(["fileKeys"]);
+
+export const SHORT_ID_LENGTH = 8;
+
+export function shortId(id: string): string {
+    return id.slice(0, SHORT_ID_LENGTH);
+}
+
+/**
+ * Resolve an agent-supplied node reference to a real node id.
+ *
+ * Accepts a patch-local alias, a full uuid, or a short (8-char) id. Returns
+ * `{ ambiguous: true }` when a short id matches more than one node so the
+ * caller can surface an actionable error instead of mutating the wrong node.
+ */
+export function resolveNodeRef(
+    ref: string,
+    nodes: Node[],
+    aliases?: Map<string, string>,
+): { id?: string; ambiguous?: boolean } {
+    const aliased = aliases?.get(ref);
+    if (aliased) return { id: aliased };
+
+    if (nodes.some((n) => n.id === ref)) return { id: ref };
+
+    const matches = nodes.filter((n) => n.id.startsWith(ref));
+    if (matches.length === 1) return { id: matches[0].id };
+    if (matches.length > 1) return { ambiguous: true };
+    return {};
+}
+
+function truncate(value: string, max: number): string {
+    return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+function fileSummary(value: unknown): string | undefined {
+    if (!Array.isArray(value) || value.length === 0) return undefined;
+    const exts = value
+        .map((v) =>
+            typeof v === "string" ? (v.split(".").pop() ?? "bin") : "bin",
+        )
+        .filter((e) => e.length <= 5);
+    const ext = exts[0] ?? "bin";
+    return `${value.length}×${ext}`;
+}
+
+function renderValue(value: unknown, maxText: number): string | undefined {
+    if (value === undefined || value === null || value === "") return undefined;
+    if (typeof value === "string")
+        return JSON.stringify(truncate(value, maxText));
+    if (typeof value === "number" || typeof value === "boolean") {
+        return String(value);
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) return undefined;
+        if (value.every((v) => typeof v === "string")) {
+            const head = (value as string[])
+                .slice(0, 3)
+                .map((v) => JSON.stringify(truncate(v, maxText)));
+            const more = value.length > 3 ? `,+${value.length - 3}` : "";
+            return `[${head.join(",")}${more}]`;
+        }
+        return `[${value.length} items]`;
+    }
+    return undefined;
+}
+
+function renderNodeLine(node: Node, maxText: number, status?: string): string {
+    const parts: string[] = [`#${shortId(node.id)}`, node.type ?? "unknown"];
+    const data = (node.data ?? {}) as Record<string, unknown>;
+
+    for (const [key, value] of Object.entries(data)) {
+        if (HIDDEN_DATA_KEYS.has(key)) continue;
+        if (FILE_KEYS.has(key)) {
+            const summary = fileSummary(value);
+            if (summary) parts.push(`files=${summary}`);
+            continue;
+        }
+        const rendered = renderValue(value, maxText);
+        if (rendered !== undefined) parts.push(`${key}=${rendered}`);
+    }
+
+    if (status) parts.push(`[${status}]`);
+    return parts.join(" ");
+}
+
+function renderEdgeLine(edge: Edge): string {
+    const handles =
+        edge.sourceHandle || edge.targetHandle
+            ? ` ${edge.sourceHandle ?? "-"}→${edge.targetHandle ?? "-"}`
+            : "";
+    return `  ${shortId(edge.source)}${handles} → ${shortId(edge.target)}`;
+}
+
+export interface RenderCanvasOptions {
+    /** Node ids the user currently has selected on the canvas. */
+    selectedIds?: string[];
+    /** nodeId → execution status, from the task store. */
+    statusByNodeId?: Map<string, string>;
+    /** Max characters per string value. Digest uses 60, full read 200. */
+    maxText?: number;
+    /** Restrict output to this subset (already scoped by the caller). */
+    only?: Set<string>;
+}
+
+export function renderCanvas(
+    nodes: Node[],
+    edges: Edge[],
+    options: RenderCanvasOptions = {},
+): string {
+    const { selectedIds, statusByNodeId, maxText = 60, only } = options;
+
+    const visible = only ? nodes.filter((n) => only.has(n.id)) : nodes;
+    if (visible.length === 0) return "canvas: empty";
+
+    const visibleIds = new Set(visible.map((n) => n.id));
+    const visibleEdges = edges.filter(
+        (e) => visibleIds.has(e.source) && visibleIds.has(e.target),
+    );
+
+    const lines: string[] = [
+        `canvas: ${visible.length} node(s), ${visibleEdges.length} edge(s)${
+            only ? ` (scoped from ${nodes.length})` : ""
+        }`,
+    ];
+
+    for (const node of visible) {
+        lines.push(renderNodeLine(node, maxText, statusByNodeId?.get(node.id)));
+    }
+
+    if (visibleEdges.length > 0) {
+        lines.push("edges:");
+        for (const edge of visibleEdges) lines.push(renderEdgeLine(edge));
+    }
+
+    const selectedVisible = (selectedIds ?? []).filter((id) =>
+        visibleIds.has(id),
+    );
+    if (selectedVisible.length > 0) {
+        lines.push(`user-selected: ${selectedVisible.map(shortId).join(", ")}`);
+    }
+
+    return lines.join("\n");
+}
+
+/**
+ * Node ids within `hops` edges of `rootId`, walking both directions. Used by
+ * `read_canvas({ scope: "around:<id>" })` so editing one chain of a large
+ * canvas costs only that chain's tokens.
+ */
+export function neighborhood(
+    rootId: string,
+    edges: Edge[],
+    hops = 2,
+): Set<string> {
+    const seen = new Set<string>([rootId]);
+    let frontier = [rootId];
+
+    for (let i = 0; i < hops; i++) {
+        const next: string[] = [];
+        for (const id of frontier) {
+            for (const edge of edges) {
+                if (edge.source === id && !seen.has(edge.target)) {
+                    seen.add(edge.target);
+                    next.push(edge.target);
+                }
+                if (edge.target === id && !seen.has(edge.source)) {
+                    seen.add(edge.source);
+                    next.push(edge.source);
+                }
+            }
+        }
+        if (next.length === 0) break;
+        frontier = next;
+    }
+
+    return seen;
+}

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -1,0 +1,228 @@
+/**
+ * Tool definitions advertised to the LLM (OpenAI function-calling shape).
+ *
+ * Isomorphic: the route sends these upstream, the client dispatches on the
+ * same names. Descriptions are prescriptive about *when* to use each tool —
+ * that is what keeps the model from inventing uuids or rebuilding graphs it
+ * should be patching.
+ */
+
+export interface AgentToolDefinition {
+    type: "function";
+    function: {
+        name: string;
+        description: string;
+        parameters: Record<string, unknown>;
+    };
+}
+
+const NODE_REF =
+    "A node reference: an alias declared in this patch's add_nodes, or an existing node's short id (8 chars, as shown in the canvas listing).";
+
+export const AGENT_TOOLS: AgentToolDefinition[] = [
+    {
+        type: "function",
+        function: {
+            name: "apply_graph_patch",
+            description:
+                "The ONLY way to change the canvas. Describes one coherent change: nodes to create, edges to draw, params to set, nodes to delete. Applied step by step so the user watches the workflow appear. " +
+                "Always patch incrementally — never rebuild an existing workflow from scratch, and never touch nodes the user did not ask about. " +
+                "Reference brand-new nodes by the alias you give them; reference existing nodes by their short id from the canvas listing. Never invent uuids.",
+            parameters: {
+                type: "object",
+                properties: {
+                    add_nodes: {
+                        type: "array",
+                        description:
+                            "Nodes to create. Layout is automatic — never supply coordinates.",
+                        items: {
+                            type: "object",
+                            properties: {
+                                alias: {
+                                    type: "string",
+                                    description:
+                                        "Short local name (e.g. 't1', 'gen1') used to reference this node in add_edges within this same patch.",
+                                },
+                                type: {
+                                    type: "string",
+                                    description:
+                                        "Canvas node type from the node catalog (e.g. 'textNode', 'textGenImageNode').",
+                                },
+                                data: {
+                                    type: "object",
+                                    description:
+                                        "Initial data. For textNode use {texts:[...]}. For an executable node set its config fields (e.g. {text:'...', duration:5}). Never set 'prompt' — it is derived at run time.",
+                                    additionalProperties: true,
+                                },
+                                pluginId: {
+                                    type: "string",
+                                    description:
+                                        "Optional explicit plugin for an executable node. Omit to use the installed default.",
+                                },
+                                pluginModel: {
+                                    type: "string",
+                                    description:
+                                        "Optional model id, only for plugins that advertise models.",
+                                },
+                                fromAttachment: {
+                                    type: "integer",
+                                    description:
+                                        "1-based index of a file the user attached to the chat. Use this for add*Node/modality nodes carrying user uploads — never write a storage key yourself.",
+                                },
+                            },
+                            required: ["alias", "type"],
+                        },
+                    },
+                    add_edges: {
+                        type: "array",
+                        description:
+                            "Edges to draw. Handles are derived automatically; supply them only to disambiguate (e.g. several images into 'in:images').",
+                        items: {
+                            type: "object",
+                            properties: {
+                                from: { type: "string", description: NODE_REF },
+                                to: { type: "string", description: NODE_REF },
+                                fromHandle: {
+                                    type: "string",
+                                    description:
+                                        "Optional source handle, e.g. 'out:image'.",
+                                },
+                                toHandle: {
+                                    type: "string",
+                                    description:
+                                        "Optional target handle, e.g. 'in:images'.",
+                                },
+                            },
+                            required: ["from", "to"],
+                        },
+                    },
+                    update_nodes: {
+                        type: "array",
+                        description:
+                            "Change params on existing nodes. Merged into current data — send only the keys you are changing.",
+                        items: {
+                            type: "object",
+                            properties: {
+                                id: { type: "string", description: NODE_REF },
+                                data: {
+                                    type: "object",
+                                    additionalProperties: true,
+                                },
+                            },
+                            required: ["id", "data"],
+                        },
+                    },
+                    remove_nodes: {
+                        type: "array",
+                        description:
+                            "Node references to delete. Explain the impact in your reply before deleting anything the user did not explicitly ask you to remove.",
+                        items: { type: "string" },
+                    },
+                },
+            },
+        },
+    },
+    {
+        type: "function",
+        function: {
+            name: "read_canvas",
+            description:
+                "Read the canvas in full detail. A summary is already attached to the latest user message, so call this only when you need untruncated values or a specific neighbourhood of a large canvas.",
+            parameters: {
+                type: "object",
+                properties: {
+                    scope: {
+                        type: "string",
+                        description:
+                            "'all' (default), 'selection' for what the user has selected, or 'around:<shortId>' for a node and its neighbours.",
+                    },
+                },
+            },
+        },
+    },
+    {
+        type: "function",
+        function: {
+            name: "validate_workflow",
+            description:
+                "Health-check the canvas: cycles, required inputs left unconnected, required config left empty, missing or uninstalled plugins. Use it when the user asks why their workflow will not run, and before telling them a build is finished.",
+            parameters: { type: "object", properties: {} },
+        },
+    },
+    {
+        type: "function",
+        function: {
+            name: "describe_node_type",
+            description:
+                "Full config schema for one node type (enums, ranges, defaults) — more detail than the catalog line. Use before setting an unfamiliar param.",
+            parameters: {
+                type: "object",
+                properties: {
+                    type: {
+                        type: "string",
+                        description:
+                            "Canvas node type, e.g. 'imageGenVideoNode'.",
+                    },
+                },
+                required: ["type"],
+            },
+        },
+    },
+    {
+        type: "function",
+        function: {
+            name: "search_docs",
+            description:
+                "Search the TongFlow user documentation. Use for questions about using the product (installing plugins, connecting Modal, modes, exporting) — NOT for what nodes exist, which is in your catalog, and NOT for what the user has installed, which is live state.",
+            parameters: {
+                type: "object",
+                properties: {
+                    query: {
+                        type: "string",
+                        description: "Natural-language search terms.",
+                    },
+                },
+                required: ["query"],
+            },
+        },
+    },
+    {
+        type: "function",
+        function: {
+            name: "list_workflows",
+            description:
+                "List the user's saved workflows (id, name, description). Use when they refer to earlier work.",
+            parameters: { type: "object", properties: {} },
+        },
+    },
+    {
+        type: "function",
+        function: {
+            name: "load_workflow",
+            description:
+                "Replace the canvas with a saved workflow. Destructive to unsaved work — confirm with the user first unless they clearly asked for it.",
+            parameters: {
+                type: "object",
+                properties: {
+                    id: { type: "integer", description: "Workflow id." },
+                },
+                required: ["id"],
+            },
+        },
+    },
+    {
+        type: "function",
+        function: {
+            name: "save_workflow",
+            description:
+                "Save the current canvas, optionally naming it. Offer this after finishing a build.",
+            parameters: {
+                type: "object",
+                properties: {
+                    name: { type: "string" },
+                    description: { type: "string" },
+                },
+            },
+        },
+    },
+];

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -1,0 +1,157 @@
+/**
+ * Wire + domain types for the workspace agent.
+ *
+ * The agentic loop runs in the browser (canvas state lives only there); the
+ * server route is a stateless per-turn streaming proxy. These types are the
+ * contract between the two halves.
+ */
+
+import type { ModalityNodeType } from "@/constants/modality-nodes";
+
+/* ------------------------------------------------------------------ */
+/* Chat wire shape (OpenAI chat-completions compatible)                */
+/* ------------------------------------------------------------------ */
+
+export interface AgentToolCall {
+    id: string;
+    type: "function";
+    function: { name: string; arguments: string };
+}
+
+export type AgentWireMessage =
+    | { role: "user"; content: string }
+    | {
+          role: "assistant";
+          content: string | null;
+          tool_calls?: AgentToolCall[];
+      }
+    | { role: "tool"; tool_call_id: string; content: string };
+
+export interface AgentChatRequest {
+    messages: AgentWireMessage[];
+    /** Plugin id selected in the panel's first-level picker. */
+    pluginId: string;
+    /** Model id from the plugin's advertised `SLOT_MODELS`. */
+    model?: string;
+    /** UI locale, so the agent answers in the user's language. */
+    locale?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/* SSE events (server → client)                                        */
+/* ------------------------------------------------------------------ */
+
+export type AgentStreamEvent =
+    | { type: "text_delta"; text: string }
+    /** Emitted only once the tool call's argument fragments are complete. */
+    | {
+          type: "tool_call";
+          id: string;
+          name: string;
+          arguments: Record<string, unknown>;
+      }
+    | { type: "done"; finishReason: string }
+    | { type: "error"; message: string; code?: string };
+
+/* ------------------------------------------------------------------ */
+/* Tool results                                                        */
+/* ------------------------------------------------------------------ */
+
+export type ToolOk = { ok: true } & Record<string, unknown>;
+export interface ToolErr {
+    ok: false;
+    error: string;
+    /** Actionable correction for the model — always prefer this over prose. */
+    hint?: string;
+}
+export type ToolResult = ToolOk | ToolErr;
+
+export const AGENT_TOOL_NAMES = [
+    "apply_graph_patch",
+    "read_canvas",
+    "validate_workflow",
+    "describe_node_type",
+    "search_docs",
+    "list_workflows",
+    "load_workflow",
+    "save_workflow",
+] as const;
+
+export type AgentToolName = (typeof AGENT_TOOL_NAMES)[number];
+
+export function isAgentToolName(name: string): name is AgentToolName {
+    return (AGENT_TOOL_NAMES as readonly string[]).includes(name);
+}
+
+/* ------------------------------------------------------------------ */
+/* Graph patch — the agent's only write form                           */
+/* ------------------------------------------------------------------ */
+
+/**
+ * A node to create. `alias` is a short local name (e.g. "t1") the agent uses
+ * to refer to this node elsewhere in the same patch; the executor assigns the
+ * real uuid. The agent never invents uuids.
+ */
+export interface GraphPatchAddNode {
+    alias: string;
+    type: string;
+    data?: Record<string, unknown>;
+    /** Optional explicit plugin choice; omitted → resolved on mount. */
+    pluginId?: string;
+    pluginModel?: string;
+    /**
+     * 1-based index into the pending chat attachments. The executor substitutes
+     * the real storage key so the model never transcribes a fileKey.
+     */
+    fromAttachment?: number;
+}
+
+/** `from`/`to` accept an alias from this patch, a full uuid, or a short id. */
+export interface GraphPatchAddEdge {
+    from: string;
+    to: string;
+    fromHandle?: string;
+    toHandle?: string;
+}
+
+export interface GraphPatchUpdateNode {
+    id: string;
+    /** Merged into the node's existing `data` — never replaces it wholesale. */
+    data: Record<string, unknown>;
+}
+
+export interface GraphPatch {
+    add_nodes?: GraphPatchAddNode[];
+    add_edges?: GraphPatchAddEdge[];
+    update_nodes?: GraphPatchUpdateNode[];
+    remove_nodes?: string[];
+}
+
+/** Per-operation outcome so a partial failure can be patched up next turn. */
+export interface PatchStepResult {
+    op: "add_node" | "add_edge" | "update_node" | "remove_node";
+    ref: string;
+    ok: boolean;
+    nodeId?: string;
+    /** True when `expands` reused an existing same-type child. */
+    reused?: boolean;
+    error?: string;
+    hint?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/* Chat attachments                                                    */
+/* ------------------------------------------------------------------ */
+
+export interface AgentAttachment {
+    /** 1-based; this is what the model cites via `fromAttachment`. */
+    index: number;
+    fileKey: string;
+    url: string;
+    name: string;
+    mime: string;
+    modality: ModalityNodeType;
+    /** Canvas node type that carries this asset (e.g. "addImageNode"). */
+    addNodeType: string;
+    size?: number;
+}

--- a/src/types/markdown.d.ts
+++ b/src/types/markdown.d.ts
@@ -1,0 +1,5 @@
+// Markdown files import as raw strings (asset/source rule in next.config.ts).
+declare module "*.md" {
+    const content: string;
+    export default content;
+}


### PR DESCRIPTION
## Summary

Adds a collapsible right-side **agent chat panel** to the workspace. Users describe what they want in natural language (optionally attaching files); the agent builds and edits the workflow **live on the canvas** — nodes appear one by one with camera follow, params fill into the forms, and one Cmd+Z undoes an entire agent turn.

### Architecture

- **Agentic loop runs in the browser** (`use-agent-chat.ts`): canvas digest + user selection auto-injected each turn, SSE streaming, sequential tool execution, attachment registry (`fromAttachment` → real fileKey substitution so the model never transcribes storage keys).
- **Stateless SSE proxy route** `/api/agent/chat`: resolves the selected gen-text plugin's key from the env store, streams via the `openai` SDK, buffers tool-call fragments; single upstream fetch piped to SSE — Workers-compatible.
- **LLM channel = two-level picker**: installed `gen-text` plugins ∩ `CHAT_ADAPTERS` (OpenAI-compatible endpoints: openrouter/openai/gemini/deepseek/xai/bytedance/apimart/agnes) → per-plugin model list from the registry.

### Canvas writes: alias-based JSON patches

`apply_graph_patch` applies `add_nodes` (aliases, never invented uuids) / `add_edges` / `update_nodes` (merge semantics) / `remove_nodes` through the same `useFlow` actions the UI uses — automatic layout, ABI handle resolution and per-turn undo for free. A structural pre-pass **enforces the alternation invariant** (`add node → data node → executable → data node → …`); shape-invalid edges (executable→executable etc.) are rejected with repair hints the model can act on.

### Knowledge design (no doc drift)

- System prompt = hand-written manual (`docs/agent-workflow-manual.md`, bundled via md asset/source — no fs at runtime) + **node catalog derived from code** (`NODE_TYPE_TO_ABI_FEATURE` + ABI topology + sourceSpec + live plugins registry), so the catalog can never drift the way hand-maintained lists do.
- Product Q&A via `search_docs` over a generated corpus (`pnpm gen:agent-docs` chunks the three READMEs; lazy-loaded per locale).

### Read tools

`read_canvas` (all/selection/around scopes), `validate_workflow` (cycles, required inputs/config, plugin availability, alternation violations), `describe_node_type`, `list/load/save_workflow`.

## Test plan

- [x] `pnpm typecheck` / `pnpm lint:check` / `pnpm build`
- [x] 15 new unit tests (patch semantics: unknown-type suggestions, alternating chain via expands, exec→exec rejection, collect-many fan-in, merge-not-replace updates, attachment substitution, short-id resolution)
- [x] Route smoke: 400/428/502 error paths + SSE framing
- [ ] Manual in-app run with a working provider key (pending — local OpenRouter key is over its limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)