### PR TITLE
fix(i18n): import canvasMessages from a server-safe entry

### DIFF
--- a/packages/tongflow/README.md
+++ b/packages/tongflow/README.md
@@ -125,7 +125,9 @@ export function Studio() {
   `/api/upload`, `/api/plugins/registry`, …), optionally with a custom
   `fetch` and an asset-URL resolver. Defaults are same-origin.
 - `canvasMessages[locale]` are the i18n catalogs (`en` / `zh` / `ja` / `ko`);
-  merge them into your `use-intl` (or `next-intl`) provider.
+  merge them into your `use-intl` (or `next-intl`) provider. Import them from
+  `tongflow/canvas/messages` in server code (RSC / SSR) — that entry carries no
+  `"use client"` directive.
 - Styling is Tailwind v4 utilities + TongFlow's tokens in `tongflow/canvas.css`
   (no preflight — bring your own base styles). React 18 and 19 are supported.
 

--- a/packages/tongflow/package.json
+++ b/packages/tongflow/package.json
@@ -47,6 +47,16 @@
                 "default": "./dist/canvas.cjs"
             }
         },
+        "./canvas/messages": {
+            "import": {
+                "types": "./dist/canvas-messages.d.ts",
+                "default": "./dist/canvas-messages.js"
+            },
+            "require": {
+                "types": "./dist/canvas-messages.d.cts",
+                "default": "./dist/canvas-messages.cjs"
+            }
+        },
         "./canvas.css": "./dist/canvas.css",
         "./abi": "./abi/tongflow.abi.json",
         "./package.json": "./package.json"

--- a/packages/tongflow/tsdown.config.ts
+++ b/packages/tongflow/tsdown.config.ts
@@ -11,7 +11,12 @@ import { defineConfig } from "tsdown";
  */
 export default defineConfig([
     {
-        entry: { index: "src/core/index.ts" },
+        // `canvas-messages` is server-safe (plain JSON catalogs, no "use client")
+        // so RSC / SSR code can merge them into its i18n provider.
+        entry: {
+            index: "src/core/index.ts",
+            "canvas-messages": "src/canvas/i18n/messages.ts",
+        },
         format: ["esm", "cjs"],
         platform: "neutral",
         dts: true,

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,7 +1,7 @@
 import { cookies, headers } from "next/headers";
 import { getRequestConfig } from "next-intl/server";
 import { logger } from "tongflow";
-import { type CanvasLocale, canvasMessages } from "tongflow/canvas";
+import { type CanvasLocale, canvasMessages } from "tongflow/canvas/messages";
 
 export default getRequestConfig(async () => {
     const cookieStore = await cookies();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,10 @@
             "@/*": ["./src/*"],
             "@ext/*": ["./src/ext/*", "./src/ext-default/*"],
             "tongflow": ["./packages/tongflow/src/core/index.ts"],
-            "tongflow/canvas": ["./packages/tongflow/src/canvas/index.ts"]
+            "tongflow/canvas": ["./packages/tongflow/src/canvas/index.ts"],
+            "tongflow/canvas/messages": [
+                "./packages/tongflow/src/canvas/i18n/messages.ts"
+            ]
         }
     },
     "include": [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
     resolve: {
         alias: {
             "@": path.resolve(__dirname, "./src"),
+            "tongflow/canvas/messages": path.resolve(
+                __dirname,
+                "./packages/tongflow/src/canvas/i18n/messages.ts",
+            ),
             "tongflow/canvas": path.resolve(
                 __dirname,
                 "./packages/tongflow/src/canvas/index.ts",


### PR DESCRIPTION
The `tongflow/canvas` entry is a `"use client"` module, so `src/i18n/request.ts` (server) hit *Cannot access canvasMessages.zh on the server*. The catalogs now ship as their own directive-free entry `tongflow/canvas/messages` (tsdown entry + package exports + tsconfig/vitest paths); `request.ts` imports from it. Verified: `next dev` → `/workspace` SSR 200, no server errors; lint/typecheck/build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)