### PR TITLE
fix(docker): keep the agent manual in the image build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,7 +21,10 @@ desktop
 # Repo meta the build doesn't need
 .git
 .github
+# docs/ stays out except the agent manual, which is bundled into the server
+# at build time (imported as a raw string by src/lib/agent/prompt.server.ts).
 docs
+!docs/agent-workflow-manual.md
 
 # Python local artifacts
 .venv


### PR DESCRIPTION
The Docker Publish run for v0.3.0 failed: `.dockerignore` excludes `docs/`, but `src/lib/agent/prompt.server.ts` imports `docs/agent-workflow-manual.md` (bundled as a raw string at build time). Re-includes exactly that one file; verified locally with a COPY probe build.

v0.3.0's draft release and tag were removed before publishing; the tag will be recreated on the fixed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)