### PR TITLE
fix(settings): stop a refetch from unmounting an open connect dialog

### DIFF
--- a/src/components/workspace/settings/use-env-settings.ts
+++ b/src/components/workspace/settings/use-env-settings.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { logger } from "tongflow";
 import { apiGet, apiPut } from "tongflow/canvas";
@@ -33,6 +33,7 @@ export function useEnvSettings() {
     const [customRows, setCustomRows] = useState<CustomRow[]>([]);
     // Keyed by env key for declared rows, `custom:${index}` for custom rows.
     const [revealed, setRevealed] = useState<Record<string, boolean>>({});
+    const hasLoaded = useRef(false);
 
     const applyEnv = useCallback(
         (env: Record<string, string>, nextDecls: PluginEnvDecl[]) => {
@@ -54,10 +55,15 @@ export function useEnvSettings() {
     );
 
     const fetchEnv = useCallback(async () => {
-        setLoading(true);
+        // Only the first load may blank the panel. A refetch triggered by a
+        // connect or disconnect swaps the whole body for a spinner, which
+        // unmounts the provider cards — and an open connect dialog, whose
+        // state lives inside one, vanishes with them mid-flow.
+        if (!hasLoaded.current) setLoading(true);
         try {
             const data = await apiGet<EnvResponse>("/api/settings/env");
             applyEnv(data.env ?? {}, data.pluginEnv ?? []);
+            hasLoaded.current = true;
         } catch (error) {
             logger.error("Failed to load settings:", error);
         } finally {


### PR DESCRIPTION
## The symptom

Connecting Modal closed the dialog **instantly** — no spinner, no result panel — while `wrangler tail` showed the GPU check running for a full 8.5 seconds against the current deployment:

```
09:19:26  200    151ms  /api/settings/env    ← token saved
09:19:26  200     49ms  /api/settings/env    ← refetch
09:19:26  200   8496ms  /api/modal/probe     ← still running
```

The check was awaited, so the dialog could not have closed on its own. It was torn down.

## The cause

`fetchEnv` flips `loading`, and the settings body renders a bare spinner in that state:

```tsx
{loading ? <Loader2 /> : <div>…provider cards…</div>}
```

So every refetch unmounts the provider cards. `connectOpen` — the connect dialog's state — lives inside `TokenConnectCardBody`, one of those cards. #179 made the connect flow refresh the env map as soon as the credential was stored (correct: the card should read *Connected* while the check runs), which meant the flow destroyed its own dialog a moment later. The probe promise carried on in a detached tree and its `setBlocked` landed on nothing.

The bug predates #179 — a refetch has always blanked the panel, on disconnect too — but nothing was mid-flow inside it before, so nobody noticed.

## The fix

Only the first load may blank the panel. A refetch updates in place, leaving the cards (and anything open inside them) mounted.

## Checks

`pnpm lint:check`, `pnpm typecheck`, `pnpm build` pass. No ABI or `sdk/` changes.