### PR TITLE
feat(dsh-tongflow): prompt method, failure diagnosis and iteration discipline

### DIFF
--- a/packages/dsh-tongflow/package.json
+++ b/packages/dsh-tongflow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dsh-tongflow",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "TongFlow studio plugin for DeepSeek Harness (dsh): agent-designed project folders, one TongFlow workflow per generated asset stored next to its outputs, deterministic media generation, embedded canvas.",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/packages/dsh-tongflow/skills/references/SOURCES.md
+++ b/packages/dsh-tongflow/skills/references/SOURCES.md
@@ -1,0 +1,37 @@
+# Sources
+
+The method in `prompt-layers.md`, `shot-contract.md`, `failure-codes.md` and
+`iteration.md` is adapted for TongFlow from **Hell Grind AIGC Skill**
+(https://github.com/renmu2017/Hell-Grind-AIGC-Skill), MIT License,
+Copyright (c) 2026 renmu2017:
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this
+> software and associated documentation files (the "Software"), to deal in the Software
+> without restriction, including without limitation the rights to use, copy, modify,
+> merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+> permit persons to whom the Software is furnished to do so, subject to the following
+> conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies
+> or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+> INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+> PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+> HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+> CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+> OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Taken: the layered prompt model, the shot-contract structure, the failure taxonomy, and
+the version/run/selection/iteration distinction. Rewritten in English and rebound to
+TongFlow's own mechanics (workflow files, numbered outputs, `.runs.json`, `{{path}}`
+includes, per-run billing confirmation).
+
+Not taken: the upstream project-folder schema and its CSV tables, and the bundled Python
+tools — a dsh-tongflow project has no fixed template, and its provenance is recorded
+automatically next to each asset.
+
+That upstream project notes its own method was informed by publicly accessible production
+material for Higgsfield's *Hell Grind*, and carries no rights to that film, its assets or
+its project-specific prompts. Neither does this. Do not copy characters, assets or source
+prompts from it into a user's project.

