### PR TITLE
docs: drop the Star History section from all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,15 +328,3 @@ TongFlow is **dual-licensed**:
 
 This covers the entire repository, including the `sdk/` directory (the `tongflow`
 PyPI package). Contributions are covered by our [CLA](CLA.md).
-
-## Star History
-
-## Star History
-
-<a href="https://www.star-history.com/?repos=tong-io%2Ftongflow&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&theme=dark&legend=top-left&sealed_token=bDvowYTt_5E0Hk_7NXepKNqbJFKd-LqBsmGG0JJlGUR5mxD8IRtNlJSy9kOqCPyxPujolsgG3IxdxXNLDEyMWZ7iv3lPQ-tAjUHdodca3b9s_Qn9Bdfu8qtyW66cEsC4EO3dw2t4R7fq-nNWMEL-j40KoU1ENlJRHuEUeReBhkhu2t4v0MvGKH74f6wV" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left&sealed_token=bDvowYTt_5E0Hk_7NXepKNqbJFKd-LqBsmGG0JJlGUR5mxD8IRtNlJSy9kOqCPyxPujolsgG3IxdxXNLDEyMWZ7iv3lPQ-tAjUHdodca3b9s_Qn9Bdfu8qtyW66cEsC4EO3dw2t4R7fq-nNWMEL-j40KoU1ENlJRHuEUeReBhkhu2t4v0MvGKH74f6wV" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left&sealed_token=bDvowYTt_5E0Hk_7NXepKNqbJFKd-LqBsmGG0JJlGUR5mxD8IRtNlJSy9kOqCPyxPujolsgG3IxdxXNLDEyMWZ7iv3lPQ-tAjUHdodca3b9s_Qn9Bdfu8qtyW66cEsC4EO3dw2t4R7fq-nNWMEL-j40KoU1ENlJRHuEUeReBhkhu2t4v0MvGKH74f6wV" />
- </picture>
-</a>

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -318,13 +318,3 @@ TongFlow は **デュアルライセンス（dual-licensing）** モデルを採
 
 上記のライセンスはリポジトリ全体（PyPI に公開される `tongflow` パッケージを含む `sdk/` ディレクトリ）をカバーします。
 コードの貢献は [CLA](../CLA.md) に従います。
-
-## Star 履歴
-
-<a href="https://www.star-history.com/?repos=tong-io%2Ftongflow&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left" />
- </picture>
-</a>

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -318,13 +318,3 @@ TongFlow 采用 **双授权(dual-licensing)** 模式:
 
 以上授权覆盖整个仓库,包括 `sdk/` 目录(发布到 PyPI 的 `tongflow` 包)。
 贡献代码受 [CLA](../CLA.md) 约束。
-
-## Star 历史
-
-<a href="https://www.star-history.com/?repos=tong-io%2Ftongflow&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=tong-io/tongflow&type=date&legend=top-left" />
- </picture>
-</a>


### PR DESCRIPTION
Removes the Star History chart block from README.md, docs/README_ZH.md and docs/README_JA.md (the English one also had a duplicated heading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)