### PR TITLE
docs: document the dsh plugin in all three READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,21 @@ Open **Settings** (the gear icon, top-right) and add the environment variables y
 
 Run the preloaded example node by node, or switch to Execute Mode and hit the run button to run the whole thing in one click.
 
+## Use it inside an agent (dsh plugin)
+
+TongFlow also runs **inside your own agent**, as a plugin for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) — no desktop app, no server of your own:
+
+```sh
+npx @deepseek-ai/dsh@next plugin --profile web add dsh-tongflow
+npx @deepseek-ai/dsh@next web
+```
+
+Then start a session whose **first message begins with `@tongflow`**. That session turns into the Studio — chat, the project's folder tree, preview / editor / the canvas, and a runs drawer — and the agent gets TongFlow's tools. Any other session stays plain dsh.
+
+The split is the point: the agent designs the project and writes the plan, briefs and prompts as ordinary files; TongFlow generates, and every generated asset comes from a saved `.tongflow.json` workflow sitting next to its outputs — so you can open it on the canvas, change it and run it again. There is no "generate an image" tool and no project template. The plugin provisions its own Python venv and clones the official plugins on first use, so the canvas offers the same catalog as the hosted app.
+
+Requirements and configuration: **[packages/dsh-tongflow/README.md](packages/dsh-tongflow/README.md)**.
+
 ## Custom plugins
 
 Every runnable node is backed by a **contract** — the ABI ([`packages/tongflow/abi/tongflow.abi.json`](packages/tongflow/abi/tongflow.abi.json)) — that defines *what capabilities exist* and *what each one's input/output looks like*, independent of *who* implements it. A plugin is just a small Python package that picks one or more ABI slots and supplies the **how**, annotated against the ABI-generated types via the tongflow Python SDK.

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -283,6 +283,21 @@ docker compose up -d
 
 あらかじめ読み込まれたサンプルをノードごとに実行することも、実行モードに切り替えて実行ボタンをクリックし、一括で実行することもできます。
 
+## 自分のエージェントに組み込む（dsh プラグイン）
+
+TongFlow は [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) のプラグインとして、**自分のエージェントの中で動かす**こともできます。デスクトップアプリも、自前のサーバーも要りません：
+
+```sh
+npx @deepseek-ai/dsh@next plugin --profile web add dsh-tongflow
+npx @deepseek-ai/dsh@next web
+```
+
+あとは、**最初のメッセージを `@tongflow` で始めて**セッションを開くだけです。そのセッションが Studio に変わり——チャット、プロジェクトのフォルダツリー、プレビュー / エディタ / キャンバス、実行履歴のドロワー——エージェントは TongFlow のツール一式を使えるようになります。ほかのセッションはこれまでどおりの dsh のままです。
+
+役割がはっきり分かれているのがポイントです。エージェントはプロジェクトを設計し、計画・設定・プロンプトをふつうのファイルとして書きます。生成を担うのは TongFlow で、生成物はすべて、その隣に置かれた `.tongflow.json` ワークフローから生まれます——だからキャンバスで開いて、手を入れて、もう一度実行できます。「画像を生成する」ようなツールも、プロジェクトのテンプレートもありません。プラグインは初回利用時に自前の Python venv を用意し、公式プラグインをクローンするので、キャンバスで選べるノードとプラグインはホスト版と同じです。
+
+動作要件と設定項目は **[packages/dsh-tongflow/README.md](../packages/dsh-tongflow/README.md)** を参照してください。
+
 ## カスタムプラグイン
 
 キャンバス上で動作するすべてのノードの背後には、**契約**——ABI（[`packages/tongflow/abi/tongflow.abi.json`](../packages/tongflow/abi/tongflow.abi.json)）があります。これは「どんな能力があるか」と「各能力の入出力がどんな形か」を定義し、「誰が実装するか」とは無関係です。プラグインとは小さなPythonパッケージで、ABI の中の1つまたは複数のスロットを選び、tongflow Python SDK を使って、ABI から生成された型で**どう実装するか**の部分を提供します。

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -283,6 +283,21 @@ docker compose up -d
 
 逐个节点执行预加载的示例，也可以切换到执行模式，点击运行按钮即可一键执行。
 
