### PR TITLE
docs: Qwen-Image-Edit runs on ComfyUI, back on 2511

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Aggregators — one key, many third-party models across labs:
 - [tongflow-modal-ernie-image](https://github.com/tong-io/tongflow-modal-ernie-image) — ERNIE Image text-to-image (alternative)
 - [tongflow-modal-krea2](https://github.com/tong-io/tongflow-modal-krea2) — Krea 2 Turbo text-to-image (open-weights 12B, 8-step, up to 2K)
 - [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — FLUX.2 Klein 9B multi-reference fusion / image editing
-- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — Qwen-Image-Edit-2509 instruction editing / multi-image fusion (SVDQuant int4, 4-step)
+- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — Qwen-Image-Edit-2511 instruction editing / multi-image fusion (headless ComfyUI, fp8 + 8-step)
 - [tongflow-modal-boogu](https://github.com/tong-io/tongflow-modal-boogu) — Boogu-Image-0.1 (fp8) text-to-image (dense bilingual text) & single-reference image editing
 - [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk audio-driven lip-sync (audio + image / video → talking-head video)
 - [tongflow-modal-wan-animate](https://github.com/tong-io/tongflow-modal-wan-animate) — Wan-Animate character swap & motion transfer (video + reference)

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -192,7 +192,7 @@ Google または WeChat でサインインすれば、すぐに創作を始め�
 - [tongflow-modal-ernie-image](https://github.com/tong-io/tongflow-modal-ernie-image) — ERNIE Image テキストから画像生成（代替）
 - [tongflow-modal-krea2](https://github.com/tong-io/tongflow-modal-krea2) — Krea 2 Turbo テキストから画像生成（オープンウェイト 12B、8 ステップ、最大 2K）
 - [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — FLUX.2 Klein 9B マルチ参照融合と画像編集
-- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — Qwen-Image-Edit-2509 指示ベースの画像編集とマルチ画像融合（SVDQuant int4、4ステップ）
+- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — Qwen-Image-Edit-2511 指示ベースの画像編集とマルチ画像融合（ヘッドレス ComfyUI、fp8 + 8ステップ）
 - [tongflow-modal-boogu](https://github.com/tong-io/tongflow-modal-boogu) — Boogu-Image-0.1（fp8）テキストから画像生成（高密度な多言語テキスト）と単一参照画像編集
 - [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk 音声駆動リップシンク（音声 + 画像 / 動画 → デジタルヒューマン動画）
 - [tongflow-modal-wan-animate](https://github.com/tong-io/tongflow-modal-wan-animate) — Wan-Animate キャラクター置換とモーション転送（動画 + 参照）

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -192,7 +192,7 @@ TongFlow **桌面版**是一个轻量（约 10 MB）的壳应用，直接加载�
 - [tongflow-modal-ernie-image](https://github.com/tong-io/tongflow-modal-ernie-image) — ERNIE Image 文本生图（备选）
 - [tongflow-modal-krea2](https://github.com/tong-io/tongflow-modal-krea2) — Krea 2 Turbo 文本生图（开源 12B，8 步蒸馏，最高 2K）
 - [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — FLUX.2 Klein 9B 多参考融合与图像编辑
-- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — Qwen-Image-Edit-2509 指令式图像编辑与多图融合（SVDQuant int4，4 步）
+- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — Qwen-Image-Edit-2511 指令式图像编辑与多图融合（无头 ComfyUI，fp8 + 8 步）
 - [tongflow-modal-boogu](https://github.com/tong-io/tongflow-modal-boogu) — Boogu-Image-0.1（fp8）文本生图（密集中英文字）与单图编辑
 - [tongflow-modal-infinitetalk](https://github.com/tong-io/tongflow-modal-infinitetalk) — InfiniteTalk 音频驱动口型同步（音频 + 图片 / 视频 → 数字人视频）
 - [tongflow-modal-wan-animate](https://github.com/tong-io/tongflow-modal-wan-animate) — Wan-Animate 换角色与动作迁移（视频 + 参考）


### PR DESCRIPTION
Third and final shape for this plugin. Follows #181 and #182.

## Why the move off Diffusers

Every quantised checkpoint for this model is ComfyUI's format: fp8 tensors paired with `weight_scale` companions. Diffusers v0.40.0 has no handling for those — verified against `single_file_utils.py` and `model_loading_utils.py` — so the Diffusers route could only reach them by dequantising back to bf16, which gives up everything the quantisation bought.

## Where each route landed

| | 2511 | Download | GPU | Steps | Untested code |
| --- | :-: | ---: | :-: | :-: | :-: |
| Diffusers, unquantised | ✓ | 57.7 GB | H100 | 40 | no |
| nunchaku (lite-infer) | ✗ 2509 | 18 GB | L40S | 4 | no, but the repo has single-digit downloads |
| lightx2v merged fp8 + shim | ✓ | 37.5 GB | H100 | 4 | **~30 lines of tensor surgery** |
| **ComfyUI** | **✓** | **31 GB** | **L40S** | **8** | **no** |

## Sourcing

Comfy-Org's own repacks — the files the official `image_qwen_image_edit_2511` template names — plus LightX2V's 8-step distillation LoRA. All four verified reachable (HTTP 200) and ungated.

The graph mirrors that template, dropping its `FluxKontextMultiReferenceLatentMethod` pair (the template's own note calls them unnecessary with Comfy-Org files) and taking the lightning branch unconditionally. Node names, input names and wiring were read off the template and ComfyUI's node schemas rather than guessed.

Not a new architecture: `minimax-h3`, `seedvr2`, `wan-animate`, `scail2` and `minimax-music3` already run headless ComfyUI, and this follows their pattern.

## One behaviour change worth knowing

`image-fusion` now refuses a fourth reference image. `TextEncodeQwenImageEditPlus` exposes `image1`/`image2`/`image3` and nothing beyond, and silently dropping a reference the user wired up is worse than saying so.

No code changes here; the implementation lives in the plugin repo.