### PR TITLE
feat(example): fuse with Qwen-Image-Edit, which needs no Hugging Face token

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Open the **plugin manager** (the blocks icon, top-right) and install what you ne
 To run the preloaded **example workflow** (text → image → fusion → video), install these three plugins:
 
 - [tongflow-modal-z-image](https://github.com/tong-io/tongflow-modal-z-image) — text-to-image
-- [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — image fusion / blending
+- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — image fusion / blending
 - [tongflow-modal-minimax-h3](https://github.com/tong-io/tongflow-modal-minimax-h3) — image-to-video
 
 These run on [Modal](https://modal.com) (up to **$30/month** of free GPU compute). Add `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` in **Settings**; create a token at [modal.com/settings/tokens](https://modal.com/settings/tokens). Any other platform can publish its own plugins the same way.

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -267,7 +267,7 @@ docker compose up -d
 あらかじめ読み込まれた**サンプルワークフロー**（テキスト → 画像 → 融合 → 動画）を実行するには、以下の3つのプラグインが必要です：
 
 - [tongflow-modal-z-image](https://github.com/tong-io/tongflow-modal-z-image) — テキストから画像生成
-- [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — 画像の融合 / ミックス
+- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — 画像の融合 / ミックス
 - [tongflow-modal-minimax-h3](https://github.com/tong-io/tongflow-modal-minimax-h3) — 画像から動画生成
 
 これらのプラグインは [Modal](https://modal.com) 上で動作します（毎月最大 **$30** 分の無料GPU演算）。**設定**で `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` を入力してください。トークンは [modal.com/settings/tokens](https://modal.com/settings/tokens) で作成できます。他のどのプラットフォームでも同じ方法で自分のプラグインを公開できます。

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -267,7 +267,7 @@ docker compose up -d
 要运行预加载的**示例工作流**（文本 → 图像 → 融合 → 视频），需安装以下三个插件：
 
 - [tongflow-modal-z-image](https://github.com/tong-io/tongflow-modal-z-image) — 文本生图
-- [tongflow-modal-flux2-klein9b](https://github.com/tong-io/tongflow-modal-flux2-klein9b) — 图像融合 / 混合
+- [tongflow-modal-qwen-image-edit](https://github.com/tong-io/tongflow-modal-qwen-image-edit) — 图像融合 / 混合
 - [tongflow-modal-minimax-h3](https://github.com/tong-io/tongflow-modal-minimax-h3) — 图生视频
 
 这些插件运行在 [Modal](https://modal.com) 上（每月最多 **$30** 免费 GPU 算力）。在**设置**里填入 `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`；可在 [modal.com/settings/tokens](https://modal.com/settings/tokens) 创建 token。任何其他平台都可以用同样方式发布自己的插件。

--- a/packages/tongflow/test/fixtures/example.json
+++ b/packages/tongflow/test/fixtures/example.json
@@ -212,7 +212,7 @@
             "id": "a1d0567f-bf5d-42e6-868d-643c3998fc87",
             "type": "imageFusionNode",
             "feature": "image-fusion",
-            "pluginId": "tongflow-modal-flux2-klein9b",
+            "pluginId": "tongflow-modal-qwen-image-edit",
             "bindings": {
                 "text": {
                     "kind": "config",
@@ -258,7 +258,7 @@
             ],
             "level": 4,
             "rawConfig": {
-                "pluginId": "tongflow-modal-flux2-klein9b",
+                "pluginId": "tongflow-modal-qwen-image-edit",
                 "width": 720,
                 "height": 1280,
                 "text": "cat and mouse take a photo together"
@@ -553,7 +553,7 @@
                         "f224f29f-968c-466c-aa8c-2ea9735d0086",
                         "29685aa4-bab0-4047-8f90-b2ce63618037"
                     ],
-                    "pluginId": "tongflow-modal-flux2-klein9b",
+                    "pluginId": "tongflow-modal-qwen-image-edit",
                     "feature": "image-fusion",
                     "width": 720,
                     "height": 1280,

--- a/public/example.json
+++ b/public/example.json
@@ -212,7 +212,7 @@
             "id": "a1d0567f-bf5d-42e6-868d-643c3998fc87",
             "type": "imageFusionNode",
             "feature": "image-fusion",
-            "pluginId": "tongflow-modal-flux2-klein9b",
+            "pluginId": "tongflow-modal-qwen-image-edit",
             "bindings": {
                 "text": {
                     "kind": "config",
@@ -258,7 +258,7 @@
             ],
             "level": 4,
             "rawConfig": {
-                "pluginId": "tongflow-modal-flux2-klein9b",
+                "pluginId": "tongflow-modal-qwen-image-edit",
                 "width": 720,
                 "height": 1280,
                 "text": "cat and mouse take a photo together"
@@ -553,7 +553,7 @@
                         "f224f29f-968c-466c-aa8c-2ea9735d0086",
                         "29685aa4-bab0-4047-8f90-b2ce63618037"
                     ],
-                    "pluginId": "tongflow-modal-flux2-klein9b",
+                    "pluginId": "tongflow-modal-qwen-image-edit",
                     "feature": "image-fusion",
                     "width": 720,
                     "height": 1280,


### PR DESCRIPTION
## Why

The example workflow is the first thing a new user runs, and its fusion node pointed at `flux2-klein9b`.

That plugin's weights sit behind **two** `gated: auto` Hugging Face repos. A token that hasn't accepted both licenses fails with a 401 — several minutes in, after the deploy and the weight pull — and the plugin's own error message names only `FLUX.2-dev`, not `FLUX.2-klein-9b-kv`, which is the repo that actually refused. We lost a debugging round to exactly that this week.

`qwen-image-edit` fills the same slot with entirely ungated weights, so the path from sign-up to a first image no longer runs through a licence page.

## What changed

The plugin id appears **three times per file** — the exported `executableNodes[2].pluginId`, its `rawConfig.pluginId`, and the canvas node at `originalFlow.nodes[8].data.pluginId`. All three move together, in `public/example.json` and the exporter/layout test fixture that mirrors it.

The example's two generated images stay within the new plugin's three-reference ceiling.

## One thing this depended on

The node asks for **720×1280**, and the two `z-image` nodes feeding it produce 1024×1024. The ComfyUI graph took its size from the first input image and ignored the ABI's width/height, so the fusion would have come out square. Fixed in the plugin repo first ([`46f7ac4`](https://github.com/tong-io/tongflow-modal-qwen-image-edit/commit/46f7ac4)) — an explicit size swaps the template's `VAEEncode` for the `EmptySD3LatentImage` the official text-to-image template uses, which is the only lever on output size once `denoise` is 1.0.

`flux2-klein9b` stays in the official-plugins catalog; it is only the example that moves.

## Checks

`lint:check`, `typecheck`, `test` (99), `test:packages` (128) all pass.

## Not verified

The new plugin has not had a real run yet. Worth landing the swap only once you've confirmed it end to end — the point of the change is the first-run experience, so shipping it untested would be self-defeating.