### PR TITLE
fix(ci): publish npm packages with pnpm so workspace: deps are rewritten; dsh-tongflow 0.1.2

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,12 @@
 # Publish the workspace npm packages via npm Trusted Publishing (OIDC): no
 # token, no 2FA prompt, provenance attached.
 #
+# Always publish with `pnpm publish`, never `npm publish`: only pnpm rewrites
+# `workspace:` dependency specs (dsh-tongflow depends on `tongflow: workspace:^`)
+# to the real version in the tarball manifest. `npm publish` ships the literal
+# `workspace:^` and every consumer install fails with
+# ERR_PNPM_WORKSPACE_PKG_NOT_FOUND (dsh-tongflow@0.1.1, issue #157).
+#
 #   packages/tongflow      npm "tongflow"      tag  npm-vX.Y.Z
 #   packages/dsh-tongflow  npm "dsh-tongflow"  tag  dsh-npm-vX.Y.Z
 #
@@ -79,11 +85,24 @@ jobs:
         working-directory: ${{ env.PKG_DIR }}
         run: pnpm typecheck && pnpm test
 
-      - name: Pack (dry run)
+      # Pack with pnpm (rewrites workspace: specs) and refuse to publish a
+      # manifest that still carries a workspace: dependency.
+      - name: Pack and verify manifest
         working-directory: ${{ env.PKG_DIR }}
-        run: npm pack --dry-run
+        run: |
+          pnpm pack --pack-destination /tmp/pack
+          TGZ="$(ls /tmp/pack/*.tgz)"
+          tar -xOzf "$TGZ" package/package.json > /tmp/pack/manifest.json
+          cat /tmp/pack/manifest.json
+          if grep -q '"workspace:' /tmp/pack/manifest.json; then
+            echo "packed package.json still contains a workspace: dependency" >&2
+            exit 1
+          fi
 
+      # pnpm rewrites workspace: specs at publish time and delegates to the npm
+      # CLI (>= 11.5.1) for the OIDC trusted-publishing exchange. --no-git-checks:
+      # tag builds run on a detached HEAD.
       - name: Publish
         if: github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         working-directory: ${{ env.PKG_DIR }}
-        run: npm publish --access public --provenance
+        run: pnpm publish --access public --provenance --no-git-checks

--- a/packages/dsh-tongflow/package.json
+++ b/packages/dsh-tongflow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dsh-tongflow",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "TongFlow studio plugin for DeepSeek Harness (dsh): film-crew style project model, agent-authored TongFlow workflows, deterministic media generation, embedded canvas.",
     "author": "tong-io",
     "license": "AGPL-3.0-only",


### PR DESCRIPTION
Fixes #157

## Problem

`dsh-tongflow@0.1.1` on npm ships `"tongflow": "workspace:^"` in its published `package.json`, so any install (`pnpm add dsh-tongflow`, `dsh plugin --profile web add dsh-tongflow`, dshmarket) fails with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`.

Root cause: [`npm-publish.yml`](.github/workflows/npm-publish.yml) packed and published with `npm pack` / `npm publish`, which do not rewrite pnpm `workspace:` specs. Only `pnpm pack` / `pnpm publish` do.

## Fix

- Workflow packs with `pnpm pack`, extracts the tarball manifest and **fails the job if it still contains a `workspace:` spec**, then publishes with `pnpm publish --access public --provenance --no-git-checks` (pnpm delegates the OIDC trusted-publishing exchange to the npm CLI ≥ 11.5.1 already installed by the workflow; `--no-git-checks` because tag builds run on a detached HEAD).
- `packages/dsh-tongflow` → **0.1.2** for the republish. Same code as 0.1.1.

## Verification

Locally from this branch: `pnpm build:packages && cd packages/dsh-tongflow && pnpm pack` yields a manifest with `"tongflow": "^0.2.0"`. Installing that tarball in the issue's minimal repro workspace (`pnpm-workspace.yaml` + empty `package.json`, `pnpm add <tgz>`) succeeds and resolves `tongflow@0.2.0` from npm.

## After merge

Push tag `dsh-npm-v0.1.2` on the merge commit to trigger the publish (or `workflow_dispatch` with `package=dsh-tongflow`, `dry_run=true` first to see the manifest check in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)