### PR TITLE
fix(dsh-tongflow): make "nothing lives only in chat" an actual rule

### DIFF
--- a/packages/dsh-tongflow/package.json
+++ b/packages/dsh-tongflow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dsh-tongflow",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "TongFlow studio plugin for DeepSeek Harness (dsh): agent-designed project folders, one TongFlow workflow per generated asset stored next to its outputs, deterministic media generation, embedded canvas.",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/packages/dsh-tongflow/skills/tongflow-studio.md
+++ b/packages/dsh-tongflow/skills/tongflow-studio.md
@@ -12,7 +12,7 @@ Three layers, never mixed up:
 
 1. **You (the agent)** create: the plan, the folder structure, briefs, scripts, character notes, prompts, decisions, review notes. Those are plain files you write with the ordinary file tools.
 2. **TongFlow** generates deterministically: every image, voice, music, video or 3D asset is produced by **running a saved workflow file** (`<name>.tongflow.json`). There is no "just generate an image" tool — the workflow file is reproducible, editable on the canvas by the user, and re-runnable.
-3. **The project folder** is the single source of truth. Nothing lives only in chat.
+3. **The project folder** is the single source of truth. Nothing lives only in chat — see **The second rule** below.
 
 ## The one rule
 
@@ -28,6 +28,22 @@ characters/mei/
 ```
 
 One workflow per asset, named after the asset, in the folder where the asset belongs. Multi-output runs are `mei_ref.03.image.png` + `mei_ref.03.caption.txt`. To use a result elsewhere, reference the file by path.
+
+## The second rule
+
+**Everything you write lands in a file. Chat is where you point at it, not where you deliver it.**
+
+Write the file first, then say a line or two in chat: what you wrote, where, and anything you had to guess. "Wrote `ep01/sh010/prompt.md` — 6s, one push-in, she stands and crosses to the door. I guessed the jacket stays wet from sh005; say if not."
+
+Do not paste the work into chat instead of saving it. Do not paste it into chat *and* save it either — the user then reviews the chat copy, their edits go to a file nobody re-reads, and the two drift apart. One copy, on disk.
+
+A file is what the user opens in the Studio, edits by hand, keeps, and what the next session reads. A chat message is none of those.
+
+**Goes in a file**: the plan and the folder README; briefs; character, style and world notes; scripts and dialogue; every prompt you write — in the workflow node itself, or in a text file the node includes with `{{path}}`; shot lists and beat sheets; research summaries; review findings and which take you picked and why; decisions and the reasoning behind them; anything longer than a few lines; anything you would otherwise have to say twice.
+
+**Stays in chat**: the billing question and the user's answer; a question you need answered before you can continue; short status ("run 3 done, kept `.02`"); and the pointer to what you just wrote.
+
+When the user asks to see something you wrote, give them the path — they can open it. Paste it inline only if they ask for it inline.
 
 ## There is no template — design the structure
 


### PR DESCRIPTION
Reported from use: the agent delivers its writing in the conversation instead of on disk, so the user cannot open it in the Studio's file tree, cannot edit it by hand, and the next session cannot read it.

## Why it was being ignored

The rule was already in the skill — four times, and not once as a rule:

| Line | What it said |
|---|---|
| 15 | "Nothing lives only in chat" — a principle in the opening list, no instruction attached |
| 38 | the plan goes in a `README.md` |
| 75 | review findings go in a notes file |
| 83 | authored script / dialogue / prompts go in files |

Three narrow clauses and one belief. Nothing told the agent what to actually do, so it did the natural thing and answered in chat.

## The change

It becomes **"The second rule"**, sitting directly after **"The one rule"** (every generated asset comes from a workflow file beside its outputs) — the two rules of this studio, one for what the machine generates, one for what the agent writes.

It states an action, not a belief: **write the file first, then say a line or two in chat about what you wrote, where, and what you had to guess.**

Both failure modes are named, because the second one is the sneaky one:

- pasting the work into chat *instead* of saving it
- pasting it into chat **as well as** saving it — the user reviews the chat copy, edits the file, and the two drift apart. One copy, on disk.

## Drawing the line

Two explicit lists, so this does not collapse into "never say anything":

**In a file** — plan and folder README; briefs; character, style and world notes; scripts and dialogue; every prompt (in the workflow node, or a text file it includes with `{{path}}`); shot lists and beat sheets; research summaries; review findings and which take was picked and why; decisions and their reasoning; anything longer than a few lines; anything you would otherwise say twice.

**In chat** — the billing question and its answer; a question that blocks the work; short status; and the pointer to what was just written.

Plus: when the user asks to see something, give the path — paste inline only when asked for inline.

## Version

0.6.0 → **0.6.1**. Skill wording only; no code, no tool contract change.

## Checks

- `pnpm --filter dsh-tongflow test` — 35 passed
- `pnpm lint:check` — 437 files, no fixes applied

Worth noting this is guidance, not enforcement — nothing in the runtime can stop the model from answering in chat. If it still does after this, the next lever is structural rather than more words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)