### PR TITLE
fix(dsh-tongflow): name a composed run's outputs after their stage

### DIFF
--- a/packages/dsh-tongflow/src/engine/ingest.ts
+++ b/packages/dsh-tongflow/src/engine/ingest.ts
@@ -27,7 +27,11 @@ export interface IngestOptions {
     result: EngineResult;
     /** Project key of the workflow file; undefined for inline (canvas) documents. */
     workflowKey?: string;
-    /** Workflow output name → label used in file names (composed workflows). */
+    /**
+     * Label used in generated file names, keyed by whatever the engine reports
+     * an output under: a declared workflow output name (`output_<id8>`) or —
+     * when the engine only returns raw node outputs — the producing node's id.
+     */
     outputLabels?: Record<string, string>;
     record: Omit<OutputRecord, "no" | "files" | "texts">;
 }
@@ -59,6 +63,23 @@ function collectFileKeys(value: unknown, into: string[]): void {
     }
 }
 
+const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * A readable file-name tag: real output names (`image`, `caption`) are kept;
+ * a raw node id is shortened to its first segment.
+ */
+function shortTag(output: string, all: Set<string>): string {
+    if (!UUID_RE.test(output)) return output;
+    const short = output.slice(0, 8);
+    // Keep the full id if shortening would collide with another output.
+    const collides = [...all].some(
+        (o) => o !== output && o !== short && o.startsWith(short),
+    );
+    return collides ? output : short;
+}
+
 function looksLikeFile(value: string): boolean {
     return (
         /\.[A-Za-z0-9]{1,5}$/.test(value) &&
@@ -72,18 +93,25 @@ export async function ingestOutputs(
 ): Promise<IngestOutcome> {
     const { projectRoot, result, workflowKey } = options;
     const outcome: IngestOutcome = { files: [], loose: [], texts: {}, no: 0 };
+    // The engine reports outputs either by workflow output name or (the usual
+    // case) as raw per-node outputs keyed by node id; a composed workflow maps
+    // both forms to a readable stage label.
+    const label = (key: string): string => options.outputLabels?.[key] ?? key;
     const byName: Record<string, string[]> = {};
     for (const [name, values] of Object.entries(result.outputs_by_name ?? {})) {
-        const label = options.outputLabels?.[name] ?? name;
-        if (!byName[label]) byName[label] = [];
-        byName[label].push(...values);
+        const l = label(name);
+        if (!byName[l]) byName[l] = [];
+        byName[l].push(...values);
     }
     if (Object.keys(byName).length === 0) {
         // Fall back to scanning raw node outputs for file refs.
         for (const [nodeId, out] of Object.entries(result.outputs ?? {})) {
             const keys: string[] = [];
             collectFileKeys(out, keys);
-            if (keys.length > 0) byName[nodeId] = keys;
+            if (keys.length === 0) continue;
+            const l = label(nodeId);
+            if (!byName[l]) byName[l] = [];
+            byName[l].push(...keys);
         }
     }
     // Split file outputs from text outputs first so the file names can tell
@@ -127,7 +155,7 @@ export async function ingestOutputs(
         const idx = perOutput.get(output) ?? 0;
         perOutput.set(output, idx + 1);
         const parts: string[] = [];
-        if (several) parts.push(output);
+        if (several) parts.push(shortTag(output, outputNames));
         if (count > 1) parts.push(String(idx + 1));
         return outputFileName(
             stem,

--- a/packages/dsh-tongflow/src/project/compose.ts
+++ b/packages/dsh-tongflow/src/project/compose.ts
@@ -10,7 +10,9 @@
  * part's producing executable node. Every stage's product stays an output
  * (a terminal "tap" data node), and `meta.outputLabels` names those outputs
  * after their part so a run of the composed workflow lands
- * `<all>.01.keyframe.png`, `<all>.01.i2v.mp4`, ….
+ * `<all>.01.keyframe.png`, `<all>.01.i2v.mp4`, …. Labels are keyed both by the
+ * exporter's output name (`output_<id8>`) and by the producing node's id,
+ * because the engine reports outputs under either form.
  */
 import { randomUUID } from "node:crypto";
 import { readdir } from "node:fs/promises";
@@ -109,6 +111,24 @@ function producersFor(
             spec?.topology.outputs.some((o) => o.nodeType === dataNodeType),
         );
     });
+}
+
+/**
+ * Record a stage label under every key the engine might report the output as:
+ * the exporter's `output_<id8>` for the output node, and the id (full and
+ * short) of each node that actually produces the file.
+ */
+function labelOutput(
+    labels: Record<string, string>,
+    stem: string,
+    outputNodeId: string,
+    ...producerIds: string[]
+): void {
+    labels[`output_${outputNodeId.substring(0, 8)}`] = stem;
+    for (const id of [outputNodeId, ...producerIds]) {
+        labels[id] = stem;
+        labels[id.substring(0, 8)] = stem;
+    }
 }
 
 function edge(source: Node, target: Node): Edge {
@@ -321,8 +341,12 @@ export async function composeWorkflows(
                     } as Node;
                     nodes.push(tap);
                     edges.push(edge(n, tap));
-                    outputLabels[`output_${tap.id.substring(0, 8)}`] =
-                        producer.pn.part.stem;
+                    labelOutput(
+                        outputLabels,
+                        producer.pn.part.stem,
+                        tap.id,
+                        n.id,
+                    );
                 }
             }
             if (linkedAny) {
@@ -345,8 +369,13 @@ export async function composeWorkflows(
                 !isExec &&
                 type.endsWith("Node") &&
                 edges.some((e) => e.target === n.id);
-            if (isExec || isFedData)
-                outputLabels[`output_${n.id.substring(0, 8)}`] = pn.part.stem;
+            if (!isExec && !isFedData) continue;
+            // A terminal data node is filled by the executable(s) feeding it;
+            // the engine reports the product under those nodes' ids.
+            const feeders = isExec
+                ? [n.id]
+                : edges.filter((e) => e.target === n.id).map((e) => e.source);
+            labelOutput(outputLabels, pn.part.stem, n.id, ...feeders);
         }
     }
 

--- a/packages/dsh-tongflow/test/compose-e2e.manual.test.ts
+++ b/packages/dsh-tongflow/test/compose-e2e.manual.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Manual end-to-end check of compose: builds two real workflows, runs the
+ * first, composes them, then runs the composition through the real engine and
+ * the installed plugins, asserting that stage b consumes stage a's freshly
+ * generated image (the composed edge) and that both stages land as
+ * `chain_all.01.a.*` / `chain_all.01.b.*`.
+ *
+ * Excluded from the suite (see vitest.config.ts): it needs the studio venv at
+ * `~/.dsh/tongflow`, an installed image plugin and its API key, and it SPENDS
+ * MONEY — three paid image calls per run. Run it deliberately:
+ *
+ *   KEEP_E2E=1 pnpm exec vitest run test/compose-e2e.manual.test.ts
+ */
+import { readdir, rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { expect, it } from "vitest";
+import { StudioApi } from "../src/api.ts";
+import { Config } from "../src/config.ts";
+import { Studio } from "../src/studio.ts";
+
+const STUDIO_ROOT = join(homedir(), ".dsh", "tongflow");
+
+it("runs a composed workflow end to end", { timeout: 900_000 }, async () => {
+    const studio = new Studio({
+        config: Config({
+            studioRoot: STUDIO_ROOT,
+            autoInstallOfficial: false,
+        }),
+        log: (l) => console.log("[studio]", l.slice(0, 200)),
+    });
+    await studio.init();
+    const api = new StudioApi(studio);
+
+    const { id: pid, root } = await api
+        .createProject({ title: "Compose E2E" })
+        .then((s) => ({ id: s.id, root: s.root }));
+    console.log("project", pid, root);
+
+    // Stage a: text → image
+    await api.newWorkflow(pid, "chain/a");
+    const pa = await api.patchWorkflow(pid, "chain/a", {
+        add_nodes: [
+            {
+                alias: "t",
+                type: "textNode",
+                data: {
+                    texts: [
+                        "a single red maple leaf on a white background, studio light, centered",
+                    ],
+                },
+            },
+            { alias: "g", type: "textGenImageNode" },
+        ],
+        add_edges: [{ from: "t", to: "g" }],
+    } as never);
+    expect(pa.ok).toBe(true);
+
+    // Run stage a on its own so its output file exists for stage b to reference.
+    const runA = await api.startRun({
+        projectId: pid,
+        workflowKey: "chain/a",
+        note: "e2e stage a",
+    });
+    await runA.done;
+    console.log("run a:", runA.summary.status, runA.error ?? "");
+    expect(runA.summary.status).toBe("completed");
+    const aFile = runA.summary.files[0]?.fileName;
+    console.log("a produced", aFile);
+    expect(aFile).toMatch(/^a\.01\./);
+
+    // Stage b: a's output + a prompt → edited image
+    await api.newWorkflow(pid, "chain/b");
+    const pb = await api.patchWorkflow(pid, "chain/b", {
+        add_nodes: [
+            {
+                alias: "img",
+                type: "imageNode",
+                data: { fileKeys: [`./${aFile}`] },
+            },
+            {
+                alias: "t2",
+                type: "textNode",
+                data: {
+                    texts: ["make the leaf bright blue, keep everything else"],
+                },
+            },
+            { alias: "e", type: "imageGenImageNode" },
+        ],
+        add_edges: [
+            { from: "img", to: "e" },
+            { from: "t2", to: "e" },
+        ],
+    } as never);
+    expect(pb.ok).toBe(true);
+
+    // Compose the folder.
+    const composed = await api.composeWorkflows(pid, { folder: "chain" });
+    console.log("composed:", JSON.stringify(composed));
+    expect(composed.key).toBe("chain/chain_all.tongflow.json");
+    expect(composed.parts).toEqual([
+        "chain/a.tongflow.json",
+        "chain/b.tongflow.json",
+    ]);
+    expect(composed.links).toBe(1);
+    expect(composed.unlinked).toEqual([]);
+
+    const doc = await api.readWorkflow(pid, "chain/chain_all");
+    expect(doc.exportError).toBeUndefined();
+    expect(doc.executable?.executableNodes).toHaveLength(2);
+    console.log(
+        "composed outputs:",
+        doc.executable?.outputs.map(
+            (o) => `${o.name}=${doc.meta.outputLabels?.[o.name]}`,
+        ),
+    );
+
+    // Run the composition: both stages execute, b consuming a's fresh output.
+    const runAll = await api.startRun({
+        projectId: pid,
+        workflowKey: "chain/chain_all",
+        note: "e2e composed",
+    });
+    await runAll.done;
+    console.log("run all:", runAll.summary.status, runAll.error ?? "");
+    for (const line of runAll.events
+        .map((e) => `${e.type} ${e.label ?? e.nodeId ?? ""} ${e.error ?? ""}`)
+        .slice(-12))
+        console.log("  ", line);
+    expect(runAll.summary.status).toBe("completed");
+
+    const names = runAll.summary.files.map((f) => f.fileName).sort();
+    console.log("composed run produced:", names);
+    expect(names).toHaveLength(2);
+    expect(names.some((n) => /^chain_all\.01\.a\./.test(n))).toBe(true);
+    expect(names.some((n) => /^chain_all\.01\.b\./.test(n))).toBe(true);
+
+    console.log("dir:", (await readdir(join(root, "chain"))).sort());
+    if (!process.env.KEEP_E2E) await rm(root, { recursive: true, force: true });
+});

--- a/packages/dsh-tongflow/test/project-model.test.ts
+++ b/packages/dsh-tongflow/test/project-model.test.ts
@@ -581,8 +581,11 @@ describe("compose", () => {
             )
             .flatMap((n) => (n.data as { fileKeys?: string[] }).fileKeys ?? []);
         expect(dataFiles).toEqual(["./line.wav"]);
-        // Every stage is an output, labelled after its part.
-        const labels = Object.values(doc.meta.outputLabels ?? {}).sort();
+        // Every stage is an output, labelled after its part (the same label is
+        // keyed under every id the engine may report the output as).
+        const labels = [
+            ...new Set(Object.values(doc.meta.outputLabels ?? {})),
+        ].sort();
         expect(labels).toEqual(["i2v", "lipsync", "ref"]);
         expect(
             doc.executable?.outputs

--- a/packages/dsh-tongflow/vitest.config.ts
+++ b/packages/dsh-tongflow/vitest.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
         include: ["test/**/*.test.ts"],
+        // `*.manual.test.ts` talks to the real engine, real plugins and paid
+        // APIs — run one explicitly: `pnpm exec vitest run test/<name>`.
+        exclude: ["**/node_modules/**", "test/**/*.manual.test.ts"],
         environment: "node",
     },
 });


### PR DESCRIPTION
## Summary

Composing small workflows built the right graph, but **running** the composition named its outputs after raw node ids:

```
chain_all.01.5851ac0e-c134-47fd-892c-de4d08f8d1df.jpg
chain_all.01.9efc894a-e234-4f42-8ee4-d80a30071571.jpg
```

The real engine leaves `outputs_by_name` empty and reports raw per-node outputs, so ingest fell back to node-id keys while `meta.outputLabels` was keyed by the exporter's output name (`output_<id8>`) — the two never met. (The unit test passed because it fed `outputs_by_name` directly.)

- compose records each stage's label under **every** id the engine may report the output as: the output node's exporter name, and the producing node ids (full + short).
- ingest resolves a label for both forms, and shortens an unlabelled uuid instead of pasting all 36 chars into a file name.

## Test plan

- [x] `pnpm --filter dsh-tongflow test` (15) / typecheck / root biome
- [x] **Real end-to-end** (new `test/compose-e2e.manual.test.ts`, excluded from the suite because it spends money): `chain/a` (text→image) + `chain/b` (image→edit) compose into `chain/chain_all`; running it lands `chain_all.01.a.jpg` and `chain_all.01.b.jpg`, and b's blue leaf is pixel-for-pixel a's *freshly generated* leaf (dried corner and all), not the `a.01.jpg` sitting on disk — so the composed edge really carries the intermediate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)