### PR TITLE
feat(example): reference the demo results by absolute URL

### DIFF
--- a/packages/tongflow/src/canvas/host.tsx
+++ b/packages/tongflow/src/canvas/host.tsx
@@ -54,6 +54,10 @@ export function hostFetch(
 
 /** URL for an asset `file_key` (private uploads endpoint by default). */
 export function assetUrl(fileKey: string): string {
+    // Already absolute: a workflow may reference an asset that does not live
+    // behind this app at all, such as the bundled example's results on the
+    // public CDN. Prefixing those would produce /api/uploads/https://...
+    if (/^https?:\/\//.test(fileKey)) return fileKey;
     return host.resolveAssetUrl
         ? host.resolveAssetUrl(fileKey)
         : `${host.apiBaseUrl}/api/uploads/${fileKey}`;

--- a/packages/tongflow/test/fixtures/example.json
+++ b/packages/tongflow/test/fixtures/example.json
@@ -82,7 +82,9 @@
             "dataType": "image",
             "isInput": false,
             "staticData": {
-                "fileKeys": ["public/CKtGcdc8YMrouNZtpjbzN.png"]
+                "fileKeys": [
+                    "https://file.tongflow.com/public/CKtGcdc8YMrouNZtpjbzN.png"
+                ]
             },
             "level": 3
         },
@@ -92,7 +94,9 @@
             "dataType": "image",
             "isInput": false,
             "staticData": {
-                "fileKeys": ["public/etz5lwKJ1aXJKm4Y5kVHA.png"]
+                "fileKeys": [
+                    "https://file.tongflow.com/public/etz5lwKJ1aXJKm4Y5kVHA.png"
+                ]
             },
             "level": 3
         },
@@ -102,7 +106,9 @@
             "dataType": "image",
             "isInput": false,
             "staticData": {
-                "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"]
+                "fileKeys": [
+                    "https://file.tongflow.com/public/pU8sgnY8F8-hKd5L-OPBl.png"
+                ]
             },
             "level": 5
         },
@@ -112,7 +118,9 @@
             "dataType": "video",
             "isInput": false,
             "staticData": {
-                "fileKeys": ["public/OcvzJdnId7kk_YWkAgYwr.mp4"]
+                "fileKeys": [
+                    "https://file.tongflow.com/public/OcvzJdnId7kk_YWkAgYwr.mp4"
+                ]
             },
             "level": 7
         }
@@ -304,7 +312,9 @@
             "dependencies": ["3fd5f0d5-68e3-4afb-b1c7-073d6c8f2f56"],
             "level": 6,
             "rawConfig": {
-                "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"],
+                "fileKeys": [
+                    "https://file.tongflow.com/public/pU8sgnY8F8-hKd5L-OPBl.png"
+                ],
                 "pluginId": "tongflow-modal-ltx",
                 "duration": 5,
                 "width": 576,
@@ -440,7 +450,9 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": ["public/CKtGcdc8YMrouNZtpjbzN.png"]
+                    "fileKeys": [
+                        "https://file.tongflow.com/public/CKtGcdc8YMrouNZtpjbzN.png"
+                    ]
                 },
                 "measured": {
                     "width": 256,
@@ -517,7 +529,9 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": ["public/etz5lwKJ1aXJKm4Y5kVHA.png"]
+                    "fileKeys": [
+                        "https://file.tongflow.com/public/etz5lwKJ1aXJKm4Y5kVHA.png"
+                    ]
                 },
                 "measured": {
                     "width": 256,
@@ -547,8 +561,8 @@
                     "prompt": {
                         "text": "cat and mouse take a photo together",
                         "images": [
-                            "public/CKtGcdc8YMrouNZtpjbzN.png",
-                            "public/etz5lwKJ1aXJKm4Y5kVHA.png"
+                            "https://file.tongflow.com/public/CKtGcdc8YMrouNZtpjbzN.png",
+                            "https://file.tongflow.com/public/etz5lwKJ1aXJKm4Y5kVHA.png"
                         ],
                         "width": 720,
                         "height": 1280
@@ -570,7 +584,9 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"]
+                    "fileKeys": [
+                        "https://file.tongflow.com/public/pU8sgnY8F8-hKd5L-OPBl.png"
+                    ]
                 },
                 "measured": {
                     "width": 320,
@@ -588,7 +604,9 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"],
+                    "fileKeys": [
+                        "https://file.tongflow.com/public/pU8sgnY8F8-hKd5L-OPBl.png"
+                    ],
                     "pluginId": "tongflow-modal-ltx",
                     "duration": 5,
                     "feature": "image-gen-video",
@@ -600,7 +618,7 @@
                         "text": "drinking",
                         "height": 1024,
                         "width": 576,
-                        "image": "public/pU8sgnY8F8-hKd5L-OPBl.png"
+                        "image": "https://file.tongflow.com/public/pU8sgnY8F8-hKd5L-OPBl.png"
                     }
                 },
                 "measured": {
@@ -619,7 +637,9 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": ["public/OcvzJdnId7kk_YWkAgYwr.mp4"]
+                    "fileKeys": [
+                        "https://file.tongflow.com/public/OcvzJdnId7kk_YWkAgYwr.mp4"
+                    ]
                 },
                 "measured": {
                     "width": 256,

--- a/public/example.json
+++ b/public/example.json
@@ -82,7 +82,9 @@
             "dataType": "image",
             "isInput": false,
             "staticData": {
-                "fileKeys": ["public/CKtGcdc8YMrouNZtpjbzN.png"]
+                "fileKeys": [
+                    "https://file.tongflow.com/public/CKtGcdc8YMrouNZtpjbzN.png"
+                ]
             },
             "level": 3
         },
