### PR TITLE
fix(dsh-tongflow): stop polling runs before a project is selected

### DIFF
--- a/packages/dsh-tongflow/package.json
+++ b/packages/dsh-tongflow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dsh-tongflow",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "TongFlow studio plugin for DeepSeek Harness (dsh): agent-designed project folders, one TongFlow workflow per generated asset stored next to its outputs, deterministic media generation, embedded canvas.",
     "author": "tong-io",
     "license": "AGPL-3.0-only",

--- a/packages/dsh-tongflow/src/client/studio/InspectorPane.tsx
+++ b/packages/dsh-tongflow/src/client/studio/InspectorPane.tsx
@@ -266,7 +266,9 @@ export function RecentRuns({
 }) {
     const t = useT();
     const { data, reload } = useAsync(
-        () => studio.runs(pid),
+        // No project selected yet: the header mounts before the project list
+        // resolves, and `/p//runs` would 404.
+        () => (pid === "" ? Promise.resolve([]) : studio.runs(pid)),
         [pid, refreshToken],
     );
     const live = useMemo(
@@ -329,7 +331,9 @@ export function RecentRuns({
 /** Live count of active runs for the header button. */
 export function useActiveRuns(pid: string, refreshToken: number): number {
     const { data, reload } = useAsync(
-        () => studio.runs(pid),
+        // No project selected yet: the header mounts before the project list
+        // resolves, and `/p//runs` would 404.
+        () => (pid === "" ? Promise.resolve([]) : studio.runs(pid)),
         [pid, refreshToken],
     );
     const n = (data ?? []).filter(


### PR DESCRIPTION
The Studio header mounts before the project list resolves, so `useActiveRuns` ran with an empty project id and issued `GET /tongflow/p//runs` — a guaranteed 404 and a console error on every Studio open. Both call sites now resolve to an empty list instead of requesting.

Found while verifying 0.8.1 against a real dsh 0.1.5-rc.2 host; unrelated to host compatibility, the bug has been there all along.

Verified live on that host: after the fix the page issues zero `/tongflow/p//` requests and the console is clean, with the Studio still rendering (project picker, file tree, runs drawer, plugins & keys).

Version → 0.8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)