### PR TITLE
feat(dsh-tongflow): one step per workflow, a composition at every level

### DIFF
--- a/packages/dsh-tongflow/package.json
+++ b/packages/dsh-tongflow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dsh-tongflow",
-    "version": "0.6.1",
+    "version": "0.7.0",
     "description": "TongFlow studio plugin for DeepSeek Harness (dsh): agent-designed project folders, one TongFlow workflow per generated asset stored next to its outputs, deterministic media generation, embedded canvas.",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/packages/dsh-tongflow/skills/tongflow-studio.md
+++ b/packages/dsh-tongflow/skills/tongflow-studio.md
@@ -45,12 +45,42 @@ A file is what the user opens in the Studio, edits by hand, keeps, and what the 
 
 When the user asks to see something you wrote, give them the path — they can open it. Paste it inline only if they ask for it inline.
 
+## The third rule
+
+**One workflow is one step. Every folder above them holds the composition of everything beneath it.**
+
+Split until a workflow has a single executable node, and give each its own place:
+
+```
+ep01/
+  ep01_all.tongflow.json        ← every leaf under ep01, composed
+  sh010/
+    sh010_all.tongflow.json     ← ref + i2v + lipsync, composed
+    ref.tongflow.json           ← ONE node: text → image
+    ref.02.png
+    i2v.tongflow.json           ← ONE node: ./ref.02.png → video
+    i2v.01.mp4
+    lipsync.tongflow.json       ← ONE node: ./i2v.01.mp4 + ./line.wav → video
+    lipsync.01.mp4
+  sh020/
+    sh020_all.tongflow.json
+    …
+```
+
+Why one node per file: a step you can re-run alone is a step you can fix alone. Re-running `i2v` does not regenerate the keyframe you already approved and paid for, its outputs number independently (`i2v.01.mp4`, `i2v.02.mp4`), and the user can open exactly the step they want to argue with on the canvas.
+
+Why the composition at every level: `tongflow_workflow_compose({ folder })` gathers the **leaves** beneath a folder — not the child folders' own `_all` files — and turns each file reference into a real edge, across folders as well as within one. So `sh010_all` is that shot end to end, `ep01_all` is the whole episode, and running either regenerates everything underneath in one go. The leaves stay exactly as they were; a composition is a view, never a replacement.
+
+Compose a level once its leaves exist and were reviewed, and compose it again after the leaves change — a stale `_all` is worse than none, because it looks whole.
+
 ## There is no template — design the structure
+
+The three rules fix the *granularity* — one workflow per step, outputs beside their workflow, a composition at every level above — not the folder names. What the folders are called and how deep they go is yours to design: `ep01/sh010/` for a drama, `spots/30s/shot-03/` for an ad, `tracks/02/stem-bass/` for an album.
 
 The project starts as an empty folder with `project.json` (title, brief). Read the brief (`tongflow_project_status`), then:
 
 1. **Research first.** If you know little about the genre, format, deliverable or style, use `web_search` / `web_fetch` when available: how is this kind of thing normally produced, what are the stages, what does a professional deliverable look like. Keep a short `research.md` with what mattered and links. Skip when the user gave the material or asked you not to browse.
-2. **Propose the folder structure** to the user as a plan: which folders, what goes in each, in what order things get made, and which assets need a workflow. Adapt it to the work — a manga drama, a product ad, a music video, an audiobook and a game asset pack all look different. Keep it flat and readable; prefer numbers or ids that sort (`ep01/sh010`) when order matters.
+2. **Propose the folder structure** to the user as a plan: which folders, what goes in each, in what order things get made, and which assets need a workflow. Adapt it to the work — a manga drama, a product ad, a music video, an audiobook and a game asset pack all look different. **Divide finely, all the way down to one step per workflow** (see **The third rule**); prefer numbers or ids that sort (`ep01/sh010`) when order matters, and let the depth follow the work's own shape — episode, scene, shot, step.
 3. **Write it down**: create the folders, and put a `README.md` (or a `plan.md` at the root) that explains the structure and the steps — the user and later sessions read that, not the chat.
 4. **Fill it stage by stage**: text you author → workflow files → runs → review → the next stage builds on the results by path.
 