--- a/packages/dsh-tongflow/skills/references/failure-codes.md
+++ b/packages/dsh-tongflow/skills/references/failure-codes.md
@@ -1,0 +1,91 @@
+# When a result is wrong — find the layer, make the smallest fix
+
+"It looks bad" is not a diagnosis. Describe the observable symptom, name the layer that
+owns it, then change the least that could fix it. Adding more negative words is almost
+never the answer.
+
+## Check the layers in this order
+
+| Layer | What to check | Where the fix goes |
+|---|---|---|
+| Asset | Is the approved identity, state and reference good enough? | the character `.md`, the wired reference file, the scope line |
+| Contract | Are the count, space, action, camera and audio actually executable? | the shot contract — simplify, split into two shots, fix first/last frame |
+| Prompt | Is the contract stated clearly, without contradiction or repetition? | reorder, compress, add the missing part |
+| Plugin | Do the params, reference slots, duration and model fit? | node config, or a different plugin for the slot |
+| Randomness | Does it happen in every run, or only some? | hold everything, run again, compare |
+| Post | Is this better fixed in the edit? | note it and move on |
+
+Look before you diagnose: `tongflow_look` for images and video contact sheets,
+`tongflow_perceive` for what a video or audio track actually says and sounds like.
+
+## Record it like this
+
+In the notes file next to the asset, and condensed into the run's `note`:
+
+```
+code · symptom with the frame or timestamp · layer · smallest fix · the one variable
+you changed · what you deliberately did not do
+```
+
+## Identity and assets
+
+| Code | Symptom | Check first | Smallest fix |
+|---|---|---|---|
+| `ID-DRIFT` | Face, build, hair or silhouette drifts | identity anchors; too many mixed references | one approved reference, explicit scope |
+| `STATE-DRIFT` | Costume, wound, wetness or carried prop reverts | which state version you wired | wire the right file, put the state in "must hold" |
+| `REF-SCOPE` | The reference's framing, background or light leaks in | your inherit/exclude line | take only what you need, refuse the rest |
+| `DUP-SUBJECT` | The same character appears twice | count, repeated description, mirrors | exact count, each once, rule out reflections |
+| `ASSET-MERGE` | Two characters or props blend features | overlapping references, overlapping space | separate the references, separate the placement |
+
+**Do not**: pile on "same face, consistent character, identical person" while the reference
+itself is unstable.
+
+## Space and continuity
+
+| Code | Symptom | Check first | Smallest fix |
+|---|---|---|---|
+| `COUNT` | Wrong number of people, or extras | the allowed set; background; reflections | exact number, ids, each appearing once |
+| `SCREEN-DIR` | Screen direction or left/right flips | ambiguous position wording | state camera side, anatomical side and facing together |
+| `AXIS` | A cut reverses who faces whom | the action axis across shots | stay on one side, or show the crossing |
+| `SPATIAL-RESET` | The layout rebuilds itself between shots | the space description; leaked reference framing | name fixed anchors, exclude reference composition |
+| `PROP-DUP` | Furniture or a key prop multiplies | count, owner, position | declare the object unique and who touches it |
+| `CONTINUITY` | Action, injury, weather or sound does not join | `close_state` vs the next `open_state` | align them; register the change deliberately |
+
+**Do not**: use one composition reference to control every angle, or write "keep it
+consistent" and hope.
+
+## Action, camera, audio
+
+| Code | Symptom | Check first | Smallest fix |
+|---|---|---|---|
+| `ACTION-OVERLOAD` | Beats compressed, dropped or reordered | beat total vs duration | cut beats, merge them, or split the shot |
+| `PHYSICS` | Floating, weightless, impact without reaction | preparation → contact → reaction → settle | write the full chain and the environment's response |
+| `MOTION-CONFLICT` | Subject both still and moving | the prompt's own wording | give the movement to a different beat or subject |
+| `CAM-MULTI` | Camera wanders, several movements at once | how many movements you asked for | one movement, with start and end frames |
+| `CAM-NO-END` | The shot cannot be cut out of | is there a `camera_end`? | name the final framing and focus target |
+| `LIPSYNC` | Mouth does not match, or speaks when silent | dialogue length vs duration; silence declared? | shorten the line, or state explicitly that nobody speaks |
+| `AUDIO-UNSPEC` | Unwanted music, burned-in subtitles | did you state the audio bed? | declare ambience, and music/subtitles present or absent |
+| `TEXT-VISUAL` | Spoken words rendered as on-screen text | heard vs seen not distinguished | mark dialogue as spoken; name printed text separately |
+
+**Do not**: fix a camera problem by describing the camera more emphatically. Fix it by
+removing a movement.
+
+## Prompt-level
+
+| Code | Symptom | Check first | Smallest fix |
+|---|---|---|---|
+| `CONTRADICT` | Two requirements cannot both be true | "must hold" vs "changes here" | delete one; decide which the shot is about |
+| `NEG-BLOAT` | Long negative list, no improvement | which negatives ever mattered here | keep only failures you have seen; delete the rest |
+| `PARAM-IN-PROSE` | Seed, steps, cfg or model name inside the prompt text | node config vs prompt string | move them to config fields |
+| `STYLE-ONLY` | Pretty, generic, does not tell the story | delete the style words — what is left? | write L2–L6 properly |
+
+## Plugin-level
+
+Before rewriting anything, rule this out: is the plugin installed, are its keys set
+(`tongflow_plugins_list`), does the slot actually support what you asked, and does the
+duration or aspect ratio fit? `tongflow_node_describe(type)` for the real enums and
+ranges. A capability the plugin does not have is not a prompt problem — try another plugin
+for the same slot, or change what you are asking for.
+
+If two runs with everything held fixed differ wildly and both are plausible, it is
+randomness — that is a selection question, see `references/iteration.md`.

