### PR TITLE
fix(example): point the sample outputs at the public bucket

### DIFF
--- a/packages/tongflow/test/fixtures/example.json
+++ b/packages/tongflow/test/fixtures/example.json
@@ -82,9 +82,7 @@
             "dataType": "image",
             "isInput": false,
             "staticData": {
-                "fileKeys": [
-                    "tasks/82xfBRQHs2mC-WJjPgpEM/CKtGcdc8YMrouNZtpjbzN.png"
-                ]
+                "fileKeys": ["public/CKtGcdc8YMrouNZtpjbzN.png"]
             },
             "level": 3
         },
@@ -94,9 +92,7 @@
             "dataType": "image",
             "isInput": false,
             "staticData": {
-                "fileKeys": [
-                    "tasks/YNiEkIqDHWzCdKu3EGMtT/etz5lwKJ1aXJKm4Y5kVHA.png"
-                ]
+                "fileKeys": ["public/etz5lwKJ1aXJKm4Y5kVHA.png"]
             },
             "level": 3
         },
@@ -106,9 +102,7 @@
             "dataType": "image",
             "isInput": false,
             "staticData": {
-                "fileKeys": [
-                    "tasks/iokJb-SC1DeiM0S_PQv0r/pU8sgnY8F8-hKd5L-OPBl.png"
-                ]
+                "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"]
             },
             "level": 5
         },
@@ -118,9 +112,7 @@
             "dataType": "video",
             "isInput": false,
             "staticData": {
-                "fileKeys": [
-                    "tasks/02dBZ5ZhgPJLEbyLaOkRZ/thatFeeVupFMbRpFH8_eg.mp4"
-                ]
+                "fileKeys": ["public/OcvzJdnId7kk_YWkAgYwr.mp4"]
             },
             "level": 7
         }
@@ -312,9 +304,7 @@
             "dependencies": ["3fd5f0d5-68e3-4afb-b1c7-073d6c8f2f56"],
             "level": 6,
             "rawConfig": {
-                "fileKeys": [
-                    "tasks/iokJb-SC1DeiM0S_PQv0r/pU8sgnY8F8-hKd5L-OPBl.png"
-                ],
+                "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"],
                 "pluginId": "tongflow-modal-ltx",
                 "duration": 5,
                 "width": 576,
@@ -450,9 +440,7 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": [
-                        "tasks/82xfBRQHs2mC-WJjPgpEM/CKtGcdc8YMrouNZtpjbzN.png"
-                    ]
+                    "fileKeys": ["public/CKtGcdc8YMrouNZtpjbzN.png"]
                 },
                 "measured": {
                     "width": 256,
@@ -529,9 +517,7 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": [
-                        "tasks/YNiEkIqDHWzCdKu3EGMtT/etz5lwKJ1aXJKm4Y5kVHA.png"
-                    ]
+                    "fileKeys": ["public/etz5lwKJ1aXJKm4Y5kVHA.png"]
                 },
                 "measured": {
                     "width": 256,
@@ -561,8 +547,8 @@
                     "prompt": {
                         "text": "cat and mouse take a photo together",
                         "images": [
-                            "tasks/82xfBRQHs2mC-WJjPgpEM/CKtGcdc8YMrouNZtpjbzN.png",
-                            "tasks/YNiEkIqDHWzCdKu3EGMtT/etz5lwKJ1aXJKm4Y5kVHA.png"
+                            "public/CKtGcdc8YMrouNZtpjbzN.png",
+                            "public/etz5lwKJ1aXJKm4Y5kVHA.png"
                         ],
                         "width": 720,
                         "height": 1280
@@ -584,9 +570,7 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": [
-                        "tasks/iokJb-SC1DeiM0S_PQv0r/pU8sgnY8F8-hKd5L-OPBl.png"
-                    ]
+                    "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"]
                 },
                 "measured": {
                     "width": 320,
@@ -604,9 +588,7 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": [
-                        "tasks/iokJb-SC1DeiM0S_PQv0r/pU8sgnY8F8-hKd5L-OPBl.png"
-                    ],
+                    "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"],
                     "pluginId": "tongflow-modal-ltx",
                     "duration": 5,
                     "feature": "image-gen-video",
@@ -618,7 +600,7 @@
                         "text": "drinking",
                         "height": 1024,
                         "width": 576,
-                        "image": "tasks/iokJb-SC1DeiM0S_PQv0r/pU8sgnY8F8-hKd5L-OPBl.png"
+                        "image": "public/pU8sgnY8F8-hKd5L-OPBl.png"
                     }
                 },
                 "measured": {
@@ -637,9 +619,7 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": [
-                        "tasks/02dBZ5ZhgPJLEbyLaOkRZ/thatFeeVupFMbRpFH8_eg.mp4"
-                    ]
+                    "fileKeys": ["public/OcvzJdnId7kk_YWkAgYwr.mp4"]
                 },
                 "measured": {
                     "width": 256,

--- a/public/example.json
+++ b/public/example.json
@@ -82,9 +82,7 @@
             "dataType": "image",
             "isInput": false,
             "staticData": {
-                "fileKeys": [
-                    "tasks/82xfBRQHs2mC-WJjPgpEM/CKtGcdc8YMrouNZtpjbzN.png"
-                ]
+                "fileKeys": ["public/CKtGcdc8YMrouNZtpjbzN.png"]
             },
             "level": 3
         },
@@ -94,9 +92,7 @@
             "dataType": "image",
             "isInput": false,
             "staticData": {
-                "fileKeys": [
-                    "tasks/YNiEkIqDHWzCdKu3EGMtT/etz5lwKJ1aXJKm4Y5kVHA.png"
-                ]
+                "fileKeys": ["public/etz5lwKJ1aXJKm4Y5kVHA.png"]
             },
             "level": 3
         },
