### PR TITLE
docs: Qwen-Image-Edit ships 2509 quantized, not 2511

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Aggregators — one key, many third-party models across labs:
 - [tongflow-modal-ernie-image](https://github.com/tong-io/tongflow-modal-ernie-image) — ERNIE Image text-to-image (alternative)
 - [tongflow-modal-krea2](https://github.com/tong-io/tongflow-modal-krea2) — Krea 2 Turbo text-to-image (open-weights 12B, 8-step, up to 2K)
 - [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — FLUX.2 Klein 9B multi-reference fusion / image editing
-- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — Qwen-Image-Edit-2511 instruction editing / multi-image fusion
+- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — Qwen-Image-Edit-2509 instruction editing / multi-image fusion (SVDQuant int4, 4-step)
 - [tongflow-modal-boogu](https://github.com/tong-io/tongflow-modal-boogu) — Boogu-Image-0.1 (fp8) text-to-image (dense bilingual text) & single-reference image editing
 - [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk audio-driven lip-sync (audio + image / video → talking-head video)
 - [tongflow-modal-wan-animate](https://github.com/tong-io/tongflow-modal-wan-animate) — Wan-Animate character swap & motion transfer (video + reference)

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -192,7 +192,7 @@ Google または WeChat でサインインすれば、すぐに創作を始め�
 - [tongflow-modal-ernie-image](https://github.com/tong-io/tongflow-modal-ernie-image) — ERNIE Image テキストから画像生成（代替）
 - [tongflow-modal-krea2](https://github.com/tong-io/tongflow-modal-krea2) — Krea 2 Turbo テキストから画像生成（オープンウェイト 12B、8 ステップ、最大 2K）
 - [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — FLUX.2 Klein 9B マルチ参照融合と画像編集
-- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — Qwen-Image-Edit-2511 指示ベースの画像編集とマルチ画像融合
+- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — Qwen-Image-Edit-2509 指示ベースの画像編集とマルチ画像融合（SVDQuant int4、4ステップ）
 - [tongflow-modal-boogu](https://github.com/tong-io/tongflow-modal-boogu) — Boogu-Image-0.1（fp8）テキストから画像生成（高密度な多言語テキスト）と単一参照画像編集
 - [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk 音声駆動リップシンク（音声 + 画像 / 動画 → デジタルヒューマン動画）
 - [tongflow-modal-wan-animate](https://github.com/tong-io/tongflow-modal-wan-animate) — Wan-Animate キャラクター置換とモーション転送（動画 + 参照）

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -192,7 +192,7 @@ TongFlow **桌面版**是一个轻量（约 10 MB）的壳应用，直接加载�
 - [tongflow-modal-ernie-image](https://github.com/tong-io/tongflow-modal-ernie-image) — ERNIE Image 文本生图（备选）
 - [tongflow-modal-krea2](https://github.com/tong-io/tongflow-modal-krea2) — Krea 2 Turbo 文本生图（开源 12B，8 步蒸馏，最高 2K）
 - [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — FLUX.2 Klein 9B 多参考融合与图像编辑
-- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — Qwen-Image-Edit-2511 指令式图像编辑与多图融合
+- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — Qwen-Image-Edit-2509 指令式图像编辑与多图融合（SVDQuant int4，4 步）
 - [tongflow-modal-boogu](https://github.com/tong-io/tongflow-modal-boogu) — Boogu-Image-0.1（fp8）文本生图（密集中英文字）与单图编辑
 - [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk 音频驱动口型同步（音频 + 图片 / 视频 → 数字人视频）
 - [tongflow-modal-wan-animate](https://github.com/tong-io/tongflow-modal-wan-animate) — Wan-Animate 换角色与动作迁移（视频 + 参考）


### PR DESCRIPTION
Follow-up to #181. The plugin now loads a Diffusers-native SVDQuant int4 repack with the 4-step Lightning LoRA fused, so the READMEs' "2511" is wrong.

| | before | after |
| --- | ---: | ---: |
| Download | 57.7 GB | **18 GB** |
| Peak VRAM | ~58 GB | **21 GiB** (upstream benchmark) |
| GPU | H100 | **L40S** |
| Steps | 40 | **4** |

Latency upstream measures at 12.6 s for a 1248×832 edit.

**Why 2509**: no 2511 checkpoint is packaged for the `nunchaku_lite` loader. Every nunchaku 2511 repo on the Hub is a ComfyUI single file, and those carry `weight_scale` companion tensors that Diffusers has no handling for — verified against v0.40.0's `single_file_utils.py` and `model_loading_utils.py`.

**Why L40S**: not a preference. The Diffusers Nunchaku quantizer raises on Hopper outright —

```python
if device_capability[0] == 9:
    raise ValueError("Loading Nunchaku checkpoints is not supported on Hopper NVIDIA GPUs.")
```

— so an H100 is unavailable to this checkpoint. Ada clears its Turing-or-newer floor for int4.

No code changes here; the implementation lives in the plugin repo.