@@ -92,7 +94,9 @@
             "dataType": "image",
             "isInput": false,
             "staticData": {
-                "fileKeys": ["public/etz5lwKJ1aXJKm4Y5kVHA.png"]
+                "fileKeys": [
+                    "https://file.tongflow.com/public/etz5lwKJ1aXJKm4Y5kVHA.png"
+                ]
             },
             "level": 3
         },
@@ -102,7 +106,9 @@
             "dataType": "image",
             "isInput": false,
             "staticData": {
-                "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"]
+                "fileKeys": [
+                    "https://file.tongflow.com/public/pU8sgnY8F8-hKd5L-OPBl.png"
+                ]
             },
             "level": 5
         },
@@ -112,7 +118,9 @@
             "dataType": "video",
             "isInput": false,
             "staticData": {
-                "fileKeys": ["public/OcvzJdnId7kk_YWkAgYwr.mp4"]
+                "fileKeys": [
+                    "https://file.tongflow.com/public/OcvzJdnId7kk_YWkAgYwr.mp4"
+                ]
             },
             "level": 7
         }
@@ -304,7 +312,9 @@
             "dependencies": ["3fd5f0d5-68e3-4afb-b1c7-073d6c8f2f56"],
             "level": 6,
             "rawConfig": {
-                "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"],
+                "fileKeys": [
+                    "https://file.tongflow.com/public/pU8sgnY8F8-hKd5L-OPBl.png"
+                ],
                 "pluginId": "tongflow-modal-minimax-h3",
                 "duration": 5,
                 "width": 576,
@@ -440,7 +450,9 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": ["public/CKtGcdc8YMrouNZtpjbzN.png"]
+                    "fileKeys": [
+                        "https://file.tongflow.com/public/CKtGcdc8YMrouNZtpjbzN.png"
+                    ]
                 },
                 "measured": {
                     "width": 256,
@@ -517,7 +529,9 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": ["public/etz5lwKJ1aXJKm4Y5kVHA.png"]
+                    "fileKeys": [
+                        "https://file.tongflow.com/public/etz5lwKJ1aXJKm4Y5kVHA.png"
+                    ]
                 },
                 "measured": {
                     "width": 256,
@@ -547,8 +561,8 @@
                     "prompt": {
                         "text": "cat and mouse take a photo together",
                         "images": [
-                            "public/CKtGcdc8YMrouNZtpjbzN.png",
-                            "public/etz5lwKJ1aXJKm4Y5kVHA.png"
+                            "https://file.tongflow.com/public/CKtGcdc8YMrouNZtpjbzN.png",
+                            "https://file.tongflow.com/public/etz5lwKJ1aXJKm4Y5kVHA.png"
                         ],
                         "width": 720,
                         "height": 1280
@@ -570,7 +584,9 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"]
+                    "fileKeys": [
+                        "https://file.tongflow.com/public/pU8sgnY8F8-hKd5L-OPBl.png"
+                    ]
                 },
                 "measured": {
                     "width": 320,
@@ -588,7 +604,9 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": ["public/pU8sgnY8F8-hKd5L-OPBl.png"],
+                    "fileKeys": [
+                        "https://file.tongflow.com/public/pU8sgnY8F8-hKd5L-OPBl.png"
+                    ],
                     "pluginId": "tongflow-modal-minimax-h3",
                     "duration": 5,
                     "feature": "image-gen-video",
@@ -600,7 +618,7 @@
                         "text": "drinking",
                         "height": 1024,
                         "width": 576,
-                        "image": "public/pU8sgnY8F8-hKd5L-OPBl.png"
+                        "image": "https://file.tongflow.com/public/pU8sgnY8F8-hKd5L-OPBl.png"
                     }
                 },
                 "measured": {
@@ -619,7 +637,9 @@
                 },
                 "origin": [0.5, 0.5],
                 "data": {
-                    "fileKeys": ["public/OcvzJdnId7kk_YWkAgYwr.mp4"]
+                    "fileKeys": [
+                        "https://file.tongflow.com/public/OcvzJdnId7kk_YWkAgYwr.mp4"
+                    ]
                 },
                 "measured": {
                     "width": 256,

--- a/src/lib/file/file-utils.ts
+++ b/src/lib/file/file-utils.ts
@@ -50,5 +50,7 @@ export async function downloadAndSave(
  * Get the public access URL for a file (relative path)
  */
 export function getFileUrl(fileKey: string): string {
+    // Absolute references pass through — see assetUrl in the canvas host.
+    if (/^https?:\/\//.test(fileKey)) return fileKey;
     return `/api/uploads/${fileKey}`;
 }


### PR DESCRIPTION
The example's results live on the public CDN and nowhere else. Pointing at them directly is simpler than routing a fileKey through the app — no session, no middleware, no redirect — and it cannot be broken by how uploads happen to be scoped, which is what went wrong twice this week.

`assetUrl` (canvas) and `getFileUrl` (app) now pass an absolute reference through instead of prefixing it; `/api/uploads/https://...` was the only reason this wasn't already possible. Both are three-line guards.

Execution is unaffected: the SDK's asset materialiser already resolves `http(s)://` references (`engine/assets.py`), so a node consuming these inputs fetches them the same as before.

Verified live before landing: all four assets answer 200 on `file.tongflow.com`, and the MP4 honours Range (`206`, `accept-ranges: bytes`), which `<video>` needs.

Checks: `lint:check`, `typecheck`, `build`, `test` (99), `test:packages` (128).