### PR TITLE
fix(canvas): pad the speech / voice / watermark nodes' body card

### DIFF
--- a/packages/tongflow/src/canvas/nodes/transfer/convert-voice.tsx
+++ b/packages/tongflow/src/canvas/nodes/transfer/convert-voice.tsx
@@ -58,7 +58,7 @@ const ConvertVoiceNode = ({ selected, data }: ConvertVoiceRfProps) => {
             executeDisabled={!fileKeys?.length}
         >
             <Card
-                className="p-5 nodrag"
+                className="mx-4 mb-4 p-4 nodrag"
                 onPointerDown={(e) => e.stopPropagation()}
             >
                 <div className="mb-4 flex flex-wrap items-center gap-3">

--- a/packages/tongflow/src/canvas/nodes/transfer/remove-watermark.tsx
+++ b/packages/tongflow/src/canvas/nodes/transfer/remove-watermark.tsx
@@ -25,7 +25,7 @@ const RemoveWatermarkNode = ({ selected, data }: RemoveWatermarkRfProps) => {
             executeLabel={t("actions.removeWatermark")}
             executeDisabled={!fileKeys?.length}
         >
-            <Card className="p-5 space-y-4">
+            <Card className="mx-4 mb-4 p-4 space-y-4">
                 <div className="text-sm text-muted-foreground">
                     {t("removeWatermark.hint")}
                 </div>

--- a/packages/tongflow/src/canvas/nodes/transfer/text-gen-speech-clone.tsx
+++ b/packages/tongflow/src/canvas/nodes/transfer/text-gen-speech-clone.tsx
@@ -75,7 +75,7 @@ const TextGenSpeechCloneNode = ({
             executeDisabled={!texts?.length || !refAudio}
         >
             <Card
-                className="p-5 nodrag"
+                className="mx-4 mb-4 p-4 nodrag"
                 onPointerDown={(e) => e.stopPropagation()}
             >
                 <div className="mb-3 flex flex-wrap items-center gap-3">

--- a/packages/tongflow/src/canvas/nodes/transfer/text-gen-speech-instruct.tsx
+++ b/packages/tongflow/src/canvas/nodes/transfer/text-gen-speech-instruct.tsx
@@ -33,7 +33,7 @@ const TextGenSpeechInstructNode = ({
             executeDisabled={!texts?.length}
         >
             <Card
-                className="p-5 nodrag"
+                className="mx-4 mb-4 p-4 nodrag"
                 onPointerDown={(e) => e.stopPropagation()}
             >
                 <div className="mb-4 flex flex-wrap items-center gap-3">

--- a/packages/tongflow/src/canvas/nodes/transfer/text-gen-speech-preset.tsx
+++ b/packages/tongflow/src/canvas/nodes/transfer/text-gen-speech-preset.tsx
@@ -69,7 +69,7 @@ const TextGenSpeechPresetNode = ({
             executeDisabled={!texts?.length}
         >
             <Card
-                className="p-5 nodrag"
+                className="mx-4 mb-4 p-4 nodrag"
                 onPointerDown={(e) => e.stopPropagation()}
             >
                 <div className="mb-4 flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary
`textGenSpeechPreset / Clone / Instruct`, `convertVoice` and `removeWatermark` wrapped their body in a bare `<Card className="p-5">` with no inset, so the card sat flush with the node shell's border (overlapping it visually) and glued to the execute button — most visible in the dsh-tongflow Studio, but identical in the app. They now use the `mx-4 mb-4 p-4` inset the other nodes already use.

## Test plan
- [x] `pnpm build:packages`
- [x] Rendered in the dsh Studio canvas before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)