+## 装进你自己的 agent（dsh 插件）
+
+TongFlow 也可以**跑在你自己的 agent 里**，作为 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 的插件——不用装桌面 app，也不用自己起服务：
+
+```sh
+npx @deepseek-ai/dsh@next plugin --profile web add dsh-tongflow
+npx @deepseek-ai/dsh@next web
+```
+
+然后开一个会话，**第一条消息以 `@tongflow` 开头**。这个会话就变成 Studio——聊天、项目的文件树、预览 / 编辑器 / 画布，加一个运行记录抽屉——agent 也就拿到了 TongFlow 的那套工具。其他会话还是原来的 dsh，不受影响。
+
+分工是这么设计的：agent 负责搭项目、把计划、设定和提示词写成普通文件；TongFlow 负责生成，而每一个生成出来的东西都来自一个存好的 `.tongflow.json` 工作流，就放在它的产物旁边——所以你随时可以在画布上打开它、改一改、再跑一遍。这里没有「生成一张图」这种工具，也没有项目模板。插件首次使用时会自己建 Python venv 并克隆官方插件，画布上的节点和插件目录跟线上版一样全。
+
+环境要求和配置项见 **[packages/dsh-tongflow/README.md](../packages/dsh-tongflow/README.md)**。
+
 ## 自定义插件
 
 画布上每一个能跑的节点，背后都是一份**契约**——ABI（[`packages/tongflow/abi/tongflow.abi.json`](../packages/tongflow/abi/tongflow.abi.json)），它定义「有哪些能力」以及「每个能力的输入输出长什么样」，而与「由谁实现」无关。一个插件就是一个小小的 Python 包，挑 ABI 里一个或多个槽，借助 tongflow Python SDK，用 ABI 生成的类型给出**怎么做**的那部分。

--- a/packages/dsh-tongflow/README.md
+++ b/packages/dsh-tongflow/README.md
@@ -82,7 +82,16 @@ A run that uses a paid plugin spends the user's money — a paid API key, or GPU
 
 `tongflow_project_create / _open / _list / _status` · `tongflow_workflow_new / _patch / _read / _list / _validate / _run / _compose` · `tongflow_node_catalog / _describe` · `tongflow_look` (images / video contact sheets, returned as an image block) · `tongflow_perceive` (video/audio/image understanding via TongFlow slots) · `tongflow_plugins_list / _install / _uninstall` · `tongflow_run_status`. Folder structure and text files are made with dsh's ordinary file tools. Long runs go through dsh background jobs (`run_in_background`).
 
-Skill shipped: `tongflow-studio` (the working method: research → propose a structure → one workflow per asset next to its outputs → run → review → next stage). Genre knowledge is not packaged; the agent researches or the user installs a skill of their own.
+Skill shipped: `tongflow-studio` (the working method: research → propose a structure → one workflow per asset next to its outputs → run → review → next stage), with four method references under [`skills/references/`](skills/references/) that the agent loads only when the step needs them:
+
+| Reference | Read before |
+|---|---|
+| `prompt-layers.md` | writing any non-trivial prompt — the seven layers, and what belongs in the prompt text vs. node config vs. a wired reference file |
+| `shot-contract.md` | a video shot — open/close state, beat timeline, camera start-path-end, audio, continuity across shots |
+| `failure-codes.md` | a result came back wrong — locate the responsible layer, make the smallest fix |
+| `iteration.md` | running the same asset again — one variable at a time, and when to stop rewriting the prompt |
+
+Genre knowledge is not packaged; the agent researches or the user installs a skill of their own.
 
 ## HTTP (same origin as dsh)
 


### PR DESCRIPTION
`dsh-tongflow` has been on npm since 0.1.0, and **none of the three main READMEs mentioned it** — `grep -c dsh` returned 0 for `README.md`, `docs/README_ZH.md` and `docs/README_JA.md` alike. The install instructions lived only in the package's own README, so the fourth way to use TongFlow — inside your own agent, with no desktop app and no server of your own — was undiscoverable from the front page.

## What's added

One section per README: **Use it inside an agent (dsh plugin)** / **装进你自己的 agent（dsh 插件）** / **自分のエージェントに組み込む（dsh プラグイン）**. Each covers the two-command install, the `@tongflow` first-message trigger that turns a session into the Studio, why the agent/TongFlow split exists (no "generate an image" tool, no project template, every asset comes from a workflow file next to its outputs), and links to the package README for requirements and config.

Per the repo's copy convention, the Chinese and Japanese sections are written natively, not translated sentence-by-sentence.

## Placement

After the self-host block, before **Custom plugins** — not between "Run from source" and "Run with Docker", which would have split those two from the **Self-host setup** steps they both feed into. Reads as: here is how to host the app → here is how to instead embed it in an agent → here is how to extend it.

## Also

`packages/dsh-tongflow/README.md` still described the shipped skill as one file. It now lists the four method references added in 0.3.0 (#169) with a one-line "read before" for each.

## Checks

- All four new relative links resolve on disk (`docs/*` correctly uses `../packages/…`)
- The install command block is byte-identical across the three languages
- Section landed before Custom plugins in all three (EN 294 / ZH 286 / JA 286)
- `pnpm lint:check` — 434 files, no fixes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)