### PR TITLE
feat(dsh-tongflow): a look is never silently blind

### DIFF
--- a/packages/dsh-tongflow/package.json
+++ b/packages/dsh-tongflow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dsh-tongflow",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "TongFlow studio plugin for DeepSeek Harness (dsh): agent-designed project folders, one TongFlow workflow per generated asset stored next to its outputs, deterministic media generation, embedded canvas.",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/packages/dsh-tongflow/src/tools/run-tools.ts
+++ b/packages/dsh-tongflow/src/tools/run-tools.ts
@@ -1,7 +1,8 @@
 /**
  * Execution & perception tools: run a workflow (foreground or as a dsh
- * background job), look at a generated image (returned as an image block so a
- * vision model sees it), perceive video/audio through TongFlow's own
+ * background job), look at a generated image (returned as an image block when
+ * the session's model takes images, otherwise described through TongFlow's own
+ * image-describe slot), perceive video/audio through TongFlow's own
  * describe / transcribe slots, and manage plugins.
  */
 import { execFile as execFileCb } from "node:child_process";
@@ -14,8 +15,13 @@ import type {
     ImageMediaType,
 } from "@deepseek-ai/dsh-attachment";
 import type { JobRegistry } from "@deepseek-ai/dsh-jobs";
+import type { LlmRuntime } from "@deepseek-ai/dsh-llm";
 import type { JsonValue } from "@deepseek-ai/dsh-session";
-import { defineTool, type ToolDefinition } from "@deepseek-ai/dsh-tools";
+import {
+    defineTool,
+    type ToolDefinition,
+    type ToolRunContext,
+} from "@deepseek-ai/dsh-tools";
 import type { RunRecord } from "../engine/runs.ts";
 import { formatEvent } from "../engine/runs.ts";
 import { modalityOfExt } from "../shared/types.ts";
@@ -29,6 +35,89 @@ import {
 } from "./support.ts";
 
 const execFile = promisify(execFileCb);