--- a/packages/dsh-tongflow/skills/references/iteration.md
+++ b/packages/dsh-tongflow/skills/references/iteration.md
@@ -1,0 +1,92 @@
+# Iterating — not pulling a slot machine
+
+Every run costs the user money. The difference between iterating and gambling is whether
+you can say what you changed and what you expected.
+
+## Four different things
+
+- **The workflow** — the file. Editing it is a *version*: a real decision about the
+  contract, the reference, the plugin or the params.
+- **A run** — one execution of that file. It never overwrites: run 1 is `mei_ref.01.png`,
+  run 2 is `mei_ref.02.png`, and `mei_ref.runs.json` records the inputs, plugins, timing
+  and your `note` for each.
+- **A selection** — which numbered output you picked, and why. Downstream work references
+  that path, so the choice is permanent until you change it.
+- **An iteration** — a version change driven by a diagnosis: what failed, what you
+  changed, what you expect to see.
+
+Running the same unchanged file five times is not four iterations. It is one run and four
+duplicates, and it costs five times as much.
+
+## One variable at a time
+
+Before running again, be able to fill this in:
+
+```
+failure:            CAM-MULTI — the camera pushes in and then pans right, ends nowhere
+layer:              contract
+changed:            removed the pan; added camera_end (medium close, focus on her eyes)
+expected:           one continuous push that settles on her face by 5s
+held fixed:         prompt L1–L4, the wired reference, plugin, seed, duration
+```
+
+Pass the short form as the run's `note` — that is what `.runs.json` keeps, and what the
+next session reads instead of guessing. Keep the long form in the notes file next to the
+asset.
+
+Changing the prompt, the reference and the plugin at once and getting a better result
+teaches you nothing; the next shot starts from zero again.
+
+## When to stop changing the prompt
+
+**Two consecutive versions with no improvement on the same failure means the problem is
+not in the prompt.** Go back up:
+
+1. Is the asset good enough? A reference that does not pin the identity will not be fixed
+   by wording.
+2. Is the contract executable? Four beats, two characters, dialogue and a moving camera in
+   five seconds is not a prompt problem — split the shot.
+3. Is the plugin capable? Some slots simply cannot do what you are asking. Try another
+   installed plugin, or change the ask.
+4. Is this a post problem? A slightly wrong colour or a trim is cheaper in the edit than in
+   ten more runs. Note it and move on.
+
+Tell the user when you hit this point, with the two versions and what stayed the same.
+Silently burning their credits on version seven is the failure mode this rule exists to
+prevent.
+
+## Randomness and comparison
+
+If two runs of the *identical* file differ a lot, the variation is the plugin's, not
+yours. Then, and only then, several runs of the same version is the right move — you are
+sampling, not iterating. Say so, ask once for a batch of N, run them, and compare:
+
+- Judge against the contract, not against taste: count, identity, state, space, camera end,
+  audio. `tongflow_look` for images and contact sheets, `tongflow_perceive` for what a
+  video actually says and sounds like.
+- Record the choice: which number, judged on what, what remains wrong but acceptable.
+- Tell the user which one you picked and why — they can see all the numbers in the folder
+  and will wonder.
+
+## Budget is a conversation
+
+A run with a paid plugin needs `user_confirmed` every single time; a yes for the last run
+never covers the next one. That constraint is also good practice — it forces you to have a
+reason before every spend.
+
+- Planning a batch (ten shots, or five samples of one shot): say so, and get one clear yes
+  for that batch.
+- Before an expensive stage, tell the user roughly how many runs you expect and what the
+  stop rule is.
+- When you hit the two-version rule, that is a checkpoint: report and ask, do not spend
+  through it.
+
+## What lands on disk
+
+No new bookkeeping files. Everything above lives in what the project already has:
+
+- `.runs.json` — automatic provenance plus your `note` per run.
+- The workflow file's `meta.purpose` — why this asset exists.
+- A notes file next to the asset (or in `notes/`) — diagnoses, selections, what is
+  knowingly imperfect.
+- `continuity.md` for state that must hold across shots, pulled in with `{{path}}`.

