### PR TITLE
feat(settings): check a Modal token can actually run GPUs, at connect time

### DIFF
--- a/src/components/workspace/settings/connect-configs.ts
+++ b/src/components/workspace/settings/connect-configs.ts
@@ -7,10 +7,38 @@ import {
     MODAL_TOKEN_ID_ENV,
     MODAL_TOKEN_SECRET_ENV,
 } from "@/lib/settings/env-key-metadata";
-import type { TokenProviderConfig } from "./token-connect";
+import type { TokenProviderConfig, TokenVerifyResult } from "./token-connect";
 
 // Prefix-anchored patterns; a minimum tail length avoids matching a bare
 // prefix the user is still typing.
+
+/**
+ * A Modal token can be perfectly valid and still buy nothing: Modal refuses
+ * GPU functions on accounts with no payment method, and only says so when a
+ * function is created. The cloud asks on our behalf right after connecting,
+ * so the answer arrives here rather than several minutes into a first
+ * generation. Self-host has no such endpoint — an unreachable probe is not a
+ * verdict, so it stays silent.
+ */
+async function probeModalGpu(): Promise<TokenVerifyResult | null> {
+    try {
+        const res = await fetch("/api/modal/probe", { method: "POST" });
+        if (!res.ok) return null;
+        const body = (await res.json()) as {
+            ok?: boolean | null;
+            errorCode?: string;
+            errorParams?: Record<string, string | number>;
+        };
+        if (body.ok !== false) return null;
+        return {
+            ok: false,
+            errorCode: body.errorCode,
+            errorParams: body.errorParams,
+        };
+    } catch {
+        return null;
+    }
+}
 
 export const MODAL_CONNECT: TokenProviderConfig = {
     ns: "ModalConnect",
@@ -32,6 +60,7 @@ export const MODAL_CONNECT: TokenProviderConfig = {
             missingKey: "missingSecret",
         },
     ],
+    verify: probeModalGpu,
     // The onboarding banner/wizard watch Modal connectivity.
     onConnectedStore: markModalConnected,
     onDisconnectedStore: markModalDisconnected,

--- a/src/components/workspace/settings/token-connect.tsx
+++ b/src/components/workspace/settings/token-connect.tsx
@@ -23,11 +23,14 @@ import {
     DialogDescription,
     DialogHeader,
     DialogTitle,
+    showErrorToast,
     Textarea,
 } from "tongflow/canvas";
+import { ModalBillingRow } from "@/components/workspace/modal-billing-row";
 import { DISCORD_URL, WECHAT_GROUP_QR_SRC } from "@/constants/community";
 import { useInChinaTz } from "@/hooks/use-in-china-tz";
 import { openExternalUrl } from "@/lib/desktop/open-external";
+import { localizeTaskError } from "@/lib/task/error-localize";
 
 /** One credential extracted from the pasted blob. */
 export interface TokenSpec {
@@ -40,6 +43,17 @@ export interface TokenSpec {
     /** i18n keys (within the provider namespace) for the parse status line. */
     detectedKey: string;
     missingKey: string;
+}
+
+/**
+ * Outcome of a post-connect check against the provider. `null` means the
+ * question could not be asked (no probe endpoint, provider unreachable) —
+ * never a verdict, so nothing is shown.
+ */
+export interface TokenVerifyResult {
+    ok: boolean;
+    errorCode?: string;
+    errorParams?: Record<string, string | number>;
 }
 
 /**
@@ -59,6 +73,13 @@ export interface TokenProviderConfig {
     specs: TokenSpec[];
     /** Interpolation values for every message (e.g. { provider: "OpenAI" }). */
     tValues?: Record<string, string>;
+    /**
+     * Optional post-connect check: a saved credential can still be unusable
+     * (Modal accepts the token but won't run GPUs without a payment method).
+     * Runs after the dialog closes; a coded failure is explained via
+     * `TaskErrors.<code>`.
+     */
+    verify?: () => Promise<TokenVerifyResult | null>;
     /** Optional store flips (e.g. Modal's onboarding banner). */
     onConnectedStore?: () => void;
     onDisconnectedStore?: () => void;
@@ -192,6 +213,7 @@ export function TokenConnectForm({
     const rawT = useTranslations(config.ns);
     const t = (key: string, values?: Record<string, string>) =>
         rawT(key, { ...config.tValues, ...values });
+    const tErr = useTranslations("TaskErrors");
     const managed = process.env.NEXT_PUBLIC_MANAGED_PLUGINS === "1";
     const [raw, setRaw] = useState("");
     const [saving, setSaving] = useState(false);
@@ -202,6 +224,25 @@ export function TokenConnectForm({
         spec.pattern ? (raw.match(spec.pattern)?.[0] ?? "") : extractLoose(raw),
     );
     const allFound = parsed.every(Boolean);
+
+    const verify = async () => {
+        const result = await config.verify?.();
+        if (!result || result.ok || !result.errorCode) return;
+        showErrorToast({
+            message: localizeTaskError(tErr, result),
+            id: `token-verify:${config.ns}`,
+            footer:
+                result.errorCode === "modal_payment_required" ? (
+                    <ModalBillingRow
+                        url={
+                            typeof result.errorParams?.url === "string"
+                                ? result.errorParams.url
+                                : undefined
+                        }
+                    />
+                ) : undefined,
+        });
+    };
 
     const connect = async () => {
         setSaving(true);
@@ -214,6 +255,9 @@ export function TokenConnectForm({
             config.onConnectedStore?.();
             toast.success(t("connectedToast"));
             onConnected?.();
+            // Costs a round trip to the provider — let the dialog close and
+            // report separately if the credential turns out to be unusable.
+            void verify();
         } catch (error) {
             logger.error(`Failed to save token (${config.ns}):`, error);
             toast.error(t("connectFailed"));


### PR DESCRIPTION
## Why

Modal happily accepts a token from an account with no payment method, then refuses every GPU function it's asked to create. So "Connect Modal" said *connected*, and the user discovered the real state of their account several minutes into their first image generation — as a failed task, which reads like a TongFlow bug.

Nothing in a Modal account's profile answers "can this run a GPU?". Creating a GPU function is the only way to ask.

## What

`TokenProviderConfig` gains an optional `verify`, run **after** the dialog closes so the round trip never blocks the Connect button:

```ts
verify?: () => Promise<TokenVerifyResult | null>;
```

- `null` means the question could not be asked — no probe endpoint, provider unreachable. That is silence, never a verdict; a working account is never accused because our own probe was down. Self-host has no probe endpoint, so it simply stays quiet.
- A coded result is explained through `TaskErrors.<code>`, reusing the copy and the "Open Modal billing" link that #177 already added for the run-time failure. No new strings.

Modal's config wires `verify` to the cloud's `POST /api/modal/probe`.

## Companion

The answering half lives in the cloud shell: a deployer-container endpoint that deploys one throwaway T4 function (`gpu_probe.py`), classifies the refusal, and stops the app immediately. Same commit also pins the previously-unpinned `modal` client in both the executor and deployer images, and makes the executor fetch a plugin's weights before deploying it.

## Checks

`pnpm lint:check`, `pnpm typecheck`, `pnpm build` pass. No ABI or `sdk/` changes.