### PR TITLE
feat(plugins): accept tongflow-local-* plugin id prefix

### DIFF
--- a/sdk/tests/test_scan.py
+++ b/sdk/tests/test_scan.py
@@ -111,3 +111,14 @@ def test_scan_accepts_router_prefix(tmp_path):
     payload = _entry(root, _write_abi(tmp_path))
     assert payload["errors"] == []
     assert "tongflow-router-fake" in payload["plugins"]
+
+
+def test_scan_accepts_local_prefix(tmp_path):
+    # tongflow-local-* (on-device engine plugins) are entry.py runners like -api-.
+    root = tmp_path / "plugins"
+    pdir = root / "tongflow-local-fake"
+    pdir.mkdir(parents=True)
+    (pdir / "entry.py").write_text(_HANDLERS, encoding="utf-8")
+    payload = _entry(root, _write_abi(tmp_path))
+    assert payload["errors"] == []
+    assert "tongflow-local-fake" in payload["plugins"]

--- a/sdk/tongflow/scan.py
+++ b/sdk/tongflow/scan.py
@@ -17,7 +17,7 @@ from ._ast_utils import (
 )
 from .parse_deploy import _slot_to_ident, parse_deploy_py
 
-SCANNER_VERSION = 3
+SCANNER_VERSION = 4
 
 SKIP_DIR_NAMES = frozenset(
     {
@@ -61,6 +61,7 @@ def _detect_runner(plugin_dir: Path) -> tuple[str | None, str | None]:
         lowered.startswith("tongflow-modal-")
         or lowered.startswith("tongflow-api-")
         or lowered.startswith("tongflow-router-")
+        or lowered.startswith("tongflow-local-")
     ):
         return None, (
             f"{plugin_dir}:1: pluginId must be all lowercase; "
@@ -91,10 +92,15 @@ def _detect_runner(plugin_dir: Path) -> tuple[str | None, str | None]:
         # Aggregator/router plugins (one key routing to many third-party models)
         # are entry.py-based local runners — identical execution to "api".
         prefix_runner = "api"
+    elif plugin_id.startswith("tongflow-local-"):
+        # On-device engine plugins (e.g. a native Metal binary) — entry.py-based
+        # local runners like "api", named honestly: no key, no remote calls.
+        prefix_runner = "api"
     else:
         return None, (
             f"{plugin_dir}:1: unknown pluginId prefix; "
-            "fix: use tongflow-modal-<name>, tongflow-api-<name>, or tongflow-router-<name>"
+            "fix: use tongflow-modal-<name>, tongflow-api-<name>, "
+            "tongflow-router-<name>, or tongflow-local-<name>"
         )
 
     if not has_deploy and not has_entry:

--- a/src/lib/plugins/plugins-install.server.ts
+++ b/src/lib/plugins/plugins-install.server.ts
@@ -23,7 +23,7 @@ const PLUGIN_GIT_AUTHOR = { name: "tongflow", email: "tongflow@local" };
 // The scanner only detects directories that follow the naming convention; a
 // plugin cloned under any other name is silently ignored. We enforce the prefix
 // up front so a custom git URL either yields a usable plugin or a clear error.
-const PLUGIN_ID_RE = /^tongflow-(modal|api)-[a-z0-9][a-z0-9-]*$/;
+const PLUGIN_ID_RE = /^tongflow-(modal|api|router|local)-[a-z0-9][a-z0-9-]*$/;
 
 export interface InstallResult {
     id: string;
@@ -70,7 +70,7 @@ function assertSafeGitUrl(gitUrl: string): void {
 function assertValidPluginId(id: string): void {
     if (!PLUGIN_ID_RE.test(id)) {
         throw new PluginInstallError(
-            `Plugin directory "${id}" must match the tongflow-modal-* or tongflow-api-* convention, otherwise the scanner cannot detect it.`,
+            `Plugin directory "${id}" must match the tongflow-modal-*, tongflow-api-*, tongflow-router-* or tongflow-local-* convention, otherwise the scanner cannot detect it.`,
         );
     }
 }


### PR DESCRIPTION
## What

Adds `tongflow-local-` as a fourth accepted plugin id prefix, for on-device engine plugins that are neither Modal deployments, API wrappers, nor routers. First consumer: a local MiniMax-H3 plugin backed by the native h3.c Metal engine on Apple Silicon.

- `sdk/tongflow/scan.py` — `tongflow-local-` branch in `_detect_runner` (registered as an `entry.py`-based local runner under the generic `"api"` tag, exactly like `tongflow-router-`), updated lowercase-rename hint and unknown-prefix fix-it message, `SCANNER_VERSION` 3 → 4.
- `src/lib/plugins/plugins-install.server.ts` — `PLUGIN_ID_RE` extended with `router|local` (the scanner already accepted `tongflow-router-` but the installer still rejected it) and the error message updated.
- `sdk/tests/test_scan.py` — `test_scan_accepts_local_prefix`, mirroring the router prefix test.

## Notes

- Conflicts with #140 on `PLUGIN_ID_RE` and `SCANNER_VERSION` (both also touched there); both are one-line resolutions — keep the union of prefixes and take the higher version.
- Verified locally: `cd sdk && pytest` (72 passed), scanner registers a real `tongflow-local-*` directory with all four slots and zero errors, `pnpm lint:check` / `typecheck` / `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)