--- a/packages/dsh-tongflow/skills/references/prompt-layers.md
+++ b/packages/dsh-tongflow/skills/references/prompt-layers.md
@@ -1,0 +1,117 @@
+# Writing a prompt — the seven layers
+
+A prompt fails for a reason that belongs to a layer. Write the layers in order, and
+when something comes out wrong you already know which layer to fix.
+
+| Layer | The question it answers |
+|---|---|
+| L1 intent | Why this image or shot exists; what the viewer must read from it |
+| L2 identity | Who exactly, in which state, inheriting what from which reference |
+| L3 space | How many, where on screen, facing where, which objects are unique |
+| L4 action | What triggers, what moves, what makes contact, where it settles |
+| L5 camera | Starting frame, one main movement, ending frame |
+| L6 texture | Light source, exposure, palette, material, dialogue, ambience |
+| L7 constraints | What must hold, what changes here, what must never appear |
+
+An image prompt uses L1–L3, L5–L7 and a static L4 (pose, weight, gaze). A video prompt
+uses all seven and owes the fuller contract in `references/shot-contract.md`.
+
+## Where each layer lives in TongFlow
+
+Layers are **not** all prose in one string. Split them the way the runtime splits them:
+
+- **L1** — the workflow file's `meta.purpose`, and the notes file next to the asset. Not
+  in the prompt text at all; the model cannot act on "this shot establishes loneliness".
+- **L2** — the wired reference **files** (`data:{fileKeys:['./mei_ref.02.png']}`) plus the
+  identity anchors you keep in `characters/mei/mei.md` and pull in with `{{./mei.md}}`.
+- **L3, L4, L5, L6, L7** — the prompt text, in **one** text node, in that order.
+- **Plugin, model, seed, steps, guidance, motion strength** — node config fields, never
+  prose. `tongflow_node_describe(type)` lists what the slot actually accepts. A parameter
+  written into the prompt string is ignored and dilutes everything around it.
+
+Compose the whole prompt in one text node. Never chain text-combining nodes to assemble it.
+
+## L2 — identity, state, and reference scope
+
+Three different things, kept apart:
+
+- **Identity invariants**: what makes her her across every shot. Written once, in her
+  `.md` file, included everywhere.
+- **State**: what is true *now* — costume version, wound, wet, dirt, what she carries.
+  State belongs to the scene, and it changes; identity does not.
+- **Reference scope**: what the wired image is being used *for*. A reference always leaks
+  more than you meant — its framing, its background, its light. Say what you take from it
+  and what you refuse:
+
+```
+{{./mei.md}} — hold face, hair length, jaw. Take costume and wounds from the wired
+reference only; do not take its framing, background, lens or lighting.
+```
+
+If identity drifts, the fix is upstream in the reference and the scope line, **not** more
+adjectives. Adding "same face, consistent character, identical person" to an unstable
+reference does nothing.
+
+## L3 — count, placement, screen direction
+
+Vague space is where extra people and duplicated props come from.
+
+- **Exact count, each once**: "exactly two figures: MEI and the mechanic, each appearing
+  once; nobody else is in frame or in the space behind camera."
+- **Screen position and facing**, both stated: "MEI stands screen-left in mid-ground,
+  facing screen-right." Screen-left and her left hand are different things — when a hand,
+  a wound or a scar matters, say which: "the bandage is on her anatomical right arm, which
+  reads screen-left here."
+- **Unique objects with an owner**: "one toolbox, on the floor at her feet, touched by
+  nobody" — otherwise the model happily renders three of them.
+- **Mirrors, screens, windows, crowds** duplicate subjects. If the scene has one, either
+  rule it out ("no reflections of MEI") or state what it shows.
+
+## L5 — one main movement
+
+An image has a frame; a shot has a start frame, one movement, and an end frame. Two
+incompatible movements in one shot is the single most common video failure. Details and
+the full camera contract: `references/shot-contract.md`.
+
+## L6 — motivated texture
+
+- **Light has a source.** "Neon sign above the door, screen-right, cold cyan, hard edge;
+  fill from a work lamp on the ground, warm, weak." Not "cinematic lighting".
+- **Exposure and palette** as decisions: what is clipped, what is crushed, two or three
+  colours that own the frame.
+- **Material** where it reads: wet steel, worn canvas, cracked rubber.
+- **Audio** is a layer, not an afterthought — see `references/shot-contract.md`.
+
+Style words are the cheapest part of a prompt. Delete every style word and the prompt must
+still fully determine the picture. If it does not, the missing information is in L2–L6.
+
+## L7 — the three-column constraint block
+
+End every non-trivial prompt with three explicit lists:
+
+```
+must hold:       MEI's face and hair; the red jacket, torn at the left cuff; night, rain
+changes here:    she straightens from the crouch; the toolbox lid closes
+must not appear: a second person; a reflection of MEI; text, logos, watermarks; daylight
+```
+
+Negatives are expensive — each one competes for attention. Only list a failure you have
+actually seen from this plugin on this asset, and delete it once it stops happening. A wall
+of generic negatives ("bad hands, blurry, low quality, extra limbs") is noise; if a plugin
+needs a fixed negative string, that is a node config field, not part of the prompt.
+
+## Before you run
+
+Read the prompt back and answer these. A "no" is cheaper to fix now than after a paid run.
+
+1. Delete the style words — is the picture still determined?
+2. Can you count the people, and does every listed subject appear exactly once?
+3. Could you draw a rough floor plan from the placement lines?
+4. Does every reference file have a stated scope?
+5. Is exactly one thing moving in the camera contract?
+6. Does each light have a source?
+7. Does anything in "changes here" contradict "must hold"?
+
+Language: prompts sent to image and video plugins are English unless the plugin says
+otherwise. Notes, character files and the constraint reasoning you keep on disk are in the
+user's language.

