### PR TITLE
feat: skill packages (tongflow-package-*) for the gen-text node

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,12 @@ Aggregators — one key, many third-party models across labs:
 - [tongflow-modal-crawl4ai](https://github.com/tong-io/tongflow-modal-crawl4ai) — Crawl4AI URL / link → text
 - [tongflow-modal-scrapling](https://github.com/tong-io/tongflow-modal-scrapling) — Scrapling stealth-browser URL / link → text
 
+### Content packages
+
+Data-only packages (no executable code), installed the same way as plugins:
+
+- [tongflow-package-skills](https://github.com/tong-io/tongflow-package-skills) — skills (reusable prompt packs) for the text-generation node: writing skills (polish / translate / expand / condense…) plus model-specific prompt-crafting guides (MiniMax-H3, Seedance, Veo, Seedream, FLUX…)
+
 ## Run from source
 
 ```bash

--- a/config/official-plugins.json
+++ b/config/official-plugins.json
@@ -43,6 +43,7 @@
         "tongflow-modal-paddle",
         "tongflow-modal-unlimited-ocr",
         "tongflow-modal-crawl4ai",
-        "tongflow-modal-scrapling"
+        "tongflow-modal-scrapling",
+        "tongflow-package-skills"
     ]
 }

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -217,6 +217,12 @@ Google または WeChat でサインインすれば、すぐに創作を始め�
 - [tongflow-modal-crawl4ai](https://github.com/tong-io/tongflow-modal-crawl4ai) — Crawl4AI URL / リンク → テキスト
 - [tongflow-modal-scrapling](https://github.com/tong-io/tongflow-modal-scrapling) — Scrapling ステルスブラウザ URL / リンク → テキスト
 
+### コンテンツパッケージ
+
+実行コードを含まないデータ専用パッケージ（インストール方法はプラグインと同じ）：
+
+- [tongflow-package-skills](https://github.com/tong-io/tongflow-package-skills) — テキスト生成ノード用のスキル（再利用可能なプロンプトパック）：ライティングスキル（推敲 / 翻訳 / 拡張 / 要約…）+ モデル別プロンプト作成ガイド（MiniMax-H3、Seedance、Veo、Seedream、FLUX…）
+
 ## ソースコードから起動
 
 ```bash

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -217,6 +217,12 @@ TongFlow **桌面版**是一个轻量（约 10 MB）的壳应用，直接加载�
 - [tongflow-modal-crawl4ai](https://github.com/tong-io/tongflow-modal-crawl4ai) — Crawl4AI URL / 链接 → 文本
 - [tongflow-modal-scrapling](https://github.com/tong-io/tongflow-modal-scrapling) — Scrapling 隐身浏览器 URL / 链接 → 文本
 
+### 内容包
+
+纯数据包（不含可执行代码），安装方式与插件相同：
+
+- [tongflow-package-skills](https://github.com/tong-io/tongflow-package-skills) — 文本生成节点的技能包（可复用提示词）：写作技能（润色 / 翻译 / 扩写 / 缩写……）+ 各模型家族的提示词写作指南（MiniMax-H3、Seedance、Veo、Seedream、FLUX……）
+
 ## 从源代码启动
 
 ```bash

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -84,12 +84,16 @@ it plays no part in discovery or execution.
 The naming convention the scanner enforces:
 
 - The directory name must be **all lowercase**.
-- It must begin with `tongflow-api-…` or `tongflow-modal-…`. **The prefix no longer selects an
+- It must begin with `tongflow-api-…`, `tongflow-modal-…`, or `tongflow-router-…` (aggregator
+  plugins routing one key to many third-party models). **The prefix no longer selects an
   execution backend** — every plugin runs the same way (see [§5](#5-what-registers-a-handler)).
   It is now just a **label** shown in the node's plugin picker, a hint about where the work
   tends to run (a local/API adapter vs. hosted compute).
 - It must **not** encode hardware (`gpu` / `cpu`) — that's the plugin's own concern, not part
   of the id.
+- `tongflow-package-…` directories are **content packages** (no executable code) and are
+  skipped by the plugin scanner entirely — see
+  [§3.1](#31-content-packages-tongflow-package-).
 
 One entry point per plugin, by convention:
 
@@ -102,6 +106,40 @@ One entry point per plugin, by convention:
   `modal`.
 
 Beyond that, your code can be laid out however you like.
+
+### 3.1 Content packages (`tongflow-package-*`)
+
+A content package ships **data, not code**: today that means **skills** — reusable prompt
+packs users pick on the text-generation node, where the skill body is prepended to the
+node's instruction at execution time. Distribution is identical to plugins (a git repo
+cloned into `plugins/`, installable from the plugins panel or by git URL), but discovery is
+different: the Python plugin scanner skips these directories, and the app's own skills
+registry (`GET /api/skills/registry`) scans them instead.
+
+Layout:
+
+```
+tongflow-package-skills/
+├── tongflow.plugin.json     # optional: { "plugin": { name, description, icon }, "env": [] }
+└── skills/
+    ├── polish.md            # one skill per file; the filename (minus .md) is the skill id
+    └── minimax-h3-prompt.md
+```
+
+Each skill file is markdown with a minimal frontmatter block — a leading `---` line,
+`key: value` pairs, a closing `---` line — followed by the prompt body:
+
+```md
+---
+name: Polish                  # required; shown in the picker
+description: Tighten wording  # optional one-liner
+category: text                # optional: text | image-prompt | video-prompt (picker grouping)
+---
+The prompt body. Everything after the frontmatter is used verbatim.
+```
+
+A file without a valid frontmatter (or missing `name`) is skipped and reported in the
+registry's `errors` — it never breaks the scan.
 
 ---
 

--- a/sdk/tests/test_scan.py
+++ b/sdk/tests/test_scan.py
@@ -111,3 +111,15 @@ def test_scan_accepts_router_prefix(tmp_path):
     payload = _entry(root, _write_abi(tmp_path))
     assert payload["errors"] == []
     assert "tongflow-router-fake" in payload["plugins"]
+
+
+def test_scan_skips_package_dirs_silently(tmp_path):
+    # tongflow-package-* content packages carry no executable code; the plugin
+    # scanner must ignore them without reporting an error.
+    root = tmp_path / "plugins"
+    pdir = root / "tongflow-package-skills"
+    (pdir / "skills").mkdir(parents=True)
+    (pdir / "skills" / "polish.md").write_text("---\nname: Polish\n---\nbody", encoding="utf-8")
+    payload = _entry(root, _write_abi(tmp_path))
+    assert payload["errors"] == []
+    assert payload["plugins"] == {}

--- a/sdk/tongflow/scan.py
+++ b/sdk/tongflow/scan.py
@@ -17,7 +17,7 @@ from ._ast_utils import (
 )
 from .parse_deploy import _slot_to_ident, parse_deploy_py
 
-SCANNER_VERSION = 3
+SCANNER_VERSION = 4
 
 SKIP_DIR_NAMES = frozenset(
     {
@@ -263,6 +263,11 @@ def scan(plugins_root: Path, abi_path: Path) -> dict[str, object]:
 
     for pdir in _iter_plugin_dirs(plugins_root):
         plugin_id = pdir.name
+        # Content packages (tongflow-package-*) ship data files only (e.g. skill
+        # prompt packs) and no executable plugin code; they are discovered by the
+        # app's own package registry, so the plugin scanner skips them silently.
+        if plugin_id.lower().startswith("tongflow-package-"):
+            continue
         _runner, runner_error = _detect_runner(pdir)
         if runner_error:
             errors.append({"pluginId": plugin_id, "message": runner_error})

--- a/src/app/api/skills/registry/route.ts
+++ b/src/app/api/skills/registry/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { loadSkillsRegistry } from "@/lib/skills/skills-registry.server";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/skills/registry
+ * Returns the skills registry (no-store): every skill found in installed
+ * `tongflow-package-*` content packages, for the node skill picker.
+ */
+export async function GET() {
+    return NextResponse.json(loadSkillsRegistry(), {
+        headers: { "Cache-Control": "no-store" },
+    });
+}

--- a/src/components/workspace/nodes/base/node-skill-select.tsx
+++ b/src/components/workspace/nodes/base/node-skill-select.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { Check, Sparkles, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useMemo } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { resolveSkill, useSkillsRegistry } from "@/hooks/use-skills";
+import type { SkillDefinition, SkillRef } from "@/lib/skills/types";
+import { cn } from "@/lib/utils";
+
+/**
+ * Skill picker for prompt-driven nodes: lists every skill from installed
+ * `tongflow-package-*` content packages, grouped by category. Selection is a
+ * plain value/onChange pair — the node persists the `SkillRef` on its data.
+ */
+
+const CATEGORY_KEYS: Record<string, string> = {
+    text: "text",
+    "image-prompt": "imagePrompt",
+    "video-prompt": "videoPrompt",
+};
+
+interface SkillGroup {
+    labelKey: string;
+    items: { packageId: string; skill: SkillDefinition }[];
+}
+
+interface NodeSkillSelectProps {
+    value?: SkillRef;
+    onChange: (ref: SkillRef | null) => void;
+}
+
+export function NodeSkillSelect({ value, onChange }: NodeSkillSelectProps) {
+    const t = useTranslations("Workspace.skills");
+    const { registry, isLoaded } = useSkillsRegistry();
+
+    const selectedSkill = resolveSkill(registry, value);
+    const isMissing = Boolean(value && isLoaded && !selectedSkill);
+
+    const groups: SkillGroup[] = useMemo(() => {
+        const byKey = new Map<string, SkillGroup["items"]>();
+        for (const pkg of Object.values(registry?.packages ?? {})) {
+            for (const skill of pkg.skills) {
+                const key = CATEGORY_KEYS[skill.category ?? ""] ?? "other";
+                const list = byKey.get(key) ?? [];
+                list.push({ packageId: pkg.id, skill });
+                byKey.set(key, list);
+            }
+        }
+        return ["text", "imagePrompt", "videoPrompt", "other"]
+            .filter((key) => byKey.has(key))
+            .map((key) => ({ labelKey: key, items: byKey.get(key) ?? [] }));
+    }, [registry]);
+
+    return (
+        <div className="nodrag flex items-center gap-1">
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    {value ? (
+                        <Button
+                            size="sm"
+                            variant="secondary"
+                            className={cn(
+                                "h-7 max-w-60 gap-1.5 px-2 text-xs",
+                                isMissing &&
+                                    "text-muted-foreground line-through",
+                            )}
+                            title={isMissing ? t("missing") : value.name}
+                        >
+                            <Sparkles className="h-3.5 w-3.5 shrink-0" />
+                            <span className="truncate">{value.name}</span>
+                        </Button>
+                    ) : (
+                        <Button
+                            size="sm"
+                            variant="ghost"
+                            className="h-7 gap-1.5 px-2 text-xs text-muted-foreground"
+                        >
+                            <Sparkles className="h-3.5 w-3.5" />
+                            {t("select")}
+                        </Button>
+                    )}
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                    align="start"
+                    className="nodrag max-h-80 w-64 overflow-y-auto"
+                >
+                    {groups.length === 0 && (
+                        <div className="px-2 py-2 text-xs text-muted-foreground">
+                            {t("empty")}
+                        </div>
+                    )}
+                    {groups.map((group, gi) => (
+                        <div key={group.labelKey}>
+                            {gi > 0 && <DropdownMenuSeparator />}
+                            <DropdownMenuLabel className="text-xs text-muted-foreground">
+                                {t(`categories.${group.labelKey}`)}
+                            </DropdownMenuLabel>
+                            {group.items.map(({ packageId, skill }) => {
+                                const isSelected =
+                                    value?.package === packageId &&
+                                    value?.id === skill.id;
+                                return (
+                                    <DropdownMenuItem
+                                        key={`${packageId}/${skill.id}`}
+                                        onSelect={() =>
+                                            onChange({
+                                                package: packageId,
+                                                id: skill.id,
+                                                name: skill.name,
+                                            })
+                                        }
+                                    >
+                                        <div className="flex min-w-0 flex-1 flex-col">
+                                            <span className="truncate text-sm">
+                                                {skill.name}
+                                            </span>
+                                            {skill.description && (
+                                                <span className="truncate text-xs text-muted-foreground">
+                                                    {skill.description}
+                                                </span>
+                                            )}
+                                        </div>
+                                        {isSelected && (
+                                            <Check className="ml-2 h-4 w-4 shrink-0" />
+                                        )}
+                                    </DropdownMenuItem>
+                                );
+                            })}
+                        </div>
+                    ))}
+                </DropdownMenuContent>
+            </DropdownMenu>
+            {value && (
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 w-7 p-0 text-muted-foreground"
+                    onClick={() => onChange(null)}
+                    title={t("clear")}
+                >
+                    <X className="h-3.5 w-3.5" />
+                </Button>
+            )}
+        </div>
+    );
+}

--- a/src/components/workspace/nodes/transfer/text-gen-text.tsx
+++ b/src/components/workspace/nodes/transfer/text-gen-text.tsx
@@ -1,7 +1,7 @@
-import { useNodesData } from "@xyflow/react";
+import { useNodeId, useNodesData } from "@xyflow/react";
 import { Maximize2, Wand2 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { memo, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -15,16 +15,29 @@ import {
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useAbiForm } from "@/hooks/use-abi-form";
+import { useFlow } from "@/hooks/use-flow";
+import {
+    resolveSkill,
+    useSkillsRegistry,
+    useSkillsRegistryStore,
+} from "@/hooks/use-skills";
 import { batchOn } from "@/lib/abi/sources";
+import { composeSkillPrompt } from "@/lib/skills/compose";
+import type { SkillRef } from "@/lib/skills/types";
 import type { TongflowPluginNodeProps } from "@/types/tongflow-flow";
 
 import { AbiNodeShell } from "../base/abi-node-shell";
+import { NodeSkillSelect } from "../base/node-skill-select";
 import { NodeTextarea } from "../base/node-textarea";
 
 const GenTextNode = ({
     selected,
     data,
-}: TongflowPluginNodeProps<"gen-text", "genTextNode">) => {
+}: TongflowPluginNodeProps<
+    "gen-text",
+    "genTextNode",
+    { skill?: SkillRef }
+>) => {
     const t = useTranslations("Workspace.nodes");
     const tBase = useTranslations("Workspace.nodes.base");
     const form = useAbiForm("gen-text");
@@ -56,6 +69,45 @@ const GenTextNode = ({
     const [isFullscreenOpen, setIsFullscreenOpen] = useState(false);
     const [fullscreenValue, setFullscreenValue] = useState("");
 
+    // Skill (reusable prompt pack from an installed tongflow-package-*).
+    // `skill` is a UI-only node.data field — buildPrompts only assembles ABI
+    // fields, so the ref never leaks into the task prompt by itself.
+    const nodeId = useNodeId();
+    const flowUpdates = useFlow((s) => s.updates);
+    const skillRef = data.skill;
+    const { registry: skillsRegistry } = useSkillsRegistry();
+    const activeSkill = resolveSkill(skillsRegistry, skillRef);
+
+    const setSkill = useCallback(
+        (ref: SkillRef | null) => {
+            if (!nodeId) return;
+            flowUpdates(nodeId, { ...data, skill: ref ?? undefined });
+        },
+        [nodeId, flowUpdates, data],
+    );
+
+    // Read the skill body via getState() at run time (not from the render
+    // closure) so an edited package always contributes its latest content.
+    const transformPrompts = useCallback(
+        (prompts: Record<string, unknown>[]) => {
+            if (!skillRef) return prompts;
+            const skill = resolveSkill(
+                useSkillsRegistryStore.getState().registry,
+                skillRef,
+            );
+            // Uninstalled package / removed skill: degrade to a no-op.
+            if (!skill) return prompts;
+            return prompts.map((p) => ({
+                ...p,
+                userPrompt: composeSkillPrompt(
+                    skill.content,
+                    typeof p.userPrompt === "string" ? p.userPrompt : "",
+                ),
+            }));
+        },
+        [skillRef],
+    );
+
     return (
         <>
             <AbiNodeShell
@@ -70,7 +122,10 @@ const GenTextNode = ({
                 title={t("titles.textGenText")}
                 icon={<Wand2 className="h-5 w-5" />}
                 executeLabel={tBase("execute")}
-                executeDisabled={!effectivePrompt.trim() || !texts?.length}
+                executeDisabled={
+                    (!effectivePrompt.trim() && !activeSkill) || !texts?.length
+                }
+                transformPrompts={transformPrompts}
                 headerActions={
                     !hasUpstreamPrompt ? (
                         <Button
@@ -89,6 +144,7 @@ const GenTextNode = ({
                 }
             >
                 <div className="p-4 space-y-4">
+                    <NodeSkillSelect value={skillRef} onChange={setSkill} />
                     <div className="space-y-2">
                         {hasUpstreamPrompt ? (
                             <Card className="p-3 bg-muted/50">

--- a/src/ext-default/skills-registry.ts
+++ b/src/ext-default/skills-registry.ts
@@ -1,0 +1,203 @@
+import fs from "node:fs";
+import { join, relative, sep } from "node:path";
+import chokidar, { type FSWatcher } from "chokidar";
+import { logger } from "@/lib/logger";
+import { PluginEnvManifestSchema } from "@/lib/plugins/plugin-env-manifest-schema";
+import { pluginsDir } from "@/lib/runtime/paths.server";
+import type {
+    SkillDefinition,
+    SkillsPackage,
+    SkillsRegistry,
+} from "@/lib/skills/types";
+
+/**
+ * Default skills registry backend: scan `tongflow-package-*` content packages
+ * under the local plugins dir (with a dev watcher for live rescans). A cloud
+ * shell substitutes e.g. a build-time baked registry via
+ * `src/ext/skills-registry.ts`.
+ */
+
+const PACKAGE_PREFIX = "tongflow-package-";
+const SKILLS_SUBDIR = "skills";
+const MANIFEST_FILE = "tongflow.plugin.json";
+
+let cached: SkillsRegistry | null = null;
+let watcher: FSWatcher | null = null;
+let rescanTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Minimal frontmatter parser: a leading `---` line, `key: value` pairs, and a
+ * closing `---` line. Returns null when the block is missing or unterminated.
+ */
+function parseFrontmatter(
+    src: string,
+): { meta: Record<string, string>; body: string } | null {
+    const lines = src.split(/\r?\n/);
+    if (lines[0]?.trim() !== "---") return null;
+    const meta: Record<string, string> = {};
+    for (let i = 1; i < lines.length; i++) {
+        const line = lines[i];
+        if (line.trim() === "---") {
+            return {
+                meta,
+                body: lines
+                    .slice(i + 1)
+                    .join("\n")
+                    .trim(),
+            };
+        }
+        const sepIdx = line.indexOf(":");
+        if (sepIdx === -1) continue;
+        const key = line.slice(0, sepIdx).trim();
+        const value = line.slice(sepIdx + 1).trim();
+        if (key) meta[key] = value;
+    }
+    return null;
+}
+
+function parseSkillFile(id: string, src: string): SkillDefinition | null {
+    const parsed = parseFrontmatter(src);
+    if (!parsed || !parsed.meta.name) return null;
+    return {
+        id,
+        name: parsed.meta.name,
+        description: parsed.meta.description || undefined,
+        category: parsed.meta.category || undefined,
+        content: parsed.body,
+    };
+}
+
+function readPackageMeta(
+    dir: string,
+): Pick<SkillsPackage, "name" | "description" | "icon"> {
+    try {
+        const raw = fs.readFileSync(join(dir, MANIFEST_FILE), "utf8");
+        const parsed = PluginEnvManifestSchema.safeParse(JSON.parse(raw));
+        if (!parsed.success) return {};
+        return {
+            name: parsed.data.plugin?.name,
+            description: parsed.data.plugin?.description,
+            icon: parsed.data.plugin?.icon,
+        };
+    } catch {
+        return {};
+    }
+}
+
+function scanSkills(): SkillsRegistry {
+    const root = pluginsDir();
+    const packages: Record<string, SkillsPackage> = {};
+    const errors: { packageId: string; message: string }[] = [];
+
+    let entries: string[] = [];
+    try {
+        entries = fs.readdirSync(root).sort();
+    } catch {
+        // Plugins dir not created yet — empty registry.
+    }
+
+    for (const id of entries) {
+        if (!id.startsWith(PACKAGE_PREFIX)) continue;
+        const dir = join(root, id);
+        try {
+            if (!fs.statSync(dir).isDirectory()) continue;
+        } catch {
+            continue;
+        }
+
+        const skillsDir = join(dir, SKILLS_SUBDIR);
+        const skills: SkillDefinition[] = [];
+        let files: string[] = [];
+        try {
+            files = fs
+                .readdirSync(skillsDir)
+                .filter((f) => f.endsWith(".md"))
+                .sort();
+        } catch {
+            errors.push({
+                packageId: id,
+                message: `${skillsDir}: missing ${SKILLS_SUBDIR}/ directory`,
+            });
+        }
+        for (const file of files) {
+            const path = join(skillsDir, file);
+            let skill: SkillDefinition | null = null;
+            try {
+                skill = parseSkillFile(
+                    file.replace(/\.md$/, ""),
+                    fs.readFileSync(path, "utf8"),
+                );
+            } catch (e) {
+                errors.push({
+                    packageId: id,
+                    message: `${path}: ${e instanceof Error ? e.message : String(e)}`,
+                });
+                continue;
+            }
+            if (!skill) {
+                errors.push({
+                    packageId: id,
+                    message: `${path}: missing or malformed frontmatter (expected a leading --- block with a name)`,
+                });
+                continue;
+            }
+            skills.push(skill);
+        }
+
+        packages[id] = { id, ...readPackageMeta(dir), skills };
+    }
+
+    return {
+        generatedAt: new Date().toISOString(),
+        packages,
+        errors: errors.length > 0 ? errors : undefined,
+    };
+}
+
+function scheduleRescan(): void {
+    if (rescanTimer) clearTimeout(rescanTimer);
+    rescanTimer = setTimeout(() => {
+        cached = scanSkills();
+        logger.debug("[skills] Registry refreshed");
+    }, 300);
+}
+
+// chokidar v4 has no glob support, so watch the plugins root and filter events
+// down to tongflow-package-* content in the handler.
+function ensureDevWatcher(): void {
+    if (process.env.NODE_ENV === "production" || watcher) return;
+    watcher = chokidar.watch(pluginsDir(), {
+        ignoreInitial: true,
+        ignored: (path) =>
+            [".git", "__pycache__", ".venv", "node_modules"].some((part) =>
+                path.split(sep).includes(part),
+            ),
+    });
+    watcher.on("all", (_event, path) => {
+        const rel = relative(pluginsDir(), path);
+        if (!rel.startsWith(PACKAGE_PREFIX)) return;
+        scheduleRescan();
+    });
+    watcher.on("error", (e) => {
+        logger.warn(
+            "[skills] Registry watcher error:",
+            e instanceof Error ? e.message : String(e),
+        );
+    });
+}
+
+export function loadSkillsRegistry(): SkillsRegistry {
+    if (cached) return cached;
+    ensureDevWatcher();
+    cached = scanSkills();
+    return cached;
+}
+
+export function invalidateSkillsRegistry(): SkillsRegistry {
+    cached = null;
+    if (rescanTimer) {
+        clearTimeout(rescanTimer);
+        rescanTimer = null;
+    }
+    return loadSkillsRegistry();
+}

--- a/src/hooks/use-skills.ts
+++ b/src/hooks/use-skills.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect } from "react";
+import { create } from "zustand";
+import type {
+    SkillDefinition,
+    SkillRef,
+    SkillsRegistry,
+} from "@/lib/skills/types";
+
+type SkillsRegistryState = {
+    registry: SkillsRegistry | null;
+    isLoaded: boolean;
+    isLoading: boolean;
+    error: Error | null;
+};
+
+let fetchPromise: Promise<void> | null = null;
+
+export const useSkillsRegistryStore = create<SkillsRegistryState>(() => ({
+    registry: null,
+    isLoaded: false,
+    isLoading: false,
+    error: null,
+}));
+
+async function loadRegistry(): Promise<void> {
+    const state = useSkillsRegistryStore.getState();
+    if (state.isLoaded || fetchPromise)
+        return fetchPromise ?? Promise.resolve();
+
+    useSkillsRegistryStore.setState({ isLoading: true });
+
+    fetchPromise = (async () => {
+        try {
+            const res = await fetch("/api/skills/registry", {
+                cache: "no-store",
+                credentials: "same-origin",
+            });
+            if (!res.ok) {
+                const j = (await res.json()) as { error?: string };
+                throw new Error(j.error || `HTTP ${res.status}`);
+            }
+            const payload = (await res.json()) as SkillsRegistry;
+            useSkillsRegistryStore.setState({
+                registry: payload,
+                isLoaded: true,
+                isLoading: false,
+                error: null,
+            });
+        } catch (e) {
+            useSkillsRegistryStore.setState({
+                isLoaded: false,
+                isLoading: false,
+                error: e instanceof Error ? e : new Error(String(e)),
+            });
+        } finally {
+            fetchPromise = null;
+        }
+    })();
+
+    return fetchPromise;
+}
+
+export function useSkillsRegistry() {
+    const registry = useSkillsRegistryStore((s) => s.registry);
+    const isLoaded = useSkillsRegistryStore((s) => s.isLoaded);
+    const isLoading = useSkillsRegistryStore((s) => s.isLoading);
+    const error = useSkillsRegistryStore((s) => s.error);
+
+    useEffect(() => {
+        void loadRegistry();
+    }, []);
+
+    return { registry, isLoaded, isLoading, error };
+}
+
+/**
+ * Force refresh from the server (e.g. after a package install/uninstall).
+ */
+export async function refreshSkillsRegistry(): Promise<void> {
+    useSkillsRegistryStore.setState({ isLoaded: false });
+    await loadRegistry();
+}
+
+/**
+ * Resolve a node's skill reference against a registry snapshot. Returns null
+ * when the package was uninstalled or the skill no longer exists in it.
+ */
+export function resolveSkill(
+    registry: SkillsRegistry | null,
+    ref: SkillRef | undefined,
+): SkillDefinition | null {
+    if (!registry || !ref) return null;
+    const pkg = registry.packages[ref.package];
+    return pkg?.skills.find((s) => s.id === ref.id) ?? null;
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -9,7 +9,7 @@
         "upToDate": "Up to date",
         "checkUpdates": "Check for updates",
         "emptyOfficial": "No official plugins available",
-        "customHint": "The repository name must follow the tongflow-modal-* or tongflow-api-* convention, otherwise it cannot be detected.",
+        "customHint": "The repository name must follow the tongflow-modal-*, tongflow-api-*, tongflow-router-* or tongflow-package-* convention, otherwise it cannot be detected.",
         "cloneButton": "Clone & install",
         "installSuccess": "Installed {id}",
         "updateSuccess": "Updated {id}",
@@ -200,6 +200,18 @@
         "tidyLayout": "Tidy layout"
     },
     "Workspace": {
+        "skills": {
+            "select": "Skill",
+            "empty": "No skill packages installed. Install a tongflow-package-* content package from the plugins panel.",
+            "missing": "Skill unavailable — its package was uninstalled or the skill was removed.",
+            "clear": "Remove skill",
+            "categories": {
+                "text": "Text",
+                "imagePrompt": "Image prompts",
+                "videoPrompt": "Video prompts",
+                "other": "Other"
+            }
+        },
         "edges": {
             "deleteConfirmTitle": "Delete connection?",
             "deleteConfirmDescription": "This connection isn't attached to any node. Delete it?",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -9,7 +9,7 @@
         "upToDate": "最新です",
         "checkUpdates": "更新を確認",
         "emptyOfficial": "利用可能な公式プラグインがありません",
-        "customHint": "リポジトリ名は tongflow-modal-* または tongflow-api-* の規約に従う必要があります。従わない場合は検出できません。",
+        "customHint": "リポジトリ名は tongflow-modal-*、tongflow-api-*、tongflow-router-* または tongflow-package-* の規約に従う必要があります。従わない場合は検出できません。",
         "cloneButton": "クローンしてインストール",
         "installSuccess": "{id} をインストールしました",
         "updateSuccess": "{id} を更新しました",
@@ -200,6 +200,18 @@
         "tidyLayout": "レイアウト整理"
     },
     "Workspace": {
+        "skills": {
+            "select": "スキル",
+            "empty": "スキルパッケージが未インストールです。プラグインパネルから tongflow-package-* パッケージをインストールしてください。",
+            "missing": "スキルを利用できません — パッケージがアンインストールされたか、スキルが削除されました。",
+            "clear": "スキルを解除",
+            "categories": {
+                "text": "テキスト",
+                "imagePrompt": "画像プロンプト",
+                "videoPrompt": "動画プロンプト",
+                "other": "その他"
+            }
+        },
         "edges": {
             "deleteConfirmTitle": "接続を削除しますか？",
             "deleteConfirmDescription": "この接続はどのノードにも接続されていません。削除しますか？",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -9,7 +9,7 @@
         "upToDate": "최신 상태",
         "checkUpdates": "업데이트 확인",
         "emptyOfficial": "사용 가능한 공식 플러그인이 없습니다",
-        "customHint": "저장소 이름은 tongflow-modal-* 또는 tongflow-api-* 규칙을 따라야 하며, 그렇지 않으면 감지할 수 없습니다.",
+        "customHint": "저장소 이름은 tongflow-modal-*, tongflow-api-*, tongflow-router-* 또는 tongflow-package-* 규칙을 따라야 하며, 그렇지 않으면 감지할 수 없습니다.",
         "cloneButton": "복제 및 설치",
         "installSuccess": "{id} 설치 완료",
         "updateSuccess": "{id} 업데이트 완료",
@@ -200,6 +200,18 @@
         "tidyLayout": "레이아웃 정리"
     },
     "Workspace": {
+        "skills": {
+            "select": "스킬",
+            "empty": "설치된 스킬 패키지가 없습니다. 플러그인 패널에서 tongflow-package-* 패키지를 설치하세요.",
+            "missing": "스킬을 사용할 수 없습니다 — 패키지가 제거되었거나 스킬이 삭제되었습니다.",
+            "clear": "스킬 해제",
+            "categories": {
+                "text": "텍스트",
+                "imagePrompt": "이미지 프롬프트",
+                "videoPrompt": "비디오 프롬프트",
+                "other": "기타"
+            }
+        },
         "edges": {
             "deleteConfirmTitle": "연결을 삭제하시겠습니까?",
             "deleteConfirmDescription": "이 연결은 어떤 노드에도 연결되어 있지 않습니다. 삭제하시겠습니까?",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -9,7 +9,7 @@
         "upToDate": "已是最新",
         "checkUpdates": "检查更新",
         "emptyOfficial": "暂无官方插件",
-        "customHint": "仓库名需符合 tongflow-modal-* 或 tongflow-api-* 约定，否则无法被识别。",
+        "customHint": "仓库名需符合 tongflow-modal-*、tongflow-api-*、tongflow-router-* 或 tongflow-package-* 约定，否则无法被识别。",
         "cloneButton": "克隆并安装",
         "installSuccess": "已安装 {id}",
         "updateSuccess": "已更新 {id}",
@@ -200,6 +200,18 @@
         "tidyLayout": "一键整理"
     },
     "Workspace": {
+        "skills": {
+            "select": "技能",
+            "empty": "尚未安装技能包——请在插件面板安装 tongflow-package-* 内容包。",
+            "missing": "技能不可用——所属技能包已卸载或该技能已被移除。",
+            "clear": "移除技能",
+            "categories": {
+                "text": "文本",
+                "imagePrompt": "图像提示词",
+                "videoPrompt": "视频提示词",
+                "other": "其他"
+            }
+        },
         "edges": {
             "deleteConfirmTitle": "删除连线？",
             "deleteConfirmDescription": "这条连线没有连接到任何节点，是否删除它？",

--- a/src/lib/plugins/plugins-install.server.ts
+++ b/src/lib/plugins/plugins-install.server.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/plugins/official-plugins.server";
 import { invalidatePluginsRegistry } from "@/lib/plugins/plugins-registry.server";
 import { pluginsDir } from "@/lib/runtime/paths.server";
+import { invalidateSkillsRegistry } from "@/lib/skills/skills-registry.server";
 
 // We clone with isomorphic-git (pure JS) so the host does not need a system git
 // binary. Trade-off: isomorphic-git speaks HTTP(S) only — SSH remotes are not
@@ -23,7 +24,13 @@ const PLUGIN_GIT_AUTHOR = { name: "tongflow", email: "tongflow@local" };
 // The scanner only detects directories that follow the naming convention; a
 // plugin cloned under any other name is silently ignored. We enforce the prefix
 // up front so a custom git URL either yields a usable plugin or a clear error.
-const PLUGIN_ID_RE = /^tongflow-(modal|api)-[a-z0-9][a-z0-9-]*$/;
+// tongflow-package-* are content packages (skill packs, no executable code)
+// discovered by the skills registry instead of the plugin scanner.
+const PLUGIN_ID_RE = /^tongflow-(modal|api|router|package)-[a-z0-9][a-z0-9-]*$/;
+
+function isContentPackageId(id: string): boolean {
+    return id.startsWith("tongflow-package-");
+}
 
 export interface InstallResult {
     id: string;
@@ -70,7 +77,7 @@ function assertSafeGitUrl(gitUrl: string): void {
 function assertValidPluginId(id: string): void {
     if (!PLUGIN_ID_RE.test(id)) {
         throw new PluginInstallError(
-            `Plugin directory "${id}" must match the tongflow-modal-* or tongflow-api-* convention, otherwise the scanner cannot detect it.`,
+            `Plugin directory "${id}" must match the tongflow-modal-*, tongflow-api-*, tongflow-router-* or tongflow-package-* convention, otherwise the scanner cannot detect it.`,
         );
     }
 }
@@ -155,6 +162,13 @@ export async function installPlugin(params: {
     logger.info(`[plugins] ${action}: ${id}`);
 
     // Rescan so the new plugin shows up in the registry without a restart.
+    // Content packages are invisible to the plugin scanner — their "recognized"
+    // signal is the skills registry finding at least one skill in them.
+    if (isContentPackageId(id)) {
+        const skillsRegistry = invalidateSkillsRegistry();
+        const pkg = skillsRegistry.packages[id];
+        return { id, action, recognized: Boolean(pkg?.skills.length) };
+    }
     const registry = invalidatePluginsRegistry();
     const recognized = Boolean(registry.plugins[id]);
 
@@ -196,7 +210,11 @@ export async function uninstallPlugin(id: string): Promise<UninstallResult> {
     logger.info(`[plugins] uninstalled: ${id}`);
 
     // Rescan so the removed plugin disappears from node pickers immediately.
-    invalidatePluginsRegistry();
+    if (isContentPackageId(id)) {
+        invalidateSkillsRegistry();
+    } else {
+        invalidatePluginsRegistry();
+    }
 
     return { id };
 }

--- a/src/lib/skills/compose.ts
+++ b/src/lib/skills/compose.ts
@@ -1,0 +1,11 @@
+/**
+ * Merge a skill's prompt body with the user's own instruction into the single
+ * `userPrompt` string the gen-text ABI slot accepts. The skill body leads so it
+ * acts as the framing instruction; either part may be empty.
+ */
+export function composeSkillPrompt(
+    skillBody: string,
+    userPrompt: string,
+): string {
+    return [skillBody.trim(), userPrompt.trim()].filter(Boolean).join("\n\n");
+}

--- a/src/lib/skills/skills-registry.server.ts
+++ b/src/lib/skills/skills-registry.server.ts
@@ -1,0 +1,12 @@
+import "server-only";
+
+/**
+ * Skills registry seam: the default backend (src/ext-default/
+ * skills-registry.ts) scans tongflow-package-* content packages under the
+ * local plugins dir with a dev watcher; a cloud shell substitutes e.g. a
+ * build-time baked registry via src/ext/skills-registry.ts.
+ */
+export {
+    invalidateSkillsRegistry,
+    loadSkillsRegistry,
+} from "@ext/skills-registry";

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Skill packages: `tongflow-package-*` directories under the plugins dir that
+ * ship reusable prompt packs (no executable plugin code). Each skill is one
+ * markdown file under `skills/` — frontmatter for metadata, body as the prompt.
+ * Shared by the server-side registry and the client picker/hook.
+ */
+
+export interface SkillDefinition {
+    /** File-name slug (without `.md`), unique within its package. */
+    id: string;
+    name: string;
+    description?: string;
+    /** Picker grouping hint: conventionally "text" | "image-prompt" | "video-prompt". */
+    category?: string;
+    /** Prompt body (markdown after the frontmatter). */
+    content: string;
+}
+
+export interface SkillsPackage {
+    id: string;
+    /** Presentation metadata from the package's `tongflow.plugin.json`. */
+    name?: string;
+    description?: string;
+    icon?: string;
+    skills: SkillDefinition[];
+}
+
+export interface SkillsRegistry {
+    generatedAt: string;
+    packages: Record<string, SkillsPackage>;
+    errors?: { packageId: string; message: string }[];
+}
+
+/** Reference stored on a node (`node.data.skill`) — non-ABI, UI-only. */
+export interface SkillRef {
+    package: string;
+    id: string;
+    /** Name snapshot so an uninstalled package still renders a labelled chip. */
+    name: string;
+}


### PR DESCRIPTION
## Summary

Adds **skills** — reusable prompt packs — to the text-generation node, distributed as decoupled `tongflow-package-*` content packages (same git-clone install flow as plugins, zero executable code, no DB/in-app editing):

- **Scanner** ([sdk/tongflow/scan.py](../blob/feat/skill-packages/sdk/tongflow/scan.py)): silently skips `tongflow-package-*` dirs (scanner v4) + test.
- **Install chain**: `PLUGIN_ID_RE` accepts `router`/`package` prefixes — this also fixes the pre-existing bug where official **router** plugins failed uninstall with 400. Package installs report `recognized` from the skills registry.
- **Skills registry**: new `src/ext-default/skills-registry.ts` (seam, cloud shell can bake) scanning `skills/*.md` frontmatter; `GET /api/skills/registry`; `use-skills` zustand hook.
- **gen-text node**: skill picker (DropdownMenu, grouped by category); selection stored as a UI-only `node.data.skill` ref; at execution the skill body is prepended to `userPrompt` via the existing `transformPrompts` hook — **no ABI/SDK model changes**. Uninstalled packages degrade gracefully (struck-through chip, no-op at run).
- **Official pack** [tong-io/tongflow-package-skills](https://github.com/tong-io/tongflow-package-skills): 5 writing skills (polish/translate/expand/condense/xiaohongshu) + 7 model prompt-crafting skills (MiniMax-H3, Seedance, Kling, Veo, Seedream, GPT-Image, FLUX) distilled from each vendor's official prompting guide; registered in `official-plugins.json` + READMEs (en/zh/ja) + docs/plugins.md §3.1.

## Verification

- `pnpm lint:check` / `pnpm typecheck` / `pnpm build` pass; `cd sdk && pytest` 72 passed.
- Scanner run against 44 installed dirs: package skipped, no errors, 43 plugins intact.
- Live dev server: `/api/skills/registry` returns all 12 skills with categories, no errors; `/api/plugins/official` lists the pack as installed.
- Not yet hand-tested in the canvas UI: picker interaction, task prompt composition, undo/redo of skill selection.

## Notes

- Cloud (managed) shell needs a baked `src/ext/skills-registry.ts` + rebaked SDK before skills appear there — follow-up in the studio repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)