@@ -89,13 +119,13 @@ These sit next to this file; resolve them against the skill's base directory.
 3. **Billing checkpoint — every paid run, every time.** A run that uses a paid plugin costs the user money (a paid API key, or GPU seconds on their Modal account — a Modal plugin also deploys on first run). `tongflow_workflow_run` without `user_confirmed` refuses and returns `needs_confirmation`: which plugins, how each is billed, whether its API keys are set, which models it offers, and installed alternatives. Put that to the user in plain words ("这一步用 Gemini 生图,按次计费到你的 GEMINI_API_KEY;也可以换 X;要用哪个模型?现在跑吗?"), wait for their yes, then call again with `user_confirmed: true`. Ask before **each** paid run — a yes for the last run does not cover the next one, and never set the flag on your own. Runs that use only local plugins are free and need no confirmation. When you plan a batch (e.g. ten shots), say so and get one clear yes for that batch, then run them one after another.
 4. `tongflow_workflow_run` — foreground for a single image, `run_in_background` for video/batches; keep working meanwhile.
 5. Review: `tongflow_look` (images, video contact sheets) and `tongflow_perceive` (video/audio/image understanding, transcripts). If this session's model does not take images, `tongflow_look` describes the asset through a describe slot instead of showing it, and says so — a look is never silently blind. Understanding runs a plugin, so it obeys the same billing checkpoint as a run: a billing plugin returns `needs_confirmation` and needs the user's yes before `tongflow_perceive` is called with `user_confirmed: true`; a local one just runs. Write findings into a notes file next to the asset or in a `notes/` folder.
-6. **Compose when a stage chain is done.** When a shot / scene / asset has several small workflows that feed each other by file (`./ref.01.png` → `i2v` → `lipsync`), `tongflow_workflow_compose({ folder })` (or an explicit `workflows` list) writes ONE big `<folder>_all.tongflow.json`: file references to another part's output become real edges, every stage stays an output named after its part (`shot_all.01.i2v.mp4`), the parts are untouched. Tell the user to open it on the canvas to see and tweak the whole; a run of it regenerates everything in one go (it is a paid run like any other).
+6. **Compose upward when a folder is done.** `tongflow_workflow_compose({ folder })` gathers every leaf workflow **under** that folder, at any depth, and writes ONE `<folder>_all.tongflow.json` beside them: file references to another part's output become real edges — across folders as well as within one — every stage stays an output named after its part (`sh010_all.01.i2v.mp4`), and the parts are untouched. Do it for the shot, then the scene, then the episode, so each level has the whole picture of what is beneath it (see **The third rule**). Tell the user to open it on the canvas; a run of it regenerates everything under that folder in one go (a paid run like any other).
 7. If it is off, name the failure and the layer that owns it (`references/failure-codes.md`), change one thing, and run again — the next number lands beside the old one. Two versions with no improvement on the same failure means the problem is not in the prompt (`references/iteration.md`). When it is right, use that file's path downstream (e.g. `./mei_ref.02.png` as the reference for a shot). Tell the user which number you picked and why.
 
 Rules of thumb:
 - Patch incrementally; never rebuild a workflow from scratch; never invent node ids. Read the patch result: `ok:false` steps must be fixed before running.
 - Prefer self-contained workflows (values written into nodes) so opening the file on the canvas shows exactly what made that output. A level-0 data node without data becomes an input you supply per run — use it only for genuinely per-run values.
-- A workflow has as many steps as *that asset* needs (fusion → upscale, i2v → lip-sync, concat → merge music) — never more.
+- A workflow is **one executable node** and the data nodes feeding it. A chain (fusion → upscale, i2v → lip-sync, concat → merge music) is that many workflows in one folder, joined by their output files, not one workflow with several steps.
 - Text you author (script, dialogue, prompts) goes into files, then into workflows by inclusion or as node text — text generation nodes are only for mechanical bulk transforms.
 - Before running, make sure the plugin for each node is installed (`tongflow_plugins_list`, `tongflow_plugins_install`) and its API keys are configured in the studio's Plugins & keys dialog.
 - **Read the plugin's own README before guessing.** `tongflow_plugins_list` gives each installed plugin's `readme` path; the file says which models it offers and which is the default, what each env key changes, the resolutions and aspect ratios it accepts, and its quirks. Read it when choosing between plugins for a slot, when setting a model or param you have not used, and when a run fails for a reason the error does not explain — it is local, authoritative, and costs nothing. Do not guess a model name; do not go looking on the web for something the installed plugin already documents.