--- a/packages/dsh-tongflow/skills/references/shot-contract.md
+++ b/packages/dsh-tongflow/skills/references/shot-contract.md
@@ -1,0 +1,123 @@
+# The shot contract — video
+
+A video prompt is a contract for one shot, not a description of a scene. Read this
+together with `references/prompt-layers.md`; the layers are the spine, this is the video
+detail that sits on it.
+
+## First decide what you are making
+
+- **One shot** — the camera observes continuously, no cut, **one** main movement.
+- **A sequence** — explicit cuts; each part owns its duration, framing and the join to the
+  next. In TongFlow that is one workflow per shot, then `tongflow_workflow_compose` — not
+  one prompt asking for four shots.
+- **A montage** — juxtaposed fragments; still bounded in count, order and total duration.
+
+Do not push several incompatible camera movements into "one shot", and do not call a list
+of actions a montage.
+
+## The twelve parts
+
+Not every shot needs all twelve spelled out; a shot that is *wrong* is almost always
+missing one of them.
+
+1. **Purpose** — one function, one visible main event, where the shot leaves the viewer.
+2. **Exact cast** — total count, one line per subject, each appearing once, and whether an
+   off-screen speaker occupies space.
+3. **Appearance and state** — identity anchors, current state, and the scope taken from
+   each wired reference.
+4. **Space** — area, foreground/mid/background, screen positions, facing, entrances, the
+   action axis, unique props and who touches them.
+5. **`open_state`** — first frame: pose, gaze, props, environment, and what is already
+   audible.
+6. **`beat_timeline`** — the causal chain across the duration.
+7. **`close_state`** — last frame: position, pose, props, expression, environment, sound.
+8. **`camera_start`** — framing, height, angle, lens feel, focus target.
+9. **`camera_path`** — the one movement, its motivation and its speed.
+10. **`camera_end`** — where the frame lands and what is in focus when it does.
+11. **Audio** — dialogue verbatim, ambience, foley, music or its explicit absence.
+12. **Constraints** — the three columns: must hold / changes here / must not appear.
+
+## open_state → beats → close_state
+
+```
+duration: 6s
+open_state:  MEI crouched beside the open toolbox, screen-left, looking down at her hands;
+             rain steady, no music.
+0.0–1.2s     she stays down; a shutter rattles off-screen right.
+1.2–3.0s     she lifts her head toward the sound, then rises, weight shifting to her
+             front foot.
+3.0–5.0s     she takes two steps toward the door and stops.
+5.0–6.0s     she holds, breathing out; the rain continues.
+close_state: MEI standing centre-frame, facing screen-right, toolbox open behind her at
+             screen-left, jacket wet across the shoulders; rain, no music.
+```
+
+Rules that make this work:
+
+- **Beats fill the duration and do not overlap.** Beats totalling 9 seconds in a 6-second
+  shot get compressed, reordered, or silently dropped.
+- **The duration is a node config field**, not a sentence in the prompt. Check what the
+  slot allows with `tongflow_node_describe(type)`; a 12-second beat sheet aimed at a plugin
+  that produces 5 seconds is a contract you cannot fulfil.
+- **Every action ends.** Movement without a settle produces a shot you cannot cut out of.
+- **You must be able to draw the first and last frame.** If you cannot, neither can the
+  model.
+- **`close_state` is the next shot's `open_state`.** That is the whole continuity
+  mechanism — write it down and reuse it verbatim.
+
+## The camera contract
+
+One movement. Give it three parts and a motivation:
+
+```
+camera_start: medium-wide, chest height, slight low angle, she is screen-left third,
+              focus on her hands.
+camera_path:  a slow push in, motivated by her rising; no pan, no roll.
+camera_end:   medium close, her face screen-centre, focus on her eyes, toolbox out of
+              frame.
+```
+
+- A single verb ("dolly in") is not a contract; it leaves the start and end frames to
+  chance and makes the shot uncuttable.
+- "Locked-off camera" and any movement verb in the same prompt is a direct contradiction —
+  so is "the subject stands completely still" alongside "she keeps running".
+- Handheld, focus pulls and lens character are camera facts, not style words; state them
+  in `camera_path` or leave them out.
+
+## Audio
+
+State it even when there is none, or you get generic music.
+
+- **Dialogue verbatim**, with who says it and when: `1.4–2.6s MEI: "It's still not
+  turning over."` Long dialogue in a short shot produces lip sync that does not fit —
+  budget roughly the words a person actually says in that many seconds.
+- **A speaker who is off-screen** must be declared off-screen *and* excluded from frame,
+  or they will walk into the background.
+- **Ambience and foley** as a short list; **music** explicitly present or explicitly
+  absent; **subtitles** explicitly off unless wanted, or they get burned in.
+- Text that is meant to be *heard* and text that is meant to be *seen* get confused
+  constantly. If a line is spoken, say so; if a word is printed on a sign, say that.
+
+## Across shots
+
+Keep a continuity file next to the shots and include it with `{{path}}` rather than
+retyping from memory:
+
+```
+ep01/
+  continuity.md          ← identity anchors, costume state, weather, the action axis
+  sh010/
+    sh010.tongflow.json  ← texts:['{{../continuity.md}} ...shot-specific contract...']
+    sh010.02.mp4
+  sh020/
+```
+
+- **Hold the axis.** Once two characters face each other across a line, every shot stays
+  on one side of it, or the cut reverses who is looking at whom. Crossing it needs a
+  visible bridging move.
+- **Carry state forward.** Wet stays wet; a wound stays on the same arm; a closed toolbox
+  stays closed. Every change must be traceable to a beat in some shot.
+- **Carry sound forward.** Rain that stops between two adjacent shots reads as an error.
+- When a shot chain is complete, `tongflow_workflow_compose({ folder })` turns the file
+  references between the parts into real edges so the user can see and re-run the whole
+  thing on the canvas.

