### PR TITLE
feat(dsh-tongflow): point the agent at the plugin's own README

### DIFF
--- a/packages/dsh-tongflow/package.json
+++ b/packages/dsh-tongflow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dsh-tongflow",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "TongFlow studio plugin for DeepSeek Harness (dsh): agent-designed project folders, one TongFlow workflow per generated asset stored next to its outputs, deterministic media generation, embedded canvas.",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/packages/dsh-tongflow/skills/tongflow-studio.md
+++ b/packages/dsh-tongflow/skills/tongflow-studio.md
@@ -82,5 +82,6 @@ Rules of thumb:
 - A workflow has as many steps as *that asset* needs (fusion → upscale, i2v → lip-sync, concat → merge music) — never more.
 - Text you author (script, dialogue, prompts) goes into files, then into workflows by inclusion or as node text — text generation nodes are only for mechanical bulk transforms.
 - Before running, make sure the plugin for each node is installed (`tongflow_plugins_list`, `tongflow_plugins_install`) and its API keys are configured in the studio's Plugins & keys dialog.
+- **Read the plugin's own README before guessing.** `tongflow_plugins_list` gives each installed plugin's `readme` path; the file says which models it offers and which is the default, what each env key changes, the resolutions and aspect ratios it accepts, and its quirks. Read it when choosing between plugins for a slot, when setting a model or param you have not used, and when a run fails for a reason the error does not explain — it is local, authoritative, and costs nothing. Do not guess a model name; do not go looking on the web for something the installed plugin already documents.
 - If the user edited a workflow on the canvas, `tongflow_workflow_read` it again before patching.
 - Never delete generated files on your own; the user decides what to keep.

--- a/packages/dsh-tongflow/src/tools/run-tools.ts
+++ b/packages/dsh-tongflow/src/tools/run-tools.ts
@@ -62,6 +62,25 @@ export async function modelTakesImages(
     }
 }
 