@@ -106,9 +102,7 @@
             "dataType": "image",
             "isInput": false,
             "staticData": {
-                "fileKeys": [
-                    "tasks/iokJb-SC1DeiM0S_PQv0r/pU8sgnY8F8-hKd5L-OPBl.png"
-                ]
+                "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"]
             },
             "level": 5
         },
@@ -118,9 +112,7 @@
             "dataType": "video",
             "isInput": false,
             "staticData": {
-                "fileKeys": [
-                    "tasks/02dBZ5ZhgPJLEbyLaOkRZ/thatFeeVupFMbRpFH8_eg.mp4"
-                ]
+                "fileKeys": ["public/OcvzJdnId7kk_YWkAgYwr.mp4"]
             },
             "level": 7
         }
@@ -312,9 +304,7 @@
             "dependencies": ["3fd5f0d5-68e3-4afb-b1c7-073d6c8f2f56"],
             "level": 6,
             "rawConfig": {
-                "fileKeys": [
-                    "tasks/iokJb-SC1DeiM0S_PQv0r/pU8sgnY8F8-hKd5L-OPBl.png"
-                ],
+                "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"],
                 "pluginId": "tongflow-modal-minimax-h3",
                 "duration": 5,
                 "width": 576,
@@ -450,9 +440,7 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": [
-                        "tasks/82xfBRQHs2mC-WJjPgpEM/CKtGcdc8YMrouNZtpjbzN.png"
-                    ]
+                    "fileKeys": ["public/CKtGcdc8YMrouNZtpjbzN.png"]
                 },
                 "measured": {
                     "width": 256,
@@ -529,9 +517,7 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": [
-                        "tasks/YNiEkIqDHWzCdKu3EGMtT/etz5lwKJ1aXJKm4Y5kVHA.png"
-                    ]
+                    "fileKeys": ["public/etz5lwKJ1aXJKm4Y5kVHA.png"]
                 },
                 "measured": {
                     "width": 256,
@@ -561,8 +547,8 @@
                     "prompt": {
                         "text": "cat and mouse take a photo together",
                         "images": [
-                            "tasks/82xfBRQHs2mC-WJjPgpEM/CKtGcdc8YMrouNZtpjbzN.png",
-                            "tasks/YNiEkIqDHWzCdKu3EGMtT/etz5lwKJ1aXJKm4Y5kVHA.png"
+                            "public/CKtGcdc8YMrouNZtpjbzN.png",
+                            "public/etz5lwKJ1aXJKm4Y5kVHA.png"
                         ],
                         "width": 720,
                         "height": 1280
@@ -584,9 +570,7 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": [
-                        "tasks/iokJb-SC1DeiM0S_PQv0r/pU8sgnY8F8-hKd5L-OPBl.png"
-                    ]
+                    "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"]
                 },
                 "measured": {
                     "width": 320,
@@ -604,9 +588,7 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": [
-                        "tasks/iokJb-SC1DeiM0S_PQv0r/pU8sgnY8F8-hKd5L-OPBl.png"
-                    ],
+                    "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"],
                     "pluginId": "tongflow-modal-minimax-h3",
                     "duration": 5,
                     "feature": "image-gen-video",
@@ -618,7 +600,7 @@
                         "text": "drinking",
                         "height": 1024,
                         "width": 576,
-                        "image": "tasks/iokJb-SC1DeiM0S_PQv0r/pU8sgnY8F8-hKd5L-OPBl.png"
+                        "image": "public/pU8sgnY8F8-hKd5L-OPBl.png"
                     }
                 },
                 "measured": {
@@ -637,9 +619,7 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": [
-                        "tasks/02dBZ5ZhgPJLEbyLaOkRZ/thatFeeVupFMbRpFH8_eg.mp4"
-                    ]
+                    "fileKeys": ["public/OcvzJdnId7kk_YWkAgYwr.mp4"]
                 },
                 "measured": {
                     "width": 256,


### PR DESCRIPTION
## Why nothing showed

The example's media nodes carried **task-output keys**:

```
tasks/82xfBRQHs2mC-WJjPgpEM/CKtGcdc8YMrouNZtpjbzN.png
```

Those resolve per user scope to `users/<scope>/tasks/...`, and they belong to whoever first ran the workflow. Every other user got a 404 and an empty canvas — where the whole point was to show the result up front. The 404s were visible in `wrangler tail` days ago:

```
302  /api/uploads/tasks/<id>/<file>.png
404  /f/users/<scope>/tasks/<id>/<file>.png
```

## Why it's a one-line-per-node fix

Two halves already existed and had simply never met:

- `cloud/ext/file-serve.ts` serves a `public/` prefix **without auth**, and even normalises `users/<scope>/public/...` back to it.
- The assets are already in the bucket under that prefix. All four answer 200 on `file.tongflow.com` and through `app.tongflow.com/f/`.

Only `example.json` never pointed at them.

## About the branch this came from

`feat/r2-public-assets` (`713d8e7`) worked out this exact mapping and was never merged. I applied the mapping to the current file rather than merging that branch: it predates the fusion-plugin swap and merging it would drag `flux2-klein9b` back in.

Its video rename is carried over too — the old `thatFeeVupFMbRpFH8_eg.mp4` is a 404 in the bucket, `OcvzJdnId7kk_YWkAgYwr.mp4` is the one that is there.

## Scope

Self-host is unchanged: it has no public bucket, so those nodes stay empty there — exactly as they already were, since the task keys never resolved for anyone but the original author either.

## Checks

`lint:check`, `typecheck`, `test` (99), `test:packages` (128). The substitution changed string lengths enough to re-wrap two JSON arrays; both files were reformatted.