### PR TITLE
feat(dsh-tongflow): install every official plugin at start (full canvas catalog)

### DIFF
--- a/packages/dsh-tongflow/README.md
+++ b/packages/dsh-tongflow/README.md
@@ -20,7 +20,7 @@ npx @deepseek-ai/dsh@next plugin --profile web add dsh-tongflow      # from npm
 npx @deepseek-ai/dsh@next web
 ```
 
-Requirements: dsh ≥ 0.1.0-rc.7 (Node ≥ 22.19), **Python ≥ 3.10** on `PATH` (or `pythonPath` in the plugin config), `git`, and `ffmpeg` for video contact sheets. On first use the plugin creates `~/.dsh/tongflow/venv` with the `tongflow` SDK; TongFlow plugins are cloned into `~/.dsh/tongflow/plugins` on demand.
+Requirements: dsh ≥ 0.1.0-rc.7 (Node ≥ 22.19), **Python ≥ 3.10** on `PATH` (or `pythonPath` in the plugin config), `git`, and `ffmpeg` for video contact sheets. On first use the plugin creates `~/.dsh/tongflow/venv` with the `tongflow` SDK and shallow-clones every official TongFlow plugin into `~/.dsh/tongflow/plugins` (the live list from `config/official-plugins.json`; set `autoInstallOfficial: false` to install by hand), so the canvas offers the same node/plugin catalog as the hosted app. Keys and Modal deploys are only needed when something runs.
 
 Start a session whose **first message begins with `@tongflow`** — that session becomes a studio session: the conversation view turns into the Studio (chat column · the project's folder tree · preview / editor / canvas · a runs drawer, all in the UI language of your browser), and the agent gets the `tongflow_*` tools and skill. Any other session is untouched dsh. In the Studio: create a project (a title and a brief — what you want to make), install TongFlow plugins and paste API keys under **Plugins & keys**, then talk to the agent — or click any file to preview / edit it, click a workflow to open it on the canvas.
 
@@ -101,6 +101,7 @@ Skill shipped: `tongflow-studio` (the working method: research → propose a str
 | `maxConcurrentRuns` | `2` | |
 | `httpPrefix` | `/tongflow` | |
 | `locale` | `en` | canvas UI locale (`en` / `zh` / `ja` / `ko`) |
+| `autoInstallOfficial` | `true` | at start, shallow-clone every official plugin that is missing (a few hundred KB each) so the canvas offers the full catalog; API keys / Modal deploys are only needed when a workflow runs |
 
 ## Development
 

--- a/packages/dsh-tongflow/src/config.ts
+++ b/packages/dsh-tongflow/src/config.ts
@@ -22,6 +22,8 @@ export interface Config {
     httpPrefix: string;
     /** UI locale for the embedded canvas (en / zh / ja / ko). */
     locale: string;
+    /** Clone every official plugin at start so the canvas offers the full catalog (shallow clones; keys / deploys only at run time). */
+    autoInstallOfficial: boolean;
 }
 
 export const Config: z<Config> = z.object({
@@ -34,4 +36,5 @@ export const Config: z<Config> = z.object({
     maxConcurrentRuns: z.number().default(2),
     httpPrefix: z.string().default("/tongflow"),
     locale: z.string().default("en"),
+    autoInstallOfficial: z.boolean().default(true),
 });

--- a/packages/dsh-tongflow/src/engine/registry.ts
+++ b/packages/dsh-tongflow/src/engine/registry.ts
@@ -38,7 +38,11 @@ export interface StudioRegistry {
 
 export const OFFICIAL_ORG = "https://github.com/tong-io";
 
-/** Official plugin ids (mirrors config/official-plugins.json in the TongFlow repo). */
+/**
+ * Official plugin ids — fallback snapshot of `config/official-plugins.json`
+ * in the TongFlow repo; `RegistryManager.officialIds()` fetches the live list
+ * and falls back to this one offline.
+ */
 export const OFFICIAL_PLUGINS: readonly string[] = [
     "tongflow-router-openrouter",
     "tongflow-router-cometapi",
@@ -56,10 +60,9 @@ export const OFFICIAL_PLUGINS: readonly string[] = [
     "tongflow-modal-pyscenedetect",
     "tongflow-modal-z-image",
     "tongflow-modal-ernie-image",
+    "tongflow-modal-krea2",
     "tongflow-modal-flux2-klein9b",
     "tongflow-modal-boogu",
-    "tongflow-modal-ltx",
-    "tongflow-modal-fastwan",
     "tongflow-modal-infinitetalk",
     "tongflow-modal-wan-animate",
     "tongflow-modal-scail2",
@@ -69,14 +72,29 @@ export const OFFICIAL_PLUGINS: readonly string[] = [
     "tongflow-modal-triposplat",
     "tongflow-modal-sam-3d-objects",
     "tongflow-modal-sam-3d-body",
-    "tongflow-modal-sam-audio",
     "tongflow-modal-sapiens2",
+    "tongflow-modal-sensenova-vision",
+    "tongflow-modal-seedvr2",
+    "tongflow-modal-gemma4",
     "tongflow-modal-qwen38",
+    "tongflow-modal-qwen3asr",
+    "tongflow-modal-qwen3tts",
     "tongflow-modal-indextts2",
-    "tongflow-modal-acestep",
+    "tongflow-modal-whisper",
+    "tongflow-modal-ace-step",
+    "tongflow-modal-levo",
     "tongflow-modal-minimax-music3",
-    "tongflow-modal-krea2",
+    "tongflow-modal-sam-audio",
+    "tongflow-modal-docling",
+    "tongflow-modal-paddle",
+    "tongflow-modal-unlimited-ocr",
+    "tongflow-modal-crawl4ai",
+    "tongflow-modal-scrapling",
 ];
+
+/** Where the live official list is fetched from. */
+export const OFFICIAL_PLUGINS_URL =
+    "https://raw.githubusercontent.com/tong-io/tongflow/main/config/official-plugins.json";
 
 const PLUGIN_ID_RE = /^tongflow-(modal|api|router|local)-[a-z0-9-]+$/;
 
@@ -87,6 +105,7 @@ export function isPluginId(id: string): boolean {
 export class RegistryManager {
     private cache: StudioRegistry | undefined;
     private inflight: Promise<StudioRegistry> | undefined;
+    private officialCache: { ids: string[]; at: number } | undefined;
 
     constructor(
         private readonly opts: {
@@ -135,6 +154,78 @@ export class RegistryManager {
         }
         this.cache = { registry, meta, scannedAt: new Date().toISOString() };
         return this.cache;
+    }
+
+    /** The official plugin list: live from GitHub (cached 1 h), else the built-in snapshot. */
+    async officialIds(): Promise<string[]> {
+        const now = Date.now();
+        if (this.officialCache && now - this.officialCache.at < 3_600_000)
+            return this.officialCache.ids;
+        let ids: string[] = [...OFFICIAL_PLUGINS];
+        try {
+            const res = await fetch(OFFICIAL_PLUGINS_URL, {
+                signal: AbortSignal.timeout(8000),
+            });
+            if (res.ok) {
+                const body = (await res.json()) as { plugins?: unknown };
+                if (
+                    Array.isArray(body.plugins) &&
+                    body.plugins.every(
+                        (p) => typeof p === "string" && isPluginId(p),
+                    )
+                )
+                    ids = body.plugins as string[];
+            }
+        } catch {
+            // offline: keep the snapshot
+        }
+        this.officialCache = { ids, at: now };
+        return ids;
+    }
+
+    /**
+     * Clone every official plugin that is not installed yet (shallow, a few
+     * hundred KB each) so the canvas offers the full catalog like the hosted
+     * app. Runs in the background at studio start; failures are logged, not
+     * thrown. Returns the ids that were newly installed.
+     */
+    async ensureOfficialInstalled(concurrency = 4): Promise<string[]> {
+        const [official, installed] = await Promise.all([
+            this.officialIds(),
+            this.installedIds(),
+        ]);
+        const have = new Set(installed);
+        const missing = official.filter((id) => !have.has(id));
+        if (missing.length === 0) return [];
+        this.opts.log(
+            `dsh-tongflow: installing ${missing.length} official plugin(s)…`,
+        );
+        const done: string[] = [];
+        let next = 0;
+        const worker = async () => {
+            while (next < missing.length) {
+                const id = missing[next++];
+                try {
+                    const r = await this.install(id);
+                    if (!r.alreadyInstalled) done.push(id);
+                } catch (error) {
+                    this.opts.log(
+                        `dsh-tongflow: install ${id} failed: ${error instanceof Error ? error.message : String(error)}`,
+                    );
+                }
+            }
+        };
+        await Promise.all(
+            Array.from(
+                { length: Math.min(concurrency, missing.length) },
+                worker,
+            ),
+        );
+        if (done.length > 0) this.invalidate();
+        this.opts.log(
+            `dsh-tongflow: installed ${done.length} official plugin(s)`,
+        );
+        return done;
     }
 
     /** Installed plugin ids (directories under pluginsDir). */

--- a/packages/dsh-tongflow/src/http/routes.ts
+++ b/packages/dsh-tongflow/src/http/routes.ts
@@ -442,9 +442,7 @@ function buildRoutes(env: RouteEnv): Route[] {
             pattern: "/plugins",
             handler: async (c) => {
                 const { registry, meta, scannedAt } = await api.registry();
-                const { OFFICIAL_PLUGINS } = await import(
-                    "../engine/registry.ts"
-                );
+                const OFFICIAL_PLUGINS = await studio.registry.officialIds();
                 json(c, {
                     registry,
                     meta,

--- a/packages/dsh-tongflow/src/studio.ts
+++ b/packages/dsh-tongflow/src/studio.ts
@@ -62,6 +62,14 @@ export class Studio {
         await mkdir(this.paths.plugins, { recursive: true });
         await mkdir(this.paths.data, { recursive: true });
         await mkdir(this.paths.tmp, { recursive: true });
+        if (this.config.autoInstallOfficial) {
+            // Background: the studio is usable meanwhile; the registry re-scans when clones land.
+            void this.registry.ensureOfficialInstalled().catch((error) => {
+                this.log(
+                    `dsh-tongflow: official plugin install failed: ${error instanceof Error ? error.message : String(error)}`,
+                );
+            });
+        }
     }
 
     /** The studio venv python (bootstrapped on first use). */

--- a/packages/dsh-tongflow/src/tools/run-tools.ts
+++ b/packages/dsh-tongflow/src/tools/run-tools.ts
@@ -433,9 +433,7 @@ export function runTools(env: ToolEnv): ToolDefinition[] {
             output: { schema: { type: "json" }, render: (_a, v) => text(v) },
             async execute() {
                 const { registry, meta } = await api.registry();
-                const { OFFICIAL_PLUGINS } = await import(
-                    "../engine/registry.ts"
-                );
+                const OFFICIAL_PLUGINS = await studio.registry.officialIds();
                 const installed = Object.entries(registry.plugins).map(
                     ([id, p]) => ({
                         id,

--- a/packages/dsh-tongflow/test/engine.test.ts
+++ b/packages/dsh-tongflow/test/engine.test.ts
@@ -142,7 +142,11 @@ describe("engine bridge", () => {
     });
 
     it("runs a workflow end to end: resolves file refs, places numbered outputs next to the workflow, logs provenance", async () => {
-        const config = Config({ studioRoot, maxConcurrentRuns: 1 });
+        const config = Config({
+            studioRoot,
+            maxConcurrentRuns: 1,
+            autoInstallOfficial: false,
+        });
         const studio = new TestStudio({ config });
         await studio.init();
         const { id, root } = await createProject(studioRoot, { title: "Demo" });
@@ -207,7 +211,7 @@ describe("engine bridge", () => {
     });
 
     it("reports failures and unbound inputs", async () => {
-        const config = Config({ studioRoot });
+        const config = Config({ studioRoot, autoInstallOfficial: false });
         const studio = new TestStudio({ config });
         await studio.init();
         const { id, root } = await createProject(studioRoot, { title: "Demo" });


### PR DESCRIPTION
## Summary
In dsh the canvas only offers installed plugins, and a fresh studio has none — so the plugin dropdowns looked nearly empty compared to the hosted app. Now the studio fetches the live official list (`config/official-plugins.json`, cached 1 h, built-in snapshot as offline fallback) and shallow-clones every missing official plugin in the background at init (`autoInstallOfficial`, default true; ~200 KB each, 46 plugins ≈ 8 MB). API keys / Modal deploys are still only needed when a workflow runs — the billing checkpoint reports missing keys. `tongflow_plugins_list` and the Plugins dialog use the live list too.

## Test plan
- [x] vitest (auto-install off in tests), typecheck, root biome
- [x] Real dsh: fresh start cloned 44 missing plugins in ~40 s; `tongflow_node_catalog` shows 73/78 executable types with a plugin (the 5 remaining slots have no official plugin in the repo either)

🤖 Generated with [Claude Code](https://claude.com/claude-code)