### PR TITLE
chore(release): v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-08-19
+
 ### Added
 
 - **CometAPI router plugin** —

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tongflow-app",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "description": "A multi-modal AIGC studio for building generative AI workflows",
     "author": "tong-io",
     "keywords": [


### PR DESCRIPTION
Cut v0.3.4: CHANGELOG section + package.json bump.

Highlights (see CHANGELOG): CometAPI and ToAPIs router plugins, live model catalogs for the model picker (public via browser fetch, authenticated via `/api/plugins/model-catalog`), Agnes unregistered. SDK 0.3.2 on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)