### PR TITLE
feat(settings): hold the connect flow open while the Modal check runs

### DIFF
--- a/src/components/workspace/settings/token-connect.tsx
+++ b/src/components/workspace/settings/token-connect.tsx
@@ -23,10 +23,8 @@ import {
     DialogDescription,
     DialogHeader,
     DialogTitle,
-    showErrorToast,
     Textarea,
 } from "tongflow/canvas";
-import { ModalBillingRow } from "@/components/workspace/modal-billing-row";
 import { DISCORD_URL, WECHAT_GROUP_QR_SRC } from "@/constants/community";
 import { useInChinaTz } from "@/hooks/use-in-china-tz";
 import { openExternalUrl } from "@/lib/desktop/open-external";
@@ -76,8 +74,11 @@ export interface TokenProviderConfig {
     /**
      * Optional post-connect check: a saved credential can still be unusable
      * (Modal accepts the token but won't run GPUs without a payment method).
-     * Runs after the dialog closes; a coded failure is explained via
-     * `TaskErrors.<code>`.
+     * Blocks the connect flow while it runs and, on a coded failure, keeps the
+     * dialog open on a fix-it panel rather than reporting success. Providers
+     * that set this must also carry `verifying`, `verifyBlockedTitle`,
+     * `verifyFixCta` and `verifyRecheck` in their namespace; the failure body
+     * comes from `TaskErrors.<code>`.
      */
     verify?: () => Promise<TokenVerifyResult | null>;
     /** Optional store flips (e.g. Modal's onboarding banner). */
@@ -206,9 +207,14 @@ function CommunityHelpFooter() {
 export function TokenConnectForm({
     config,
     onConnected,
+    onSaved,
 }: {
     config: TokenProviderConfig;
+    /** Connected *and* verified — the caller closes the dialog / advances. */
     onConnected?: () => void;
+    /** Credential persisted, verification still pending or failed. Lets the
+     * caller refresh its env map without dismissing the fix-it panel. */
+    onSaved?: () => void;
 }) {
     const rawT = useTranslations(config.ns);
     const t = (key: string, values?: Record<string, string>) =>
@@ -216,7 +222,9 @@ export function TokenConnectForm({
     const tErr = useTranslations("TaskErrors");
     const managed = process.env.NEXT_PUBLIC_MANAGED_PLUGINS === "1";
     const [raw, setRaw] = useState("");
-    const [saving, setSaving] = useState(false);
+    const [phase, setPhase] = useState<"idle" | "saving" | "verifying">("idle");
+    const [blocked, setBlocked] = useState<TokenVerifyResult | null>(null);
+    const busy = phase !== "idle";
 
     // Token pages usually show one copyable command/value, so accept any
     // pasted blob and extract the value(s) — no field splitting required.
@@ -225,27 +233,27 @@ export function TokenConnectForm({
     );
     const allFound = parsed.every(Boolean);
 
-    const verify = async () => {
-        const result = await config.verify?.();
-        if (!result || result.ok || !result.errorCode) return;
-        showErrorToast({
-            message: localizeTaskError(tErr, result),
-            id: `token-verify:${config.ns}`,
-            footer:
-                result.errorCode === "modal_payment_required" ? (
-                    <ModalBillingRow
-                        url={
-                            typeof result.errorParams?.url === "string"
-                                ? result.errorParams.url
-                                : undefined
-                        }
-                    />
-                ) : undefined,
-        });
+    /** Runs the provider check; true when the flow may report success. */
+    const runVerify = async (): Promise<boolean> => {
+        if (!config.verify) return true;
+        setPhase("verifying");
+        const result = await config.verify();
+        if (result && !result.ok && result.errorCode) {
+            setBlocked(result);
+            return false;
+        }
+        setBlocked(null);
+        return true;
+    };
+
+    const succeed = () => {
+        toast.success(t("connectedToast"));
+        onConnected?.();
     };
 
     const connect = async () => {
-        setSaving(true);
+        setBlocked(null);
+        setPhase("saving");
         try {
             const env: Record<string, string> = {};
             config.specs.forEach((spec, i) => {
@@ -253,16 +261,27 @@ export function TokenConnectForm({
             });
             await apiPatch("/api/settings/env", { env });
             config.onConnectedStore?.();
-            toast.success(t("connectedToast"));
-            onConnected?.();
-            // Costs a round trip to the provider — let the dialog close and
-            // report separately if the credential turns out to be unusable.
-            void verify();
+            // The credential is stored whatever the check says next, so let
+            // the caller refresh now; only success dismisses the dialog.
+            onSaved?.();
+            if (await runVerify()) succeed();
         } catch (error) {
             logger.error(`Failed to save token (${config.ns}):`, error);
             toast.error(t("connectFailed"));
         } finally {
-            setSaving(false);
+            setPhase("idle");
+        }
+    };
+
+    // Re-ask without re-saving: the fix happens in the provider's console, so
+    // the user comes back to this panel with the same credential in place.
+    const recheck = async () => {
+        try {
+            if (await runVerify()) succeed();
+        } catch (error) {
+            logger.error(`Verify failed (${config.ns}):`, error);
+        } finally {
+            setPhase("idle");
         }
     };
 
@@ -327,13 +346,59 @@ export function TokenConnectForm({
                 </div>
             </div>
 
+            {phase === "verifying" ? (
+                <p className="flex items-start gap-2 text-xs text-muted-foreground">
+                    <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin" />
+                    {t("verifying")}
+                </p>
+            ) : null}
+
+            {blocked ? (
+                <div className="space-y-2 rounded-lg border border-amber-500/40 bg-amber-500/5 p-3">
+                    <p className="text-sm font-medium">
+                        {t("verifyBlockedTitle")}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                        {localizeTaskError(tErr, blocked)}
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                        {typeof blocked.errorParams?.url === "string" ? (
+                            <Button
+                                type="button"
+                                size="sm"
+                                onClick={() =>
+                                    openExternalUrl(
+                                        String(blocked.errorParams?.url),
+                                    )
+                                }
+                            >
+                                {t("verifyFixCta")}
+                                <ExternalLink className="ml-1 h-3 w-3" />
+                            </Button>
+                        ) : null}
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            disabled={busy}
+                            onClick={recheck}
+                        >
+                            {busy ? (
+                                <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                            ) : null}
+                            {t("verifyRecheck")}
+                        </Button>
+                    </div>
+                </div>
+            ) : null}
+
             <Button
                 type="button"
                 className="w-full"
-                disabled={!allFound || saving}
+                disabled={!allFound || busy}
                 onClick={connect}
             >
-                {saving ? (
+                {busy ? (
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 ) : null}
                 {t("saveConnect")}
@@ -368,10 +433,8 @@ export function TokenConnectDialog({
                 </DialogHeader>
                 <TokenConnectForm
                     config={config}
-                    onConnected={() => {
-                        onOpenChange(false);
-                        onConnected?.();
-                    }}
+                    onSaved={onConnected}
+                    onConnected={() => onOpenChange(false)}
                 />
             </DialogContent>
         </Dialog>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -90,6 +90,10 @@
         "detectedId": "Token ID {id}",
         "detectedSecret": "Token Secret detected",
         "missingId": "Waiting for the Token ID (starts with ak-)",
+        "verifying": "Checking that this account can actually get a GPU — we deploy one throwaway test function to Modal and remove it straight away. A few seconds.",
+        "verifyBlockedTitle": "Token saved — one thing left",
+        "verifyFixCta": "Add a payment method on Modal",
+        "verifyRecheck": "Check again",
         "missingSecret": "Waiting for the Token Secret (starts with as-)"
     },
     "HfConnect": {

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -90,6 +90,10 @@
         "detectedId": "トークン ID {id}",
         "detectedSecret": "トークンシークレットを検出",
         "missingId": "トークン ID が見つかりません（ak- で始まります）",
+        "verifying": "このアカウントで実際に GPU を確保できるか確認しています。使い捨てのテスト関数を Modal にデプロイして、すぐ削除します。数秒で終わります。",
+        "verifyBlockedTitle": "トークンは保存しました。あと一つだけ",
+        "verifyFixCta": "Modal で支払い方法を登録する",
+        "verifyRecheck": "もう一度確認",
         "missingSecret": "シークレットが見つかりません（as- で始まります）"
     },
     "HfConnect": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -90,6 +90,10 @@
         "detectedId": "토큰 ID {id}",
         "detectedSecret": "토큰 시크릿 인식됨",
         "missingId": "토큰 ID를 아직 찾지 못했어요(ak-로 시작)",
+        "verifying": "이 계정에서 GPU를 실제로 받을 수 있는지 확인하고 있어요. 일회용 테스트 함수를 Modal에 배포한 뒤 바로 지웁니다. 몇 초면 끝나요.",
+        "verifyBlockedTitle": "토큰은 저장했어요. 하나만 더",
+        "verifyFixCta": "Modal에서 결제 수단 등록하기",
+        "verifyRecheck": "다시 확인",
         "missingSecret": "토큰 시크릿을 아직 찾지 못했어요(as-로 시작)"
     },
     "HfConnect": {

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -90,6 +90,10 @@
         "detectedId": "Token ID {id}",
         "detectedSecret": "已识别 Token Secret",
         "missingId": "还没识别到 Token ID（ak- 开头）",
+        "verifying": "正在确认这个账号能不能真的拿到 GPU——往 Modal 部署一个一次性的测试函数，随即删掉。几秒钟。",
+        "verifyBlockedTitle": "Token 已存好，还差一步",
+        "verifyFixCta": "去 Modal 绑定支付方式",
+        "verifyRecheck": "重新检查",
         "missingSecret": "还没识别到 Token Secret（as- 开头）"
     },
     "HfConnect": {


### PR DESCRIPTION
## Why

#178 ran the GPU check fire-and-forget after the dialog closed. That gave the user a green **Modal connected**, and then — seconds later, on a settings page they had already moved on from — a toast contradicting it. The check is a precondition for the account being usable at all, so it belongs in the flow, not after it.

## What

**It blocks now.** Between saving the token and reporting success, the form shows a spinner line that says what is actually happening:

> Checking that this account can actually get a GPU — we deploy one throwaway test function to Modal and remove it straight away. A few seconds.

**A refusal keeps the dialog open** on a panel that names the gap (from `TaskErrors.<code>`) and offers the one button that fixes it — *Add a payment method on Modal* — plus **Check again**, which re-asks without re-saving the credential that is already stored. No toast; the fix-it panel replaces it, so `token-connect` no longer borrows `showErrorToast` / `ModalBillingRow` (still used by the run-time failure toast).

**Reconnect is covered for free**: the card's Reconnect button opens this same form.

## The `onSaved` split

The credential is persisted whatever the check answers next, so the form reports that through a new optional `onSaved`, and only a *verified* connect calls `onConnected`. The dialog maps them to "refresh your env map" and "close" respectively, so a blocked check leaves the panel visible while the settings card behind it still updates to Connected.

One deliberate consequence: `welcome-wizard` passes `onConnected={() => setStep(3)}`, so onboarding no longer walks the user past a Modal account that cannot run anything.

## Copy

Four new keys in the `ModalConnect` namespace (`verifying`, `verifyBlockedTitle`, `verifyFixCta`, `verifyRecheck`), written natively in en/zh/ja/ko. They are required only of providers that set `verify` — HF and the generic provider config stay as they were rather than carrying dead strings.

## Checks

`pnpm lint:check`, `pnpm typecheck`, `pnpm build` pass. No ABI or `sdk/` changes.