--- a/packages/dsh-tongflow/skills/tongflow-studio.md
+++ b/packages/dsh-tongflow/skills/tongflow-studio.md
@@ -55,15 +55,26 @@ Read `tongflow_node_catalog` before writing any workflow; it opens with the gram
 - Text you keep in files can be **included** in a prompt: `texts:['{{../style.md}} {{./mei.md}} full-body character sheet, front and side view, plain background']` — `{{path}}` is replaced by the file's content at run time. Write shared style / character descriptions once and include them where needed instead of re-describing from memory.
 - Compose the whole prompt in ONE text node; never chain text-combining nodes for that.
 
+## Method references — load only what the step needs
+
+These sit next to this file; resolve them against the skill's base directory.
+
+- `references/prompt-layers.md` — before writing any non-trivial prompt: the seven layers, what belongs in the prompt text versus the node config versus a wired file, reference scope, and the checks to run before spending a paid run.
+- `references/shot-contract.md` — any video shot: `open_state` / beats / `close_state`, the camera start-path-end contract, dialogue and audio, and continuity across shots.
+- `references/failure-codes.md` — a result came back wrong: locate the responsible layer and make the smallest fix, instead of adding negative words.
+- `references/iteration.md` — before running the same asset again: what counts as an iteration, changing one variable, when to stop rewriting the prompt, and how to record the choice.
+
+`references/SOURCES.md` records where this method comes from and what it does not license.
+
 ## The loop for any media
 
 1. `tongflow_project_status` — see what exists; `tongflow_node_catalog` — node types and installed plugins.