+
+/**
+ * Whether the model this call runs under accepts image content. Mirrors the
+ * llm runtime's own predicate: it only projects images away for a model that
+ * *declares* modalities without "image", so an undeclared catalog stays
+ * image-capable here too. Unknown agent or absent llm service means "assume it
+ * takes images" — the runtime degrades gracefully either way, and guessing the
+ * other direction would spend a plugin run on every look.
+ */
+export async function modelTakesImages(
+    env: ToolEnv,
+    exec: ToolRunContext,
+): Promise<boolean> {
+    const llm = env.ctx.get("llm") as LlmRuntime | undefined;
+    const { provider, model } = exec.agent?.options ?? {};
+    if (!llm || !provider || !model) return true;
+    try {
+        const info = await llm.resolveModelInfo(provider, model, exec.signal);
+        return (
+            info.inputModalities === undefined ||
+            info.inputModalities.includes("image")
+        );
+    } catch {
+        return true;
+    }
+}
+
+/** One TongFlow describe/transcribe slot run over a local media file. */
+interface SlotDescription {
+    ok: boolean;
+    feature: string;
+    pluginId?: string;
+    answer?: string;
+    error?: string;
+    log?: string[];
+    raw?: unknown;
+}
+
+/**
+ * Understand a media file through TongFlow's own describe / transcribe slots.
+ * Shared by `tongflow_perceive` and by `tongflow_look`'s fallback for a model
+ * that does not take images.
+ */
+async function describeViaSlot(
+    env: ToolEnv,
+    pid: string,
+    feature: string,
+    prompt: Record<string, unknown>,
+    pluginId?: string,
+): Promise<SlotDescription> {
+    const { registry } = await env.api.registry();
+    const chosen = pluginId ?? registry.nodePluginMap[feature]?.[0];
+    if (!chosen)
+        return {
+            ok: false,
+            feature,
+            error: `no installed plugin implements ${feature}; install one (e.g. tongflow-api-gemini or tongflow-modal-qwen38) with tongflow_plugins_install`,
+        };
+    const record = await env.api.startCanvasRun(pid, {
+        feature,
+        pluginId: chosen,
+        prompt,
+        nodeId: "perceive",
+    });
+    await record.done;
+    if (record.summary.status !== "completed")
+        return {
+            ok: false,
+            feature,
+            pluginId: chosen,
+            error: record.error ?? "perception run failed",
+            log: record.events.slice(-10).map(formatEvent),
+        };
+    const texts = record.outcome?.texts ?? {};
+    const answer = Object.values(texts).flat().join("\n").trim();
+    return {
+        ok: true,
+        feature,
+        pluginId: chosen,
+        answer: answer || "(empty answer)",
+        raw: record.outcome?.result.outputs,
+    };
+}
 
 declare module "@deepseek-ai/dsh-jobs" {
     interface JobKindMap {
@@ -202,7 +291,8 @@ export function runTools(env: ToolEnv): ToolDefinition[] {
         defineTool({
             name: "tongflow_look",
             description:
-                "Look at an asset. Images are returned as an image you can see (requires a vision-capable model route). Videos are returned as a contact sheet of sampled frames plus duration/resolution. " +
+                "Look at an asset. Images come back as an image you can see, videos as a contact sheet of sampled frames plus duration/resolution. " +
+                "When this session's model does not take images, both are routed through TongFlow's describe slots instead and come back as text, saying so — so a look is never silently blind. " +
                 "Audio returns metadata only — use tongflow_perceive for content. Takes a project-relative path (e.g. 'characters/mei/mei_ref.02.png').",
             parameters: {
                 project: PROJECT_PARAM,
@@ -252,6 +342,24 @@ export function runTools(env: ToolEnv): ToolDefinition[] {
                         return compact({
                             summary: `${args.ref}: image ${st.size} bytes at ${path} (attachments service not mounted; cannot show inline)`,
                         });
+                    if (!(await modelTakesImages(env, exec))) {
+                        const described = await describeViaSlot(
+                            env,
+                            pid,
+                            "image-describe",
+                            {
+                                image: path,
+                                text: "Describe this image in detail.",
+                            },
+                        );
+                        return compact({
+                            ...described,
+                            summary: described.ok
+                                ? `${args.ref}: ${st.size} bytes. This session's model does not take images, so the image was described by ${described.pluginId} instead of shown:\n${described.answer}`
+                                : `${args.ref}: ${st.size} bytes. This session's model does not take images and the image could not be described (${described.error}). Switch to a vision-capable model, or install a plugin for the image-describe slot.`,
+                            path,
+                        });
+                    }
                     const attachment = await attachments.saveImage({
                         data: new Uint8Array(await readFile(path)),
                         mediaType: mime,
@@ -272,6 +380,24 @@ export function runTools(env: ToolEnv): ToolDefinition[] {
                             summary: `${args.ref}: video ${st.size} bytes`,
                             probe,
                         });
+                    if (!(await modelTakesImages(env, exec))) {
+                        const described = await describeViaSlot(
+                            env,
+                            pid,
+                            "video-describe",
+                            {
+                                video: path,
+                                text: "Describe this video in detail: subjects, action, camera, continuity issues.",
+                            },
+                        );
+                        return compact({
+                            ...described,
+                            summary: described.ok
+                                ? `${args.ref}: video ${st.size} bytes; ${JSON.stringify(probe)}. This session's model does not take images, so a contact sheet would be unreadable; described by ${described.pluginId} instead:\n${described.answer}`
+                                : `${args.ref}: video ${st.size} bytes; ${JSON.stringify(probe)}. This session's model does not take images and the video could not be described (${described.error}). Switch to a vision-capable model, or install a plugin for the video-describe slot.`,
+                            probe,
+                        });
+                    }
                     try {
                         const sheet = await contactSheet(
                             path,
@@ -392,37 +518,15 @@ export function runTools(env: ToolEnv): ToolDefinition[] {
                         error: `${args.ref} is not a video/audio/image`,
                     };
                 }
-                const { registry } = await api.registry();
-                const pluginId =
-                    args.pluginId ?? registry.nodePluginMap[feature]?.[0];
-                if (!pluginId) {
-                    return {
-                        ok: false,
-                        error: `no installed plugin implements ${feature}; install one (e.g. tongflow-api-gemini or tongflow-modal-qwen38) with tongflow_plugins_install`,
-                    };
-                }
-                const record = await api.startCanvasRun(pid, {
-                    feature,
-                    pluginId,
-                    prompt,
-                    nodeId: "perceive",
-                });
-                await record.done;
-                if (record.summary.status !== "completed")
-                    return compact({
-                        ok: false,
-                        error: record.error ?? "perception run failed",
-                        log: record.events.slice(-10).map(formatEvent),
-                    });
-                const texts = record.outcome?.texts ?? {};
-                const answer = Object.values(texts).flat().join("\n").trim();
-                return compact({
-                    ok: true,
-                    feature,
-                    pluginId,
-                    answer: answer || "(empty answer)",
-                    raw: record.outcome?.result.outputs,
-                });
+                return compact(
+                    await describeViaSlot(
+                        env,
+                        pid,
+                        feature,
+                        prompt,
+                        args.pluginId,
+                    ),
+                );
             },
         }),
         defineTool({

--- a/packages/dsh-tongflow/test/model-modality.test.ts
+++ b/packages/dsh-tongflow/test/model-modality.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { modelTakesImages } from "../src/tools/run-tools.ts";
+import type { ToolEnv } from "../src/tools/support.ts";
+
+/**
+ * `tongflow_look` degrades to a describe slot only for a model that is known
+ * not to take images. The predicate must mirror the llm runtime's own rule
+ * (`inputModalities !== undefined && !includes("image")` is what makes it
+ * project images away) — erring toward "takes images" everywhere else, so an
+ * unknown route never silently spends a plugin run on every look.
+ */
+
+interface Case {
+    name: string;
+    llm: unknown;
+    options: { provider?: string; model?: string } | undefined;
+    expected: boolean;
+}
+
+function env(llm: unknown): ToolEnv {
+    return {
+        ctx: { get: (key: string) => (key === "llm" ? llm : undefined) },
+        studio: {},
+        api: {},
+    } as unknown as ToolEnv;
+}
+
+function exec(options: Case["options"]) {
+    return {
+        agent: options === undefined ? undefined : { options },
+        signal: new AbortController().signal,
+    } as never;
+}
+
+function llmWith(inputModalities: readonly string[] | undefined) {
+    return {
+        resolveModelInfo: async () => ({ inputModalities }),
+    };
+}
+
+const SELECTED = { provider: "deepseek-official", model: "deepseek-v4-pro" };
+
+const cases: Case[] = [
+    {
+        name: "no llm service mounted",
+        llm: undefined,
+        options: SELECTED,
+        expected: true,
+    },
+    {
+        name: "no agent on the execution",
+        llm: llmWith(["text"]),
+        options: undefined,
+        expected: true,
+    },
+    {
+        name: "agent without a resolved provider/model",
+        llm: llmWith(["text"]),
+        options: {},
+        expected: true,
+    },
+    {
+        name: "model declares no modalities at all",
+        llm: llmWith(undefined),
+        options: SELECTED,
+        expected: true,
+    },
+    {
+        name: "model declares text only",
+        llm: llmWith(["text"]),
+        options: SELECTED,
+        expected: false,
+    },
+    {
+        name: "model declares text and image",
+        llm: llmWith(["text", "image"]),
+        options: SELECTED,
+        expected: true,
+    },
+    {
+        name: "resolveModelInfo throws",
+        llm: {
+            resolveModelInfo: async () => {
+                throw new Error("unknown model");
+            },
+        },
+        options: SELECTED,
+        expected: true,
+    },
+];
+
+describe("modelTakesImages", () => {
+    for (const c of cases) {
+        it(`${c.name} → ${c.expected}`, async () => {
+            expect(await modelTakesImages(env(c.llm), exec(c.options))).toBe(
+                c.expected,
+            );
+        });
+    }
+});


### PR DESCRIPTION
## The bug

`tongflow_look` returned an image block unconditionally. Under a model that does not take images, dsh's llm runtime quietly replaces that block with placeholder text before dispatch (`projectImagesForTextModel` → `replaceImagesForTextModel`), so:

- the tool call **succeeds**
- the agent believes it looked at the asset
- it saw nothing

For a tool whose entire job is review, that is the worst possible failure shape — worse than an error.

## The fix

The plugin already had the answer. `tongflow_perceive` routes understanding through TongFlow's own describe slots — its description literally says *"this is how you review generated media the chat model cannot ingest directly"*, and it is how video and audio have always been reviewed.

`tongflow_look` now checks the session model's declared modalities:

| Model takes images | Images | Video |
|---|---|---|
| yes | image block, as before | contact sheet, as before |
| no | routed through `image-describe`, returns text | routed through `video-describe` on the file itself (a contact sheet would be equally unreadable), returns text |

Either way the summary says which plugin described it, so the agent knows it read a description rather than saw a picture.

## The predicate

`modelTakesImages` mirrors the llm runtime's own rule — it degrades only for a model that *declares* `inputModalities` without `"image"` — and errs toward "takes images" for an unknown agent, an absent llm service, or a failed resolve. Guessing the other way would spend a plugin run on every look under an unrecognized route.

Chain: `exec.agent?.options` → `{provider, model}` → `ctx.llm.resolveModelInfo()` → `inputModalities`. The `llm` service is read with `ctx.get()` (optional, same pattern as `attachments`) since it is not in the plugin's `inject`.

New test `test/model-modality.test.ts` is a truth table over all six branches. Checked against the real DeepSeek catalog: `deepseek-v4-pro` declares nothing and the adapter schema defaults it to `["text"]` → degrades; `deepseek-v4-flash-vision-exp` declares `["text","image"]` → attaches. Both land in the intended branch.

## Refactor

The slot-run body is lifted out of `tongflow_perceive` into a shared `describeViaSlot`, so `look`'s fallback and `perceive` keep one implementation.

## ⚠️ One consequence to be aware of

**The fallback can spend money.** `describeViaSlot` calls `startCanvasRun`, and the billing checkpoint (`user_confirmed`) lives only on `tongflow_workflow_run` — `tongflow_perceive` has always called it ungated. So in a text-model session, every `tongflow_look` on an image or video now costs one describe run.

This is consistent with `tongflow_perceive`'s existing behaviour and is visible in the transcript (the summary names the plugin that ran), but it does turn a previously free tool into a potentially paid one. Whether `look`'s fallback — or `perceive` itself — should be gated is a separate design decision, deliberately not made here.

## Version

0.3.0 → **0.4.0** (a tool's observable contract changes).

## Checks

- `pnpm --filter dsh-tongflow test` — 22 passed (4 files; was 15)
- `pnpm --filter dsh-tongflow typecheck` — clean, including the client project
- `pnpm lint:check` — 435 files, no fixes applied
- `pnpm --filter dsh-tongflow build` — clean

Not run against a live harness; the predicate's branches are covered by the truth table rather than by a real session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)