### PR TITLE
fix(lint): never lint or format .open-next build output

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,6 +11,8 @@
             "**",
             "!.next",
             "!**/.next",
+            "!.open-next",
+            "!**/.open-next",
             "!out",
             "!build",
             "!node_modules",


### PR DESCRIPTION
## Summary

`app.tongflow.com` returned **Error 1101 (worker threw exception)** for every signed-in user; anonymous requests were fine. The worker stack was:

```
TypeError: NullObject is not a constructor
    at Object.parseCookie (worker-entry.js:186377:19)
    at Object.convertFrom (…)      ← OpenNext request converter
```

`cookie@1.1.1` (bundled by OpenNext) builds its null-prototype dictionary as

```js
const C = function () {};   // constructible
C.prototype = Object.create(null);
```

The deployed bundle contained `const C = () => {}` instead — an arrow function is **not constructible**, so `new NullObject()` inside `parse()` throws. `parse()` only runs when a `Cookie` header is present, which is why signed-out visitors saw a working site.

The arrow came from **biome**: `biome check --write` applies `style/useArrowFunction` as a safe fix, and `biome.json` ignores `.next` but not `.open-next`, so a lint run over the repo rewrote the built worker bundles between build and `wrangler deploy` (the corrupted files' mtimes sit a minute after the build). `biome format --write` alone does not do this — only the check/fix path.

Fix: ignore `.open-next` (and `**/.open-next`) like `.next`. Verified: a fresh `opennextjs-cloudflare build` emits `const C = function() {` again.

## Test plan

- [x] `pnpm exec biome check --error-on-warnings .` clean
- [x] Rebuilt the cloud worker (`opennextjs-cloudflare build --skipNextBuild`) → `.open-next/**` contains the constructible form
- [ ] Redeploy `tongflow-cloud` (blocked on my side; user runs `npx wrangler deploy`) and re-check a request with a session cookie

🤖 Generated with [Claude Code](https://claude.com/claude-code)