-2. `tongflow_workflow_new({ path: '<folder>/<asset>' })` — one file per asset → `tongflow_workflow_patch` (write the concrete prompt / file refs / params into the nodes; `copy_from` another workflow of the project when the shape is the same) → `tongflow_workflow_read` (verify wires + validation).
+2. `tongflow_workflow_new({ path: '<folder>/<asset>' })` — one file per asset → `tongflow_workflow_patch` (write the concrete prompt / file refs / params into the nodes — `references/prompt-layers.md`, and `references/shot-contract.md` for a video shot; `copy_from` another workflow of the project when the shape is the same) → `tongflow_workflow_read` (verify wires + validation).
 3. **Billing checkpoint — every paid run, every time.** A run that uses a paid plugin costs the user money (a paid API key, or GPU seconds on their Modal account — a Modal plugin also deploys on first run). `tongflow_workflow_run` without `user_confirmed` refuses and returns `needs_confirmation`: which plugins, how each is billed, whether its API keys are set, which models it offers, and installed alternatives. Put that to the user in plain words ("这一步用 Gemini 生图,按次计费到你的 GEMINI_API_KEY;也可以换 X;要用哪个模型?现在跑吗?"), wait for their yes, then call again with `user_confirmed: true`. Ask before **each** paid run — a yes for the last run does not cover the next one, and never set the flag on your own. Runs that use only local plugins are free and need no confirmation. When you plan a batch (e.g. ten shots), say so and get one clear yes for that batch, then run them one after another.
 4. `tongflow_workflow_run` — foreground for a single image, `run_in_background` for video/batches; keep working meanwhile.
 5. Review: `tongflow_look` (images, video contact sheets) and `tongflow_perceive` (video/audio understanding, transcripts). Write findings into a notes file next to the asset or in a `notes/` folder.
 6. **Compose when a stage chain is done.** When a shot / scene / asset has several small workflows that feed each other by file (`./ref.01.png` → `i2v` → `lipsync`), `tongflow_workflow_compose({ folder })` (or an explicit `workflows` list) writes ONE big `<folder>_all.tongflow.json`: file references to another part's output become real edges, every stage stays an output named after its part (`shot_all.01.i2v.mp4`), the parts are untouched. Tell the user to open it on the canvas to see and tweak the whole; a run of it regenerates everything in one go (it is a paid run like any other).
-7. If it is off, fix *that* workflow (or the text it includes) and run again — the next number lands beside the old one. When it is right, use that file's path downstream (e.g. `./mei_ref.02.png` as the reference for a shot). Tell the user which number you picked and why.
+7. If it is off, name the failure and the layer that owns it (`references/failure-codes.md`), change one thing, and run again — the next number lands beside the old one. Two versions with no improvement on the same failure means the problem is not in the prompt (`references/iteration.md`). When it is right, use that file's path downstream (e.g. `./mei_ref.02.png` as the reference for a shot). Tell the user which number you picked and why.
 
 Rules of thumb:
 - Patch incrementally; never rebuild a workflow from scratch; never invent node ids. Read the patch result: `ok:false` steps must be fixed before running.