+/**
+ * A plugin's own README, when the clone shipped one. Only the path travels in
+ * the catalog: the agent reads the file when it needs to choose between
+ * plugins, set an unfamiliar model, or understand a failure. An installed
+ * plugin is not a new trust surface — its code already runs on this machine.
+ */
+export async function pluginReadme(
+    pluginsDir: string,
+    id: string,
+): Promise<{ readme?: string }> {
+    const path = join(pluginsDir, id, "README.md");
+    try {
+        if ((await stat(path)).isFile()) return { readme: path };
+    } catch {
+        // Not every plugin ships one; absence is normal, not an error.
+    }
+    return {};
+}
+
 /** One TongFlow describe/transcribe slot run over a local media file. */
 interface SlotDescription {
     ok: boolean;
@@ -581,14 +600,15 @@ export function runTools(env: ToolEnv): ToolDefinition[] {
         defineTool({
             name: "tongflow_plugins_list",
             description:
-                "Installed TongFlow plugins (id, name, ABI slots they implement, required env keys) and the official plugin ids that can be installed.",
+                "Installed TongFlow plugins (id, name, ABI slots they implement, required env keys, and the path of the plugin's own README when it has one) and the official plugin ids that can be installed. " +
+                "A plugin's README is written by whoever wrote the plugin: which models it offers and which is the default, what each env key does, resolutions and aspect ratios it accepts, and its quirks. Read that file before choosing between plugins for a slot, before setting an unfamiliar model or param, and when a run fails for a reason the error does not explain.",
             parameters: {},
             output: { schema: { type: "json" }, render: (_a, v) => text(v) },
             async execute() {
                 const { registry, meta } = await api.registry();
                 const OFFICIAL_PLUGINS = await studio.registry.officialIds();
-                const installed = Object.entries(registry.plugins).map(
-                    ([id, p]) => ({
+                const installed = await Promise.all(
+                    Object.entries(registry.plugins).map(async ([id, p]) => ({
                         id,
                         name: (p as { name?: string }).name ?? id,
                         slots: Object.keys(
@@ -601,7 +621,11 @@ export function runTools(env: ToolEnv): ToolDefinition[] {
                         env: (meta[id]?.env ?? []).map(
                             (e) => `${e.key}${e.required ? "*" : ""}`,
                         ),
-                    }),
+                        // The path only; the file is read on demand, never
+                        // pulled into the catalog. Together the installed
+                        // READMEs run to thousands of lines.
+                        ...(await pluginReadme(studio.paths.plugins, id)),
+                    })),
                 );
                 return compact({
                     installed,

--- a/packages/dsh-tongflow/test/plugin-readme.test.ts
+++ b/packages/dsh-tongflow/test/plugin-readme.test.ts
@@ -1,0 +1,44 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { pluginReadme } from "../src/tools/run-tools.ts";
+
+/**
+ * Only the path travels in the plugins catalog — the installed READMEs run to
+ * thousands of lines together, and the agent reads one when it needs it. A
+ * plugin without a README must not gain an empty or dangling `readme` field.
+ */
+describe("pluginReadme", () => {
+    let dir: string;
+
+    beforeEach(async () => {
+        dir = await mkdtemp(join(tmpdir(), "tf-readme-"));
+    });
+    afterEach(async () => {
+        await rm(dir, { recursive: true, force: true });
+    });
+
+    it("gives the path when the plugin shipped one", async () => {
+        await mkdir(join(dir, "tongflow-api-gemini"), { recursive: true });
+        const path = join(dir, "tongflow-api-gemini", "README.md");
+        await writeFile(path, "# tongflow-api-gemini\n");
+        expect(await pluginReadme(dir, "tongflow-api-gemini")).toEqual({
+            readme: path,
+        });
+    });
+
+    it("stays silent for a plugin without one", async () => {
+        await mkdir(join(dir, "tongflow-modal-bare"), { recursive: true });
+        expect(await pluginReadme(dir, "tongflow-modal-bare")).toEqual({});
+    });
+
+    it("stays silent for a plugin directory that is not there", async () => {
+        expect(await pluginReadme(dir, "never-installed")).toEqual({});
+    });
+
+    it("does not mistake a README directory for a file", async () => {
+        await mkdir(join(dir, "odd", "README.md"), { recursive: true });
+        expect(await pluginReadme(dir, "odd")).toEqual({});
+    });
+});


### PR DESCRIPTION
## The gap

Every installed plugin ships a README written by whoever wrote the plugin — which models it offers and which is the default, what each env key changes, which resolutions and aspect ratios it takes, where it is quirky. `tongflow-api-gemini`'s alone explains that image slots default to Nano Banana Lite and that `2K`/`4K` need a different model.

Nothing ever told the agent those files exist. `tongflow_plugins_list` returned `{id, name, slots, env}`, so the agent guessed model names it could have read.

## The change

Each installed plugin now carries a `readme` path when its clone shipped one — verified against the live install: **46 of 46** official plugins have one.

**The path only.** Together the installed READMEs run to ~1700 lines; pulling them into the catalog would be a token disaster. The agent reads one when it needs it — the same progressive disclosure the skill references use.

`tongflow_node_catalog` is deliberately untouched: it returns one text line per node type, and README paths there would bloat and duplicate.

## When to read it

The skill now says: choosing between plugins for a slot, setting a model or param not used before, and a run that failed for a reason the error does not explain. Explicitly: *"Do not guess a model name; do not go looking on the web for something the installed plugin already documents."*

## Why this and not a web lookup

An installed plugin's README is **not a new trust surface — its code already runs on this machine**, so reading its documentation is strictly less dangerous than running it. Arbitrary web content is the opposite: a fresh, uncontrolled path into the agent's own instructions. Local and authoritative should be tried first; the web is a fallback, and separate work.

## Tests

`test/plugin-readme.test.ts` — four cases: plugin with a README gives the path; plugin without one stays silent; missing plugin directory stays silent; a directory *named* `README.md` is not mistaken for a file. A plugin without a README must not gain an empty or dangling field.

## Version

0.4.0 → **0.5.0** (new capability surfaced to the agent).

## Checks

- `pnpm --filter dsh-tongflow test` — 31 passed (6 files; was 27)
- `pnpm --filter dsh-tongflow typecheck` — clean, including the client project
- `pnpm lint:check` — 437 files, no fixes applied
- Verified against `~/.dsh/tongflow/plugins`: 46 with a README, 0 without

🤖 Generated with [Claude Code](https://claude.com/claude-code)