--- a/packages/dsh-tongflow/src/api.ts
+++ b/packages/dsh-tongflow/src/api.ts
@@ -34,6 +34,7 @@ import {
     singleNodeDocument,
 } from "./engine/single-node.ts";
 import {
+    COMPOSED_SUFFIX,
     type ComposeResult,
     composeWorkflows,
     workflowsInFolder,
@@ -79,6 +80,13 @@ import type {
 import { modalityOfExt } from "./shared/types.ts";
 import type { Studio } from "./studio.ts";
 import { exists, writeFileAtomic } from "./util/fsx.ts";
+
+/** Where a folder's composed workflow lives: inside that folder, named after it. */
+function composedKeyForFolder(folderKey: string): string {
+    const dir = normalizeKey(folderKey);
+    const name = `${basename(dir || "project")}${COMPOSED_SUFFIX}${WORKFLOW_EXT}`;
+    return dir ? `${dir}/${name}` : name;
+}
 
 export class StudioApi {
     constructor(readonly studio: Studio) {}
@@ -324,9 +332,17 @@ export class StudioApi {
                 "nothing to compose — pass workflows: [...] or a folder that holds workflow files",
             );
         const registry = (await this.studio.registry.get()).registry;
+        // Composing a folder writes into THAT folder. The generic fallback
+        // uses the first part's directory, which for a recursive gather is
+        // some leaf several levels down, not the folder that was asked for.
+        const path =
+            options.path ??
+            (options.folder !== undefined
+                ? composedKeyForFolder(options.folder)
+                : undefined);
         return composeWorkflows(ref.root, {
             workflows,
-            ...(options.path !== undefined ? { path: options.path } : {}),
+            ...(path !== undefined ? { path } : {}),
             ...(options.name ? { name: options.name } : {}),
             registry,
         });

--- a/packages/dsh-tongflow/src/project/compose.ts
+++ b/packages/dsh-tongflow/src/project/compose.ts
@@ -65,21 +65,41 @@ export interface ComposeResult {
 /** Suffix of the composed file when none is given. */
 export const COMPOSED_SUFFIX = "_all";
 
-/** Every workflow directly inside `folder` (not recursive), sorted by name, composed files excluded. */
+/**
+ * Every workflow under `folder`, at any depth, sorted by project key so the
+ * order is stable and folders stay together; composed files are excluded at
+ * every level.
+ *
+ * A parent composes the LEAVES beneath it, never its children's own composed
+ * files: a part is linked to a producer by the file it references, and a
+ * composed file's outputs are named after the composition (`a_all.01.x.png`),
+ * not after the part that a sibling actually references (`a/x.02.png`). Taking
+ * the leaves keeps every reference matchable, so the parent's graph is
+ * connected the whole way down instead of silently reading stale files.
+ */
 export async function workflowsInFolder(
     projectRoot: string,
     folderKey: string,
 ): Promise<string[]> {
     const dir = fromProjectKey(projectRoot, normalizeKey(folderKey) || ".");
     if (!(await exists(dir))) return [];
-    return (await readdir(dir))
-        .filter(
-            (n) =>
-                n.endsWith(WORKFLOW_EXT) &&
-                !basename(n, WORKFLOW_EXT).endsWith(COMPOSED_SUFFIX),
-        )
-        .sort()
-        .map((n) => toProjectKey(projectRoot, join(dir, n)));
+    const out: string[] = [];
+    const walk = async (at: string): Promise<void> => {
+        for (const entry of await readdir(at, { withFileTypes: true })) {
+            const full = join(at, entry.name);
+            if (entry.isDirectory()) {
+                await walk(full);
+                continue;
+            }
+            if (
+                entry.name.endsWith(WORKFLOW_EXT) &&
+                !basename(entry.name, WORKFLOW_EXT).endsWith(COMPOSED_SUFFIX)
+            )
+                out.push(toProjectKey(projectRoot, full));
+        }
+    };
+    await walk(dir);
+    return out.sort();
 }
 
 /** Resolve a data-node file reference of part `partKey` to a project key (URLs / absolute paths → undefined). */
@@ -161,7 +181,12 @@ function fileRefsOf(part: ComposePart): string[] {
     return out;
 }
 
-/** Which part produces the file at `key` (same folder, `<stem>.NN…` name), if any. */
+/**
+ * Which part produces the file at `key`, if any. `key` arrives already
+ * resolved to a project key by {@link refToKey}, so comparing it against each
+ * part's own directory matches across folders as well as within one — a
+ * workflow's outputs land beside it, wherever it lives.
+ */
 function producerIndex(parts: ComposePart[], key: string): number {
     const dir = keyDir(key);
     const file = key.slice(dir ? dir.length + 1 : 0);

--- a/packages/dsh-tongflow/src/tools/workflow-tools.ts
+++ b/packages/dsh-tongflow/src/tools/workflow-tools.ts
@@ -246,7 +246,7 @@ export function workflowTools(env: ToolEnv): ToolDefinition[] {
         defineTool({
             name: "tongflow_workflow_compose",
             description:
-                "Compose several small workflows into ONE big workflow file for a whole-picture canvas view and one-shot re-runs (e.g. a shot's keyframe → i2v → lip-sync, or every stage in a folder). " +
+                "Compose several small workflows into ONE big workflow file for a whole-picture canvas view and one-shot re-runs (e.g. a shot's keyframe → i2v → lip-sync, or everything under a scene folder). " +
                 "Where a part references another part's output file (an imageNode with './keyframe.02.png' while keyframe.tongflow.json sits in the same folder), that file becomes a real edge from the producing node; other file refs stay files. Every stage's product remains an output, named after its part (<all>.01.keyframe.png, <all>.01.i2v.mp4). The parts are not modified. " +
                 "Do this after the parts exist and were reviewed; tell the user to open the composed file on the canvas.",
             parameters: {
@@ -260,7 +260,7 @@ export function workflowTools(env: ToolEnv): ToolDefinition[] {
                 folder: {
                     type: "string",
                     description:
-                        "Compose every workflow directly inside this folder, sorted by file name (previous *_all files excluded).",
+                        "Compose every workflow under this folder, at any depth, sorted by path (previous *_all files excluded at every level). This is how a parent folder gets the whole picture of everything beneath it: it takes the leaf workflows, not its children's composed files, so every file reference still matches the part that produces it.",
                 },
                 path: {
                     type: "string",

--- a/packages/dsh-tongflow/test/project-model.test.ts
+++ b/packages/dsh-tongflow/test/project-model.test.ts
@@ -465,6 +465,117 @@ describe("billing checkpoint", () => {
 });
 
 describe("compose", () => {
+    /** The plugin catalog the composition tests resolve node types against. */
+    function fakeRegistry(api: StudioApi): void {
+        (api.studio.registry as unknown as { cache: unknown }).cache = {
+            registry: {
+                plugins: {
+                    fake: {
+                        needsDeploy: false,
+                        methodsByNodeSlot: {
+                            "image-gen": { methodName: "a" },
+                            "image-edit": { methodName: "b" },
+                            "image-gen-video": { methodName: "c" },
+                            "audio-video-lip-sync": { methodName: "d" },
+                        },
+                    },
+                },
+                nodePluginMap: {
+                    "image-gen": ["fake"],
+                    "image-edit": ["fake"],
+                    "image-gen-video": ["fake"],
+                    "audio-video-lip-sync": ["fake"],
+                },
+            },
+            meta: { fake: { env: [] } },
+            scannedAt: "now",
+        };
+    }
+
+    /**
+     * A parent folder composes everything beneath it, and a part links to a
+     * producer that lives in a different folder. Both matter for a tree of
+     * one-node workflows: the leaves sit several levels down, and a shot's
+     * first step reads the previous shot's last output.
+     */
+    it("gathers leaves at any depth and links a reference across folders", async () => {
+        const api = new StudioApi(
+            new Studio({ config: Config({ studioRoot: studio }) }),
+        );
+        fakeRegistry(api);
+
+        // ep01/sh010/ref: text → image
+        await api.newWorkflow(projectId, "ep01/sh010/ref");
+        await api.patchWorkflow(projectId, "ep01/sh010/ref", {
+            add_nodes: [
+                { alias: "t", type: "textNode", data: { texts: ["a girl"] } },
+                { alias: "g", type: "textGenImageNode" },
+            ],
+            add_edges: [{ from: "t", to: "g" }],
+        } as never);
+        await put("ep01/sh010/ref.01.png");
+
+        // ep01/sh010/i2v: ./ref.01.png → video (same folder)
+        await api.newWorkflow(projectId, "ep01/sh010/i2v");
+        await api.patchWorkflow(projectId, "ep01/sh010/i2v", {
+            add_nodes: [
+                {
+                    alias: "img",
+                    type: "imageNode",
+                    data: { fileKeys: ["./ref.01.png"] },
+                },
+                {
+                    alias: "v",
+                    type: "imageGenVideoNode",
+                    data: { text: "slow push in", duration: 5 },
+                },
+            ],
+            add_edges: [{ from: "img", to: "v" }],
+        } as never);
+        await put("ep01/sh010/i2v.01.mp4");
+
+        // ep01/sh020/open: ../sh010/ref.01.png → image (ANOTHER folder)
+        await api.newWorkflow(projectId, "ep01/sh020/open");
+        await api.patchWorkflow(projectId, "ep01/sh020/open", {
+            add_nodes: [
+                {
+                    alias: "img",
+                    type: "imageNode",
+                    data: { fileKeys: ["../sh010/ref.01.png"] },
+                },
+                {
+                    alias: "e",
+                    type: "imageEditNode",
+                    data: { text: "wider crop" },
+                },
+            ],
+            add_edges: [{ from: "img", to: "e" }],
+        } as never);
+
+        // The parent sees every leaf beneath it, not just its own directory.
+        expect(await workflowsInFolder(root, "ep01")).toEqual([
+            "ep01/sh010/i2v.tongflow.json",
+            "ep01/sh010/ref.tongflow.json",
+            "ep01/sh020/open.tongflow.json",
+        ]);
+
+        const result = await api.composeWorkflows(projectId, {
+            folder: "ep01",
+        });
+        expect(result.key).toBe("ep01/ep01_all.tongflow.json");
+        // ref produces what both of the others read, so it is ordered first.
+        expect(result.parts[0]).toBe("ep01/sh010/ref.tongflow.json");
+        expect(result.parts).toHaveLength(3);
+        // Two real edges: the same-folder one AND the cross-folder one.
+        expect(result.links).toBe(2);
+        expect(result.unlinked).toEqual([]);
+
+        // Composing the parent again skips the _all it just wrote.
+        expect(await workflowsInFolder(root, "ep01")).not.toContain(
+            "ep01/ep01_all.tongflow.json",
+        );
+    });
+
     it("links parts by their output files, keeps every stage an output, names outputs after the parts, leaves the parts untouched", async () => {
         const api = new StudioApi(
             new Studio({ config: Config({ studioRoot: studio }) }),


### PR DESCRIPTION
Three requirements from use: generated text goes to files (landed in #175), folders divided finely down to one-step workflows, and every parent folder holding a workflow composed from what is beneath it.

## What was blocking the third

**`compose({folder})` never descended.** `readdir(dir)` listed one directory, so a project divided into `ep01/sh010/` had nothing to compose at `ep01`. It now gathers every leaf beneath a folder at any depth.

**It gathers leaves, not the children's `_all` files** — and this is the part worth being careful about. A part is linked to a producer by the file it references. A composed file's outputs are named after the *composition* (`sh010_all.01.i2v.mp4`), not after the part a sibling actually reads (`sh010/i2v.01.mp4`). So composing compositions matches nothing: every cross-level reference stays a static file, and the parent graph runs on **stale outputs while looking whole**. Taking the leaves keeps every reference matchable.

**The default output path was wrong for a recursive gather.** It came from the first part's directory — a leaf several levels down — so composing `ep01` wrote `ep01/sh010/sh010_all.tongflow.json`. Caught by the new test. A folder composition now writes into that folder.

## A correction to something I claimed earlier

I said cross-folder references could not become edges, because `producerIndex` compares directories. That was wrong: `refToKey` already resolves `./` and `../` against the consuming part's directory into a project key, so the comparison is between *the referenced file's* directory and *the part's own* directory — which matches across folders, since a workflow's outputs land beside it. The new test asserts it (`links: 2`, `unlinked: []`, one of the two links crossing from `sh020/` to `sh010/`).

## The skill

Granularity becomes **"The third rule"**, beside the two already there:

> **One workflow is one step. Every folder above them holds the composition of everything beneath it.**

With the reasoning attached: a step you can re-run alone is a step you can fix alone — re-running `i2v` does not regenerate the keyframe you already approved and paid for, and its outputs number independently.

Two rules of thumb said the opposite and now agree with it:

- "Keep it flat and readable" → divide finely, down to one step per workflow
- "A workflow has as many steps as *that asset* needs — never more" → a workflow is one executable node; a chain is that many workflows joined by their output files

"There is no template" survives, with the line drawn: the rules fix the **granularity**, not the folder names. `ep01/sh010/` for a drama, `spots/30s/shot-03/` for an ad, `tracks/02/stem-bass/` for an album.

Also added: compose a level again after its leaves change — a stale `_all` is worse than none, because it looks whole.

## Version

0.6.1 → **0.7.0**. 0.6.1 (#175) is merged but unpublished, so both ship together.

## Checks

- `pnpm --filter dsh-tongflow test` — 36 passed (was 35)
- `pnpm --filter dsh-tongflow typecheck` — clean, including the client project
- `pnpm lint:check` — 437 files, no fixes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)