### PR DESCRIPTION
## What

The bundled `tongflow-studio` skill covered the **mechanics** — workflow files, patching, the billing checkpoint, compose — but said nothing about what makes a prompt good, what to do when a result comes back wrong, or when to stop spending the user's money re-running the same shot.

Four references now sit under `skills/references/`, loaded on demand:

| File | Covers |
|---|---|
| `prompt-layers.md` | The seven layers (intent → identity → space → action → camera → texture → constraints), and which of them belong in the prompt text vs. node config vs. a wired reference file. Reference scope, exact counts and screen direction, the three-column constraint block, and the checks to run before spending a paid run. |
| `shot-contract.md` | The video shot contract: `open_state` / beat timeline / `close_state`, `camera_start` / `camera_path` / `camera_end`, dialogue and audio, and continuity across shots via a `continuity.md` pulled in with `{{path}}`. |
| `failure-codes.md` | Locate the responsible layer (asset → contract → prompt → plugin → randomness → post), then make the smallest fix. Coded symptom tables with "check first / smallest fix" per row. |
| `iteration.md` | Workflow version / run / selection / iteration as four different things; one variable at a time; the stop rule when two versions do not improve the same failure; sampling vs. iterating. |

`tongflow-studio.md` gains a routing section plus pointers from loop steps 2 and 7 (15 lines changed).

## Why it needs no code change

`src/skills/provider.ts` already publishes the skills directory as `resourceBase: { kind: "directory" }`, which dsh renders as *"Base directory for this skill: … Resolve relative paths mentioned by this skill against the base directory. Load referenced resources only as needed."* The listing uses a non-recursive `readdir` filtered to `.md`, so `references/` is not mistaken for a skill, and `files: ["skills"]` already ships the subdirectory.

## Bound to this plugin's own mechanics

The method is adapted, not transplanted. Each rule lands on something the plugin already has:

- reference scope → the wired `fileKeys` plus a scope line in the `{{./character.md}}` include
- the "platform adapter" layer → node config fields, checked with `tongflow_node_describe(type)`; a seed or cfg written into prompt prose is a coded error (`PARAM-IN-PROSE`)
- iteration bookkeeping → the existing `note` argument of `tongflow_workflow_run` ("Why this run / what changed"), recorded in `.runs.json`. **No new bookkeeping files.**
- the stop rule → hangs off the existing per-run `user_confirmed` billing checkpoint
- continuity → `close_state` is the next shot's `open_state`; chains close with `tongflow_workflow_compose`

## Deliberately left behind

The upstream method ships a fixed ten-directory project schema with 14 CSV tables and Python init/validate tools. That contradicts this plugin's plain project model (*"There is no template — design the structure"*), and its generation/iteration logs duplicate what `.runs.json` records automatically. `references/SOURCES.md` says so explicitly.

## Attribution

Adapted from [Hell Grind AIGC Skill](https://github.com/renmu2017/Hell-Grind-AIGC-Skill), MIT, Copyright (c) 2026 renmu2017. `references/SOURCES.md` carries the full notice, records what was taken and what was not, and repeats upstream's caveat that no rights to Higgsfield's *Hell Grind* film, assets or source prompts are granted by either repository.

## Version

`dsh-tongflow` 0.2.0 → **0.3.0** (new capability, no breaking change). Publishes on a `dsh-npm-v0.3.0` tag.

## Checks

- `pnpm --filter dsh-tongflow test` — 15 passed (3 files)
- `pnpm --filter dsh-tongflow typecheck` — clean, including the client project
- `pnpm lint:check` — 434 files, no fixes applied
- `npm pack --dry-run` — all five reference files present in the tarball
- Provider discovery simulated: skills listed = `['tongflow-studio.md']`, `references/` correctly invisible

**Not verified:** this is the plugin's first actual use of `resourceBase`. Whether the dsh agent's file tools can read a path under `node_modules/dsh-tongflow/skills/references/` needs one real run to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)